### PR TITLE
fix segfault when getting more mpi ranks than nb cells 

### DIFF
--- a/coreneuron/nrniv/patternstim.cpp
+++ b/coreneuron/nrniv/patternstim.cpp
@@ -75,6 +75,14 @@ void nrn_set_extra_thread0_vdata() {
 
 // fname is the filename of an output_spikes.h format raster file.
 void nrn_mkPatternStim(const char* fname) {
+
+    // if rank doesn't have any cells, return immediately
+    NrnThread *nt = nrn_threads;
+
+    if(nt && nt->ncells == 0) {
+      return;
+    }
+
     int type = nrn_get_mechtype("PatternStim");
     if (!memb_func[type].sym) {
         printf("nrn_set_extra_thread_vdata must be called (after mk_mech, and before nrn_setup\n");


### PR DESCRIPTION
when a patternStim file is specified on command line, ranks without cells should do nothing concerning patternStim