### PR TITLE
update RPath config for Cray (static linkage)

### DIFF
--- a/CMake/config/SetRpath.cmake
+++ b/CMake/config/SetRpath.cmake
@@ -2,7 +2,7 @@
 set(CMAKE_MACOSX_RPATH 1)
 
 # on bg-q we do static linking and xlc doesnt like RPATH settings in this case
-IF( NOT BLUEGENE)
+IF( NOT BLUEGENE AND NOT CRAY_SYSTEM)
 
     # use, i.e. don't skip the full RPATH for the build tree
     SET(CMAKE_SKIP_BUILD_RPATH  FALSE)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The workflow for building CoreNEURON is different from that of NEURON, especiall
 ```bash
 cmake .. -DADDITIONAL_MECHPATH="/path/of/mod/files/directory/"
 ```
-This directory should have only mod files that are compatible with CoreNEURON. You can also provide multiple directories separated by a semicolon :
+This directory should have only mod files that are compatible with CoreNEURON. You can also provide multiple directories separated by a semicolon:
 
 ```bash
 -DADDITIONAL_MECHPATH="/path/of/folder/with/mod_files;/path/of/another_folder/with/mod_files" 

--- a/coreneuron/coreneuron.h
+++ b/coreneuron/coreneuron.h
@@ -30,7 +30,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
  * Includes all headers required to communicate and run all methods
  * described in CoreNeuron, neurox, and mod2c C-generated mechanisms
  * functions.
- **/
+**/
 
 #ifndef CORENEURON_H
 #define CORENEURON_H
@@ -45,16 +45,10 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/utils/randoms/nrnran123.h"      //Random Number Generator
 
 #if defined(__cplusplus)
-#include "coreneuron/nrniv/memory.h"  //Memory alignemnts and padding
+#include "coreneuron/nrniv/memory.h"  //Memory alignments and padding
 
 extern "C" {
 #endif
-
-// global variables required by mechanisms
-// TODO requires #include coreneuron/coreneuron.h in all mechs
-// extern double celsius; //from coreneuron/coreneuron/nrnconf.h
-// extern int nrn_ion_global_map_size; //from coreneuron/nrnoc/membfunc.h
-// extern double** nrn_ion_global_map; //from coreneuron/nrnoc/membfunc.h
 
 #ifdef EXPORT_MECHS_FUNCTIONS
 // from (auto-generated) mod_func_ptrs.c

--- a/coreneuron/nrniv/global_vars.cpp
+++ b/coreneuron/nrniv/global_vars.cpp
@@ -40,6 +40,7 @@ void set_globals(const char* path) {
     if (!f) {
         printf("ignore: could not open %s\n", fname.c_str());
         delete n2v;
+        n2v = NULL;
         return;
     }
 
@@ -99,4 +100,5 @@ void set_globals(const char* path) {
 #endif
 
     delete n2v;
+    n2v = NULL;
 }

--- a/coreneuron/nrniv/main1.cpp
+++ b/coreneuron/nrniv/main1.cpp
@@ -63,7 +63,10 @@ int nrn_feenableexcept() {
 
 int main1(int argc, char* argv[], char** env);
 void call_prcellstate_for_prcellgid(int prcellgid, int compute_gpu, int is_init);
-void nrn_init_and_load_data(int argc, char* argv[], bool run_setup_cleanup = true) {
+void nrn_init_and_load_data(int argc,
+                            char* argv[],
+                            bool nrnmpi_under_nrncontrol = true,
+                            bool run_setup_cleanup = true) {
 #if defined(NRN_FEEXCEPT)
     nrn_feenableexcept();
 #endif
@@ -74,7 +77,7 @@ void nrn_init_and_load_data(int argc, char* argv[], bool run_setup_cleanup = tru
 
 // mpi initialisation
 #if NRNMPI
-    nrnmpi_init(1, &argc, &argv);
+    nrnmpi_init(nrnmpi_under_nrncontrol ? 1 : 0, &argc, &argv);
 #endif
 
     // memory footprint after mpi initialisation

--- a/coreneuron/nrniv/nrn_setup.h
+++ b/coreneuron/nrniv/nrn_setup.h
@@ -47,8 +47,10 @@ static void read_phasegap(data_reader& F, int imult, NrnThread& nt);
 static void setup_ThreadData(NrnThread& nt);
 
 // Functions to load and clean data;
-extern void nrn_init_and_load_data(int argc, char** argv, bool run_setup_cleanup = true);
-extern void nrn_cleanup();
+extern void nrn_init_and_load_data(int argc,
+                                   char** argv,
+                                   bool nrnmpi_under_nrncontrol = true,
+                                   bool run_setup_cleanup = true);
 extern void nrn_setup_cleanup();
 
 namespace coreneuron {

--- a/coreneuron/nrniv/nrniv_decl.h
+++ b/coreneuron/nrniv/nrniv_decl.h
@@ -53,7 +53,7 @@ extern void nrn_p_construct(void);
 extern void nrn_setup(const char* filesdat, int byte_swap, bool run_setup_cleanup = true);
 extern int nrn_setup_multiple;
 extern int nrn_setup_extracon;
-extern void nrn_cleanup();
+extern void nrn_cleanup(bool clean_ion_global_map = true);
 extern void BBS_netpar_solve(double);
 extern void nrn_mkPatternStim(const char* filename);
 extern int nrn_extra_thread0_vdata;

--- a/coreneuron/nrnmpi/nrnmpi.c
+++ b/coreneuron/nrnmpi/nrnmpi.c
@@ -63,12 +63,6 @@ static int nrnmpi_under_nrncontrol_;
 
 void nrnmpi_init(int nrnmpi_under_nrncontrol, int* pargc, char*** pargv) {
     int i, b, flag;
-    static int called = 0;
-
-    if (called) {
-        return;
-    }
-    called = 1;
     nrnmpi_use = 1;
     nrnmpi_under_nrncontrol_ = nrnmpi_under_nrncontrol;
     if (nrnmpi_under_nrncontrol_) {
@@ -113,11 +107,10 @@ void nrnmpi_init(int nrnmpi_under_nrncontrol, int* pargc, char*** pargv) {
             nrn_assert(MPI_Init(pargc, pargv) == MPI_SUCCESS);
 #endif
         }
-
-        { nrn_assert(MPI_Comm_dup(MPI_COMM_WORLD, &nrnmpi_world_comm) == MPI_SUCCESS); }
     }
     grp_bbs = MPI_GROUP_NULL;
     grp_net = MPI_GROUP_NULL;
+    nrn_assert(MPI_Comm_dup(MPI_COMM_WORLD, &nrnmpi_world_comm) == MPI_SUCCESS);
     nrn_assert(MPI_Comm_dup(nrnmpi_world_comm, &nrnmpi_comm) == MPI_SUCCESS);
     nrn_assert(MPI_Comm_dup(nrnmpi_world_comm, &nrn_bbs_comm) == MPI_SUCCESS);
     nrn_assert(MPI_Comm_rank(nrnmpi_world_comm, &nrnmpi_myid_world) == MPI_SUCCESS);


### PR DESCRIPTION
cmake try to setup rpath of coreneuron when doing make install, however we build coreneuron statically on cray systems.
