### PR TITLE
Fix issue with Tau instrumentation on OS X

### DIFF
--- a/CMake/portability/BlueGenePortability.cmake
+++ b/CMake/portability/BlueGenePortability.cmake
@@ -36,17 +36,23 @@ endif()
 if(BLUEGENE)
 	# define library type to static on BGQ
 	set(COMPILE_LIBRARY_TYPE "STATIC")
-	
+
 	## Blue Gene/Q do not support linking with MPI library when compiled with mpicc wrapper
         ## we disable any MPI_X_LIBRARY linking and rely on mpicc wrapper
 	set(MPI_LIBRARIES "")
-	set(MPI_C_LIBRARIES "")	
+	set(MPI_C_LIBRARIES "")
 	set(MPI_CXX_LIBRARIES "")
 
 	## static linking need to be forced on BlueGene
 	# Boost need a bit of tuning parameters for static linking
 	set(Boost_NO_BOOST_CMAKE TRUE)
-        set(Boost_USE_STATIC_LIBS TRUE)	
+        set(Boost_USE_STATIC_LIBS TRUE)
+
+    CHECK_INCLUDE_FILES("spi/include/kernel/memory.h" have_memory_h)
+    if(have_memory_h)
+        add_definitions("-DHAVE_MEMORY_H")
+    endif()
+
 else()
 
 if(NOT DEFINED COMPILE_LIBRARY_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,11 +158,6 @@ endif()
 # using this macro for CoreNeuron build
 add_definitions(-DCORENEURON_BUILD)
 
-CHECK_INCLUDE_FILES("spi/include/kernel/memory.h" have_memory_h)
-if(have_memory_h)
-  add_definitions("-DHAVE_MEMORY_H")
-endif()
-
 option (ENABLE_SELECTIVE_GPU_PROFILING "Enable GPU profiling only for Solver" ON)
 option (ENABLE_OPENACC "Enable use of OpenACC" OFF)
 


### PR DESCRIPTION
CMake try to enable bg-q related memory usage functions on OS X while profiling with TAU.
Check spi.h on bg-q only