### PR TITLE
Fixes nrnhines/nrn#42

### DIFF
--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -1554,7 +1554,11 @@ for (int i=0; i < nt.end; ++i) {
     for (int i = 0; i < nnetcon; ++i) {
         NetCon& nc = nt.netcons[i];
         nc.u.weight_index_ = iw;
-        iw += pnt_receive_size[pnttype[i]];
+        if (pnttype[i] != 0) {
+            iw += pnt_receive_size[pnttype[i]];
+        } else {
+            iw += 1;
+        }
     }
     assert(iw == nweight);
     delete[] pnttype;


### PR DESCRIPTION
This pull request fixes nrnhines/nrn#42.

The issue appeared when calling `nrnbbcore_write` from NEURON to generate a dataset for CoreNeuron. Specifically, the culprit of the issue appeared when NetCons without a target were present in the original python or hoc script that specified the model.

### Before
NetCons without a target were being (correctly) saved to the coreneuron dataset by NEURON. 
Moreover, _every NetCon has at least one weight_. 
NetCons without a target have a `pnttype` value of `0`.

However, when CoreNeuron was reading the same dataset, it was not increasing the value of `iw` because `pnt_receive_size[0]` is equal to `0`.

### Now
NetCons without a target are still being (correctly) saved to the coreneuron dataset by NEURON. 
NetCons without a target still have a `pnttype` value of `0`.
`pnt_receive_size[0]` is still equal to `0`.

However, while reading the dataset, CoreNeuron now makes a special check and artificially increases by `1` the value of `iw` in case of a NetCon without a target. 
