### PR TITLE
Fix clang-format indentation for OpenMP and OpenACC pragmas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,8 +177,15 @@ if(CLANG_FORMAT_FOUND)
     file(COPY ${PROJECT_SOURCE_DIR}/.clang-format DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
     #to indent files using clang-format
-    file(GLOB_RECURSE SRC_FILES_FOR_CLANG_FORMAT ${PROJECT_SOURCE_DIR}/coreneuron/*.c*
-        ${PROJECT_SOURCE_DIR}/coreneuron/*.h* ${PROJECT_SOURCE_DIR}/coreneuron/*.ipp*)
+    file(GLOB_RECURSE SRC_FILES_FOR_CLANG_FORMAT
+        ${PROJECT_SOURCE_DIR}/coreneuron/*.c
+        ${PROJECT_SOURCE_DIR}/coreneuron/*.cpp
+        ${PROJECT_SOURCE_DIR}/coreneuron/*.h*
+        ${PROJECT_SOURCE_DIR}/coreneuron/*.ipp*)
+
+    # exclude ezoption header file
+    list(REMOVE_ITEM SRC_FILES_FOR_CLANG_FORMAT
+        "${PROJECT_SOURCE_DIR}/coreneuron/utils/ezoption/ezOptionParser.hpp")
 
     add_custom_target(formatsource COMMAND ${CMAKE_COMMAND}
         -DSOURCE_FILES:STRING="${SRC_FILES_FOR_CLANG_FORMAT}"

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ If you have installed `clang-format`, you can reformat/reindent generated .c fil
 make formatbuild
 ```
 
-The `.clang-format` file in the source repository is compatible with version 3.9.
+The `.clang-format` file in the source repository is compatible with version 3.9 and 4.0.
 
 ## License
 * See LICENSE.txt

--- a/coreneuron/coreneuron.h
+++ b/coreneuron/coreneuron.h
@@ -30,7 +30,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
  * Includes all headers required to communicate and run all methods
  * described in CoreNeuron, neurox, and mod2c C-generated mechanisms
  * functions.
-**/
+ **/
 
 #ifndef CORENEURON_H
 #define CORENEURON_H
@@ -45,7 +45,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/utils/randoms/nrnran123.h"      //Random Number Generator
 
 #if defined(__cplusplus)
-#include "coreneuron/nrniv/memory.h"                 //Memory alignemnts and padding
+#include "coreneuron/nrniv/memory.h"  //Memory alignemnts and padding
 
 extern "C" {
 #endif

--- a/coreneuron/nrnconf.h
+++ b/coreneuron/nrnconf.h
@@ -62,7 +62,7 @@ extern double t, dt;
 extern int rev_dt;
 extern int secondorder;
 extern int stoprun;
-extern const char *bbcore_write_version;
+extern const char* bbcore_write_version;
 #define tstopbit (1 << 15)
 #define tstopset stoprun |= tstopbit
 #define tstopunset stoprun &= (~tstopbit)
@@ -80,7 +80,7 @@ extern void* erealloc(void* ptr, size_t size);
 extern void* emalloc_align(size_t size, size_t alignment);
 extern void* ecalloc_align(size_t n, size_t alignment, size_t size);
 extern double hoc_Exp(double x);
-extern void check_bbcore_write_version(const char *);
+extern void check_bbcore_write_version(const char*);
 
 /* will go away at some point */
 typedef struct Point_process {

--- a/coreneuron/nrniv/cellorder.h
+++ b/coreneuron/nrniv/cellorder.h
@@ -49,7 +49,7 @@ int* node_order(int ncell,
 template <typename T>
 void copy_array(T*& dest, T* src, size_t n) {
     dest = new T[n];
-    std::copy(src, src+n, dest);
+    std::copy(src, src + n, dest);
 }
 
 #define INTERLEAVE_DEBUG 0

--- a/coreneuron/nrniv/cvodestb.cpp
+++ b/coreneuron/nrniv/cvodestb.cpp
@@ -82,7 +82,9 @@ void init_net_events() {
         double* weights = nt->weights;
         int n_weight = nt->n_weight;
         if (n_weight) {
+// clang-format off
             #pragma acc update device(weights[0 : n_weight]) if (nt->compute_gpu)
+            // clang-format on
         }
     }
 #endif

--- a/coreneuron/nrniv/main1.cpp
+++ b/coreneuron/nrniv/main1.cpp
@@ -63,7 +63,7 @@ int nrn_feenableexcept() {
 
 int main1(int argc, char* argv[], char** env);
 void call_prcellstate_for_prcellgid(int prcellgid, int compute_gpu, int is_init);
-void nrn_init_and_load_data(int argc, char* argv[], bool run_setup_cleanup=true) {
+void nrn_init_and_load_data(int argc, char* argv[], bool run_setup_cleanup = true) {
 #if defined(NRN_FEEXCEPT)
     nrn_feenableexcept();
 #endif
@@ -72,7 +72,7 @@ void nrn_init_and_load_data(int argc, char* argv[], bool run_setup_cleanup=true)
     stop_profile();
 #endif
 
-    // mpi initialisation
+// mpi initialisation
 #if NRNMPI
     nrnmpi_init(1, &argc, &argv);
 #endif
@@ -92,7 +92,7 @@ void nrn_init_and_load_data(int argc, char* argv[], bool run_setup_cleanup=true)
     // set global variables
     // precedence is: set by user, globals.dat, 34.0
     celsius = nrnopt_get_dbl("--celsius");
-    t = celsius; // later will read globals.dat and compare with this.
+    t = celsius;  // later will read globals.dat and compare with this.
 
 #if _OPENACC
     if (!nrnopt_get_flag("--gpu") && nrnopt_get_int("--cell-permute") == 2) {
@@ -103,7 +103,7 @@ void nrn_init_and_load_data(int argc, char* argv[], bool run_setup_cleanup=true)
     }
 #endif
 
-    // if multi-threading enabled, make sure mpi library supports it
+// if multi-threading enabled, make sure mpi library supports it
 #if NRNMPI
     if (nrnopt_get_flag("--threading")) {
         nrnmpi_check_threading_support();
@@ -235,7 +235,9 @@ int main1(int argc, char** argv, char** env) {
     // nrnopt_get... still available until call nrnopt_delete()
 
     bool compute_gpu = nrnopt_get_flag("-gpu");
+// clang-format off
     #pragma acc data copyin(celsius, secondorder) if (compute_gpu)
+    // clang-format on
     {
         double v = nrnopt_get_dbl("--voltage");
         nrn_finitialize(v != 1000., v);
@@ -255,8 +257,9 @@ int main1(int argc, char** argv, char** env) {
                         "\n WARNING! : Can't enable reports with model duplications feature! \n");
             } else {
                 r = new ReportGenerator(nrnopt_get_int("--report"), nrnopt_get_int("--tstart"),
-                                        nrnopt_get_dbl("--tstop"), nrnopt_get_int("--dt"), nrnopt_get_dbl("--mindelay"),
-                                        nrnopt_get_dbl("--dt_report"), nrnopt_get_str("--outpath"));
+                                        nrnopt_get_dbl("--tstop"), nrnopt_get_int("--dt"),
+                                        nrnopt_get_dbl("--mindelay"), nrnopt_get_dbl("--dt_report"),
+                                        nrnopt_get_str("--outpath"));
                 r->register_report();
             }
 #else
@@ -302,7 +305,7 @@ int main1(int argc, char** argv, char** env) {
     // Cleaning the memory
     nrn_cleanup();
 
-    // mpi finalize
+// mpi finalize
 #if NRNMPI
     nrnmpi_finalize();
 #endif

--- a/coreneuron/nrniv/memory.h
+++ b/coreneuron/nrniv/memory.h
@@ -50,13 +50,13 @@ namespace coreneuron {
     }
 
     /** Check for the pointer alignment.
-    */
+     */
     inline bool is_aligned(void* pointer, size_t alignment) {
         return (((uintptr_t)(const void*)(pointer)) % (alignment) == 0);
     }
 
     /** Allocate the aligned memory.
-    */
+     */
     inline void* emalloc_align(size_t size, size_t alignment) {
         void* memptr;
         nrn_assert(posix_memalign(&memptr, alignment, size) == 0);
@@ -65,7 +65,7 @@ namespace coreneuron {
     }
 
     /** Allocate the aligned memory and set it to 1.
-    */
+     */
     inline void* ecalloc_align(size_t n, size_t alignment, size_t size) {
         void* p;
         if (n == 0) {
@@ -76,6 +76,6 @@ namespace coreneuron {
         memset(p, 1, n * size);  // Avoid native division by zero (cyme...)
         return p;
     }
-}  // end name space
+}  // namespace coreneuron
 
 #endif

--- a/coreneuron/nrniv/netcvode.cpp
+++ b/coreneuron/nrniv/netcvode.cpp
@@ -663,12 +663,13 @@ void NetCvode::check_thresh(NrnThread* nt) {  // for default method
 //#endif
 
 // on GPU...
-    #pragma acc parallel loop present(                 \
-        nt[0 : 1],                                     \
-            presyns_helper[0 : nt->n_presyn],          \
-                      presyns[0 : nt->n_presyn],       \
-                              actual_v[0 : nt->end])   \
-                                  copy(net_send_buf_count) if (nt->compute_gpu) async(stream_id)
+// clang-format off
+    #pragma acc parallel loop present(                  \
+        nt[0:1], presyns_helper[0:nt->n_presyn],        \
+        presyns[0:nt->n_presyn], actual_v[0:nt->end])   \
+        copy(net_send_buf_count) if (nt->compute_gpu)   \
+        async(stream_id)
+    // clang-format on
     for (i = 0; i < nt->ncell; ++i) {
         PreSyn* ps = presyns + i;
         PreSynHelper* psh = presyns_helper + i;
@@ -688,23 +689,28 @@ void NetCvode::check_thresh(NrnThread* nt) {  // for default method
             }
 #endif
 
+// clang-format off
             #pragma acc atomic capture
+            // clang-format on
             idx = net_send_buf_count++;
 
             nt->_net_send_buffer[idx] = i;
         }
     }
 
+// clang-format off
     #pragma acc wait(stream_id)
+    // clang-format on
     nt->_net_send_buffer_cnt = net_send_buf_count;
 
     if (nt->_net_send_buffer_cnt) {
 #ifdef _OPENACC
         int* nsbuffer = nt->_net_send_buffer;
 #endif
-        #pragma acc update host(nsbuffer[0 : nt->_net_send_buffer_cnt]) if (nt->compute_gpu) \
-                                                                        async(stream_id)
+// clang-format off
+        #pragma acc update host(nsbuffer[0:nt->_net_send_buffer_cnt]) if (nt->compute_gpu) async(stream_id)
         #pragma acc wait(stream_id)
+        // clang-format on
     }
 
     // on CPU...

--- a/coreneuron/nrniv/node_permute.cpp
+++ b/coreneuron/nrniv/node_permute.cpp
@@ -156,7 +156,7 @@ void update_pdata_values(Memb_list* ml, int type, NrnThread& nt) {
                 int ixnew = p_target[ix];
                 *pd = ixnew + area0;
             }
-        }else if (s == -9) {                               // diam
+        } else if (s == -9) {                        // diam
             int diam0 = nt._actual_diam - nt._data;  // includes padding if relevant
             int* p_target = nt._permute;
             for (int iml = 0; iml < cnt; ++iml) {

--- a/coreneuron/nrniv/nrn_acc_manager.cpp
+++ b/coreneuron/nrniv/nrn_acc_manager.cpp
@@ -804,7 +804,9 @@ extern "C" {
 void update_matrix_from_gpu(NrnThread* _nt) {
 #ifdef _OPENACC
     if (_nt->compute_gpu && (_nt->end > 0)) {
-        /* before copying, make sure all computations in the stream are completed */
+/* before copying, make sure all computations in the stream are completed */
+
+// clang-format off
         #pragma acc wait(_nt->stream_id)
 
         /* openacc routine doesn't allow asyn, use pragma */
@@ -818,6 +820,7 @@ void update_matrix_from_gpu(NrnThread* _nt) {
 
         #pragma acc update host(rhs[0 : 2 * ne]) async(_nt->stream_id)
         #pragma acc wait(_nt->stream_id)
+        // clang-format on
     }
 #else
     (void)_nt;
@@ -827,7 +830,9 @@ void update_matrix_from_gpu(NrnThread* _nt) {
 void update_matrix_to_gpu(NrnThread* _nt) {
 #ifdef _OPENACC
     if (_nt->compute_gpu && (_nt->end > 0)) {
-        /* before copying, make sure all computations in the stream are completed */
+/* before copying, make sure all computations in the stream are completed */
+
+// clang-format off
         #pragma acc wait(_nt->stream_id)
 
         /* while discussion with Michael we found that RHS is also needed on
@@ -841,6 +846,7 @@ void update_matrix_to_gpu(NrnThread* _nt) {
         #pragma acc update device(v[0 : ne]) async(_nt->stream_id)
         #pragma acc update device(rhs[0 : ne]) async(_nt->stream_id)
         #pragma acc wait(_nt->stream_id)
+        // clang-format on
     }
 #else
     (void)_nt;

--- a/coreneuron/nrniv/nrn_datareader.cpp
+++ b/coreneuron/nrniv/nrn_datareader.cpp
@@ -29,7 +29,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 #include "coreneuron/nrniv/nrn_datareader.h"
 
-extern "C" int check_bbcore_write_version(const char *);
+extern "C" int check_bbcore_write_version(const char*);
 
 data_reader::data_reader(const char* filename, bool reorder) {
     this->open(filename, reorder);
@@ -61,10 +61,7 @@ int data_reader::read_int() {
     return i;
 }
 
-void data_reader::read_mapping_count(int* gid,
-                                     int* nsec,
-                                     int* nseg,
-                                     int* nseclist) {
+void data_reader::read_mapping_count(int* gid, int* nsec, int* nseg, int* nseclist) {
     char line_buf[max_line_length];
 
     F.getline(line_buf, sizeof(line_buf));

--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -48,7 +48,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/utils/reports/nrnreport.h"
 #include "coreneuron/utils/reports/nrnsection_mapping.h"
 
-
 // file format defined in cooperation with nrncore/src/nrniv/nrnbbcore_write.cpp
 // single integers are ascii one per line. arrays are binary int or double
 // Note that regardless of the gid contents of a group, since all gids are
@@ -227,7 +226,8 @@ void nrn_read_filesdat(int& ngrp, int*& grp, int multiple, int*& imult, const ch
     }
 
     if (nrnmpi_numprocs > iNumFiles && nrnmpi_myid == 0) {
-        printf("Info : The number of input datasets are less than ranks, some ranks will be idle!\n");
+        printf(
+            "Info : The number of input datasets are less than ranks, some ranks will be idle!\n");
     }
 
     ngrp = 0;
@@ -262,9 +262,9 @@ void read_phase1(data_reader& F, int imult, NrnThread& nt) {
     nt.netcons = new NetCon[nt.n_netcon + nrn_setup_extracon];
     nt.presyns_helper = (PreSynHelper*)ecalloc(nt.n_presyn, sizeof(PreSynHelper));
 
-    /// Checkpoint in coreneuron is defined for both phase 1 and phase 2 since they are written together
-    /// output_gid has all of output PreSyns, netcon_srcgid is created for NetCons which might be
-    /// 10k times more than output_gid.
+    /// Checkpoint in coreneuron is defined for both phase 1 and phase 2 since they are written
+    /// together output_gid has all of output PreSyns, netcon_srcgid is created for NetCons which
+    /// might be 10k times more than output_gid.
     int* output_gid = F.read_array<int>(nt.n_presyn);
     // the extra netcon_srcgid will be filled in later
     netcon_srcgid[nt.id] = new int[nt.n_netcon + nrn_setup_extracon];
@@ -636,8 +636,8 @@ void nrn_setup(const char* filesdat, int byte_swap, bool run_setup_cleanup) {
     double mindelay = set_mindelay(nrnopt_get_dbl("--mindelay"));
     nrnopt_modify_dbl("--mindelay", mindelay);
 
-    if (run_setup_cleanup) //if run_setup_cleanup==false, user must call nrn_setup_cleanup() later
-       nrn_setup_cleanup();
+    if (run_setup_cleanup)  // if run_setup_cleanup==false, user must call nrn_setup_cleanup() later
+        nrn_setup_cleanup();
 
 #if INTERLEAVE_DEBUG
     mk_cell_indices();
@@ -938,10 +938,11 @@ void read_phase2(data_reader& F, int imult, NrnThread& nt) {
     nrn_assert(n_outputgid > 0);  // avoid n_outputgid unused warning
     nt.ncell = F.read_int();
     nt.end = F.read_int();
-    int ndiam = F.read_int(); // 0 if not needed, else nt.end
+    int ndiam = F.read_int();  // 0 if not needed, else nt.end
     int nmech = F.read_int();
 
-    /// Checkpoint in coreneuron is defined for both phase 1 and phase 2 since they are written together
+    /// Checkpoint in coreneuron is defined for both phase 1 and phase 2 since they are written
+    /// together
     // printf("ncell=%d end=%d nmech=%d\n", nt.ncell, nt.end, nmech);
     // printf("nart=%d\n", nart);
     NrnThreadMembList* tml_last = NULL;
@@ -1187,7 +1188,7 @@ void read_phase2(data_reader& F, int imult, NrnThread& nt) {
                     nrn_assert((ix >= 0) && (ix < nt.end));
                     *pd = area0 + ix;
                 }
-            }else if (s == -9) {  // diam
+            } else if (s == -9) {  // diam
                 int diam0 = nt._actual_diam - nt._data;
                 for (int iml = 0; iml < cnt; ++iml) {
                     int* pd = pdata + nrn_i_layout(iml, cnt, i, szdp, layout);
@@ -1385,14 +1386,14 @@ for (int i=0; i < nt.end; ++i) {
     // for fast watch statement checking
     // setup a list of types that have WATCH statement
     {
-        int sz = 0; // count the types with WATCH
+        int sz = 0;  // count the types with WATCH
         for (NrnThreadMembList* tml = nt.tml; tml; tml = tml->next) {
             if (nrn_watch_check[tml->index]) {
                 ++sz;
             }
         }
         if (sz) {
-            nt._watch_types = (int*)ecalloc(sz + 1, sizeof(int)); // NULL terminated
+            nt._watch_types = (int*)ecalloc(sz + 1, sizeof(int));  // NULL terminated
             sz = 0;
             for (NrnThreadMembList* tml = nt.tml; tml; tml = tml->next) {
                 if (nrn_watch_check[tml->index]) {
@@ -1434,7 +1435,7 @@ for (int i=0; i < nt.end; ++i) {
         PreSyn* ps = nt.presyns + i;
 
         int ix = output_vindex[i];
-        if (ix == -1 && i < nt.ncell) { // real cell without a presyn
+        if (ix == -1 && i < nt.ncell) {  // real cell without a presyn
             continue;
         }
         if (ix < 0) {
@@ -1707,17 +1708,16 @@ void read_phase3(data_reader& F, int imult, NrnThread& nt) {
 
     /** for every neuron */
     for (int i = 0; i < nt.ncell; i++) {
-
         int gid, nsec, nseg, nseclist;
 
         // read counts
         F.read_mapping_count(&gid, &nsec, &nseg, &nseclist);
 
-        CellMapping *cmap = new CellMapping(gid);
+        CellMapping* cmap = new CellMapping(gid);
 
         // read section-segment mapping for every section list
-        for(int j = 0; j < nseclist; j++) {
-            SecMapping *smap = new SecMapping();
+        for (int j = 0; j < nseclist; j++) {
+            SecMapping* smap = new SecMapping();
             F.read_mapping_info(smap);
             cmap->add_sec_map(smap);
         }
@@ -1726,7 +1726,7 @@ void read_phase3(data_reader& F, int imult, NrnThread& nt) {
     }
 
     // make number #cells match with mapping size
-    nrn_assert( (int)ntmapping->size() ==  nt.ncell);
+    nrn_assert((int)ntmapping->size() == nt.ncell);
 
     // set pointer in NrnThread
     nt.mapping = (void*)ntmapping;

--- a/coreneuron/nrniv/nrn_setup.h
+++ b/coreneuron/nrniv/nrn_setup.h
@@ -128,6 +128,6 @@ namespace coreneuron {
     inline static void phase_wrapper() {
         nrn_multithread_job(phase_wrapper_w<P>);
     }
-}
+}  // namespace coreneuron
 
 #endif

--- a/coreneuron/nrniv/nrnoptarg.cpp
+++ b/coreneuron/nrniv/nrnoptarg.cpp
@@ -58,7 +58,8 @@ struct param_str {
 
 static param_int param_int_args[] = {
     {"--spikebuf -b", 100000, 1, 2000000000, "Spike buffer size. (100000)"},
-    {"--spkcompress", 0, 0, 100000, "Spike compression. Up to ARG are exchanged during MPI_Allgather. (0)"},
+    {"--spkcompress", 0, 0, 100000,
+     "Spike compression. Up to ARG are exchanged during MPI_Allgather. (0)"},
     {"--prcellgid -g", -1, -1, 2000000000, "Output prcellstate information for the gid NUMBER."},
     {"--cell-permute -R", 1, 0, 3,
      "Cell permutation, 0 No; 1 optimise node adjacency; 2 optimize parent adjacency. (1)"},
@@ -76,7 +77,8 @@ static param_int param_int_args[] = {
 static param_dbl param_dbl_args[] = {
     {"--tstart -s", 0., -1e9, 1e9, "Start time (ms). (0)"},
     {"--tstop -e", 100.0, 0.0, 1e9, "Stop time (ms). (100)"},
-    {"--dt -dt", -1000., -1000., 1e9, "Fixed time step. The default value is set by defaults.dat or is 0.025."},
+    {"--dt -dt", -1000., -1000., 1e9,
+     "Fixed time step. The default value is set by defaults.dat or is 0.025."},
     {"--dt_io -i", 0.1, 1e-9, 1e9, "Dt of I/O. (0.1)"},
     {"--voltage -v", -65.0, -1e9, 1e9,
      "Initial voltage used for nrn_finitialize(1, v_init). If 1000, then nrn_finitialize(0,...). (-65.)"},
@@ -89,7 +91,8 @@ static param_dbl param_dbl_args[] = {
     {NULL, 0., 0., 0., NULL}};
 
 static param_flag param_flag_args[] = {
-    {"--help -h", "Print a usage message briefly summarizing these command-line options, then exit."},
+    {"--help -h",
+     "Print a usage message briefly summarizing these command-line options, then exit."},
     {"--threading -c", "Parallel threads. The default is serial threads."},
     {"--gpu -gpu", "Enable use of GPUs. The default implies cpu only run."},
     {"-mpi", "Enable MPI. In order to initialize MPI environment this argument must be specified."},

--- a/coreneuron/nrnmpi/mpispike.h
+++ b/coreneuron/nrnmpi/mpispike.h
@@ -82,8 +82,7 @@ extern NRNMPI_Spikebuf* spbufout_;
 extern NRNMPI_Spikebuf* spbufin_;
 #endif
 
-
-#endif // NRNMPI
+#endif  // NRNMPI
 
 #if defined(__cplusplus)
 }

--- a/coreneuron/nrnmpi/nrnmpi.c
+++ b/coreneuron/nrnmpi/nrnmpi.c
@@ -191,7 +191,7 @@ double nrn_wtime() {
     {
         struct timeval time1;
         gettimeofday(&time1, NULL);
-        return (time1.tv_sec + time1.tv_usec/1.e6);
+        return (time1.tv_sec + time1.tv_usec / 1.e6);
     }
 }
 

--- a/coreneuron/nrnmpi/nrnmpi_impl.h
+++ b/coreneuron/nrnmpi/nrnmpi_impl.h
@@ -36,6 +36,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
 extern MPI_Comm nrnmpi_world_comm;
 extern MPI_Comm nrnmpi_comm;
 
-#endif // NRNMPI
+#endif  // NRNMPI
 
 #endif

--- a/coreneuron/nrnmpi/nrnmpiuse.h
+++ b/coreneuron/nrnmpi/nrnmpiuse.h
@@ -32,12 +32,12 @@ THE POSSIBILITY OF SUCH DAMAGE.
 /* define to 1 if you want MPI specific features activated
    (optionally provided by CMake option NRNMPI) */
 #ifndef NRNMPI
-  #define NRNMPI 1
+#define NRNMPI 1
 #endif
 
 /* define to 1 if want multisend spike exchange available */
 #ifndef NRN_MULTISEND
- #define NRN_MULTISEND 1
+#define NRN_MULTISEND 1
 #endif
 
 /* define to 1 if you want parallel distributed cells (and gap junctions) */

--- a/coreneuron/nrnoc/fadvance_core.c
+++ b/coreneuron/nrnoc/fadvance_core.c
@@ -144,14 +144,20 @@ void update(NrnThread* _nt) {
 
     /* do not need to worry about linmod or extracellular*/
     if (secondorder) {
-        #pragma acc parallel loop present(vec_v[0 : i2], \
-                                        vec_rhs[0 : i2]) if (_nt->compute_gpu) async(stream_id)
+// clang-format off
+        #pragma acc parallel loop present(          \
+            vec_v[0:i2], vec_rhs[0:i2])             \
+            if (_nt->compute_gpu) async(stream_id)
+        // clang-format on
         for (i = i1; i < i2; ++i) {
             vec_v[i] += 2. * vec_rhs[i];
         }
     } else {
-        #pragma acc parallel loop present(vec_v[0 : i2], \
-                                        vec_rhs[0 : i2]) if (_nt->compute_gpu) async(stream_id)
+// clang-format off
+        #pragma acc parallel loop present(              \
+                vec_v[0:i2], vec_rhs[0:i2])             \
+                if (_nt->compute_gpu) async(stream_id)
+        // clang-format on
         for (i = i1; i < i2; ++i) {
             vec_v[i] += vec_rhs[i];
         }
@@ -204,9 +210,11 @@ static void* nrn_fixed_step_thread(NrnThread* nth) {
     if (nth->ncell) {
 #if defined(_OPENACC)
         int stream_id = nth->stream_id;
-        /*@todo: do we need to update nth->_t on GPU: Yes (Michael, but can launch kernel) */
+/*@todo: do we need to update nth->_t on GPU: Yes (Michael, but can launch kernel) */
+// clang-format off
         #pragma acc update device(nth->_t) if (nth->compute_gpu) async(stream_id)
         #pragma acc wait(stream_id)
+// clang-format on
 #endif
 
         fixed_play_continuous(nth);
@@ -227,15 +235,17 @@ void* nrn_fixed_step_lastpart(NrnThread* nth) {
     if (nth->ncell) {
 #if defined(_OPENACC)
         int stream_id = nth->stream_id;
-        /*@todo: do we need to update nth->_t on GPU */
+/*@todo: do we need to update nth->_t on GPU */
+// clang-format off
         #pragma acc update device(nth->_t) if (nth->compute_gpu) async(stream_id)
         #pragma acc wait(stream_id)
+// clang-format on
 #endif
 
         fixed_play_continuous(nth);
         nonvint(nth);
         nrn_ba(nth, AFTER_SOLVE);
-	nrn_ba(nth, BEFORE_STEP);
+        nrn_ba(nth, BEFORE_STEP);
     }
 
     nrn_deliver_events(nth); /* up to but not past texit */

--- a/coreneuron/nrnoc/finitialize.c
+++ b/coreneuron/nrnoc/finitialize.c
@@ -48,7 +48,11 @@ void nrn_finitialize(int setv, double v) {
     if (setv) {
         for (_nt = nrn_threads; _nt < nrn_threads + nrn_nthread; ++_nt) {
             double* vec_v = &(VEC_V(0));
-            #pragma acc parallel loop present(_nt[0 : 1], vec_v[0 : _nt->end]) if (_nt->compute_gpu)
+// clang-format off
+            #pragma acc parallel loop present(      \
+                _nt[0:1], vec_v[0:_nt->end])        \
+                if (_nt->compute_gpu)
+            // clang-format on
             for (i = 0; i < _nt->end; ++i) {
                 vec_v[i] = v;
             }

--- a/coreneuron/nrnoc/multicore.c
+++ b/coreneuron/nrnoc/multicore.c
@@ -309,7 +309,8 @@ void nrn_threads_create(int n, int parallel) {
     int i, j;
     NrnThread* nt;
     if (nrn_nthread != n) {
-      /*printf("sizeof(NrnThread)=%d   sizeof(Memb_list)=%d\n", sizeof(NrnThread), sizeof(Memb_list));*/
+        /*printf("sizeof(NrnThread)=%d   sizeof(Memb_list)=%d\n", sizeof(NrnThread),
+         * sizeof(Memb_list));*/
 
         nrn_threads = (NrnThread*)0;
         nrn_nthread = n;
@@ -444,17 +445,19 @@ void nrn_multithread_job(void* (*job)(NrnThread*)) {
     int i;
 #if defined(_OPENMP)
 
-    /* Todo : Remove schedule clause usage by using OpenMP 3 API.
-     *        Need better CMake handling for checking OpenMP 3 support.
-     */
-  #if defined(ENABLE_OMP_RUNTIME_SCHEDULE)
+/* Todo : Remove schedule clause usage by using OpenMP 3 API.
+ *        Need better CMake handling for checking OpenMP 3 support.
+ */
+// clang-format off
+#if defined(ENABLE_OMP_RUNTIME_SCHEDULE)
     #pragma omp parallel for private(i) shared(nrn_threads, job, nrn_nthread, \
                                            nrnmpi_myid) schedule(runtime)
-  #else
+#else
     // default(none) removed to avoid issue with opari2
     #pragma omp parallel for private(i) shared(nrn_threads, job, nrn_nthread, \
                                            nrnmpi_myid) schedule(static, 1)
-  #endif
+#endif
+    // clang-format on
     for (i = 0; i < nrn_nthread; ++i) {
         (*job)(nrn_threads + i);
     }

--- a/coreneuron/nrnoc/multicore.h
+++ b/coreneuron/nrnoc/multicore.h
@@ -104,10 +104,10 @@ typedef struct NrnThread {
     double* _actual_v;
     double* _actual_area;
     double* _actual_diam; /* NULL if no mechanism has dparam with diam semantics */
-    double* _shadow_rhs; /* Not pointer into _data. Avoid race for multiple POINT_PROCESS in same
-                            compartment */
-    double* _shadow_d;   /* Not pointer into _data. Avoid race for multiple POINT_PROCESS in same
-                            compartment */
+    double* _shadow_rhs;  /* Not pointer into _data. Avoid race for multiple POINT_PROCESS in same
+                             compartment */
+    double* _shadow_d;    /* Not pointer into _data. Avoid race for multiple POINT_PROCESS in same
+                             compartment */
     int* _v_parent_index;
     int* _permute;
     char* _sp13mat;                     /* handle to general sparse matrix */
@@ -125,7 +125,7 @@ typedef struct NrnThread {
     int* _net_send_buffer;
 
     int* _watch_types; /* NULL or 0 terminated array of integers */
-    void* mapping; /* section to segment mapping information */
+    void* mapping;     /* section to segment mapping information */
 
 } NrnThread;
 

--- a/coreneuron/nrnoc/register_mech.c
+++ b/coreneuron/nrnoc/register_mech.c
@@ -37,8 +37,10 @@ THE POSSIBILITY OF SUCH DAMAGE.
 int secondorder = 0;
 double t, dt, celsius;
 #if defined(PG_ACC_BUGS)
+// clang-format off
     #pragma acc declare copyin(secondorder)
     #pragma acc declare copyin(celsius)
+// clang-format on
 #endif
 int rev_dt;
 

--- a/coreneuron/nrnoc/solve_core.c
+++ b/coreneuron/nrnoc/solve_core.c
@@ -32,7 +32,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 int use_solve_interleave;
 
-static void triang(NrnThread *), bksub(NrnThread *);
+static void triang(NrnThread*), bksub(NrnThread*);
 
 /* solve the matrix equation */
 void nrn_solve_minimal(NrnThread* _nt) {
@@ -89,20 +89,26 @@ static void bksub(NrnThread* _nt) {
 #endif
 
 /** @todo: just for benchmarking, otherwise produces wrong results */
-    #pragma acc parallel loop seq present(vec_d[0 : i2], vec_rhs[0 : i2]) \
-                                          async(stream_id) if (_nt->compute_gpu)
+// clang-format off
+    #pragma acc parallel loop seq present(      \
+        vec_d[0:i2], vec_rhs[0:i2])             \
+        async(stream_id) if (_nt->compute_gpu)
+    // clang-format on
     for (i = i1; i < i2; ++i) {
         vec_rhs[i] /= vec_d[i];
     }
 
 /** @todo: just for benchmarking, otherwise produces wrong results */
-    #pragma acc parallel loop seq present(                                   \
-        vec_b[0 : i3], vec_d[0 : i3], vec_rhs[0 : i3], parent_index[0 : i3]) \
-                                      async(stream_id) if (_nt->compute_gpu)
+// clang-format off
+    #pragma acc parallel loop seq present(          \
+        vec_b[0:i3], vec_d[0:i3], vec_rhs[0:i3],    \
+        parent_index[0:i3]) async(stream_id)        \
+        if (_nt->compute_gpu)
     for (i = i2; i < i3; ++i) {
         vec_rhs[i] -= vec_b[i] * vec_rhs[parent_index[i]];
         vec_rhs[i] /= vec_d[i];
     }
 
     #pragma acc wait(stream_id)
+    // clang-format on
 }

--- a/coreneuron/scopmath_core/newton_thread.c
+++ b/coreneuron/scopmath_core/newton_thread.c
@@ -123,7 +123,7 @@ int nrn_newton_thread(NewtonSpace* ns,
             max_dev = 0.0;
             for (i = 0; i < n; i++) {
                 value[ix(i)] = -value[ix(i)]; /* Required correction to function
-                                       * values */
+                                               * values */
                 if ((temp = fabs(value[ix(i)])) > max_dev)
                     max_dev = temp;
             }

--- a/coreneuron/scopmath_core/sparse_thread.c
+++ b/coreneuron/scopmath_core/sparse_thread.c
@@ -54,7 +54,7 @@ static char RCSid[] = "sparse.c,v 1.7 1998/03/12 13:17:17 hines Exp";
  *
  *  Files accessed:  none
  *
-*/
+ */
 
 #if LINT
 #define IGNORE(arg) \

--- a/coreneuron/utils/memory_utils.cpp
+++ b/coreneuron/utils/memory_utils.cpp
@@ -66,9 +66,9 @@ double nrn_mallinfo(void) {
 #elif defined(__APPLE__) && defined(__MACH__)
     struct mach_task_basic_info info;
     mach_msg_type_number_t infoCount = MACH_TASK_BASIC_INFO_COUNT;
-    if ( task_info( mach_task_self( ), MACH_TASK_BASIC_INFO,
-        (task_info_t)&info, &infoCount ) != KERN_SUCCESS )
-        return (size_t)0L;      /* Can't access? */
+    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)&info, &infoCount) !=
+        KERN_SUCCESS)
+        return (size_t)0L; /* Can't access? */
     return info.resident_size / (1024.0 * 1024.0);
 #elif defined HAVE_MALLOC_H
     struct mallinfo m;

--- a/coreneuron/utils/randoms/Random123/features/nvccfeatures.h
+++ b/coreneuron/utils/randoms/Random123/features/nvccfeatures.h
@@ -68,7 +68,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     if ((x))           \
         ;              \
     else               \
-    asm("trap;")
+        asm("trap;")
 #endif
 
 #ifndef R123_BUILTIN_EXPECT

--- a/coreneuron/utils/reports/nrnreport.cpp
+++ b/coreneuron/utils/reports/nrnreport.cpp
@@ -52,8 +52,10 @@ void ReportEvent::deliver(double t, NetCvode* nc, NrnThread* nt) {
 // avoid pgc++-Fatal-/opt/pgi/linux86-64/16.5/bin/pggpp2ex TERMINATED by signal 11
 #ifdef ENABLE_REPORTING
 
-    /** @todo: reportinglib is not thread safe, fix this */
+/** @todo: reportinglib is not thread safe, fix this */
+// clang-format off
     #pragma omp critical
+    // clang-format on
     {
 // each thread needs to know its own step
 #ifdef ENABLE_REPORTING

--- a/coreneuron/utils/swap_endian.h
+++ b/coreneuron/utils/swap_endian.h
@@ -66,8 +66,8 @@ namespace endian {
                 *d_++ = *s_++;
             return d;
         }
-    }
-}
+    }  // namespace impl
+}  // namespace endian
 #endif
 
 namespace endian {
@@ -409,7 +409,7 @@ namespace endian {
                     swap_endian<sizeof(V), 1, false>::eval((unsigned char*)b++);
             }
         }
-    }
+    }  // namespace impl
 
     /** Reverse the endianness of a value in-place.
      *
@@ -437,7 +437,7 @@ namespace endian {
                 swap_endian_unroll(b, e);
             }
         };
-    }
+    }  // namespace impl
 
     /** Reverse the endianness of the values in the given range.
      *


### PR DESCRIPTION
OpenMP/OpenACC pragma is more like programming cnstruct rather
than just hint and hence we would like to have those indented.
clang-format doesn't recognize these "special" pragmas and end-up
removing all indendation. Currently there is no way to fix
this rather than using clang-format off/on comments.