### PR TITLE
Fix nodecount argument for check_table_thread

### DIFF
--- a/coreneuron/nrnoc/multicore.c
+++ b/coreneuron/nrnoc/multicore.c
@@ -436,7 +436,7 @@ void nrn_thread_table_check() {
         NrnThread* nt = nrn_threads + table_check_[i].i;
         NrnThreadMembList* tml = (NrnThreadMembList*)table_check_[i + 1]._pvoid;
         Memb_list* ml = tml->ml;
-        (*memb_func[tml->index].thread_table_check_)(0, ml->nodecount, ml->data, ml->pdata,
+        (*memb_func[tml->index].thread_table_check_)(0, ml->_nodecount_padded, ml->data, ml->pdata,
                                                      ml->_thread, nt, tml->index);
     }
 }


### PR DESCRIPTION
When SoA layout is enabled with padding, the _check_table_thread
function expects padded nodecount. We were using non-padded nodecount
which was working with : AoS layout / without padding / when variables
were GLOBAL. This issue was discovered in latest StochKv where some
variables used in TABLE statement were changed from GLOBAL to RANGE.