### PR TITLE
Centralize global variables definitions

### DIFF
--- a/coreneuron/nrniv/netcvode.cpp
+++ b/coreneuron/nrniv/netcvode.cpp
@@ -36,10 +36,12 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/nrniv/netcvode.h"
 #include "coreneuron/nrniv/ivocvect.h"
 #include "coreneuron/nrniv/nrniv_decl.h"
+#include "coreneuron/nrnoc/nrnoc_decl.h"
 #include "coreneuron/nrniv/output_spikes.h"
 #include "coreneuron/nrniv/nrn_assert.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/nrniv/multisend.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #ifdef _OPENACC
 #include <openacc.h>
 #endif
@@ -63,10 +65,8 @@ void mk_netcvode() {
     }
 }
 
-extern void nrn_outputevent(unsigned char, double);
 extern "C" {
-extern pnt_receive_t* pnt_receive;
-extern pnt_receive_t* pnt_receive_init;
+//TODO following declarations dont appears in any include files
 extern short* nrn_artcell_qindex_;
 extern bool nrn_use_localgid_;
 extern void nrn2ncs_outputevent(int netcon_output_index, double firetime);
@@ -76,8 +76,6 @@ void net_move(void**, Point_process*, double);
 void net_sem_from_gpu(int sendtype, int i_vdata, int, int ith, int ipnt, double, double);
 void artcell_net_send(void**, int, Point_process*, double, double);
 void artcell_net_move(void**, Point_process*, double);
-extern void nrn_fixed_step_minimal();
-extern void nrn_fixed_step_group_minimal(int);
 
 #ifdef DEBUG
 // temporary

--- a/coreneuron/nrniv/netpar.cpp
+++ b/coreneuron/nrniv/netpar.cpp
@@ -34,7 +34,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrnmpi/nrnmpi.h"
 #include "coreneuron/nrnoc/nrnoc_decl.h"
-
+#include "coreneuron/nrnmpi/nrnmpidec.h"
 class PreSyn;
 class InputPreSyn;
 
@@ -49,8 +49,6 @@ static double t_exchange_;
 static double dt1_;  // 1/dt
 
 extern "C" {
-extern double t, dt;
-extern void nrn_fake_fire(int gid, double firetime, int fake_out);
 void nrn_spike_exchange_init();
 }
 
@@ -677,7 +675,7 @@ static void mk_localgid_rep() {
 // set the third arg to 1 and set the output cell thresholds very
 // high so that they do not themselves generate spikes.
 // Can only be called by thread 0 because of the ps->send.
-void nrn_fake_fire(int gid, double spiketime, int fake_out) {
+extern "C" void nrn_fake_fire(int gid, double spiketime, int fake_out) {
     std::map<int, InputPreSyn*>::iterator gid2in_it;
     gid2in_it = gid2in.find(gid);
     if (gid2in_it != gid2in.end()) {

--- a/coreneuron/nrniv/nrn_filehandler.cpp
+++ b/coreneuron/nrniv/nrn_filehandler.cpp
@@ -29,7 +29,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 #include "coreneuron/nrniv/nrn_filehandler.h"
 #include "coreneuron/nrnconf.h"
-extern "C" void check_bbcore_write_version(const char*);
 
 FileHandler::FileHandler(const char* filename, bool reorder) {
     this->open(filename, reorder);

--- a/coreneuron/nrniv/nrn_stats.cpp
+++ b/coreneuron/nrniv/nrn_stats.cpp
@@ -41,8 +41,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/netcvode.h"
 #include "coreneuron/nrniv/partrans.h"
-
-extern std::vector<int> spikevec_gid;
+#include "coreneuron/nrniv/output_spikes.h"
 extern NetCvode* net_cvode_instance;
 
 const int NUM_STATS = 12;

--- a/coreneuron/nrniv/nrnoptarg.cpp
+++ b/coreneuron/nrniv/nrnoptarg.cpp
@@ -372,7 +372,6 @@ static void graceful_exit(int err) {
 #if defined(nrnoptargtest)
 // for testing, compile with: g++ -g -I../.. nrnoptarg.cpp
 
-int nrnmpi_myid;
 
 int main(int argc, const char* argv[]) {
     nrnopt_parse(argc, argv);

--- a/coreneuron/nrniv/nrnoptarg.cpp
+++ b/coreneuron/nrniv/nrnoptarg.cpp
@@ -368,25 +368,3 @@ static void graceful_exit(int err) {
 #endif
     exit(nrnmpi_myid == 0 ? err : 0);
 }
-
-#if defined(nrnoptargtest)
-// for testing, compile with: g++ -g -I../.. nrnoptarg.cpp
-
-
-int main(int argc, const char* argv[]) {
-    nrnopt_parse(argc, argv);
-
-    printf("prcellgid = %d\n", nrnopt_get_int("--prcellgid"));
-    printf("outpath = %s\n", nrnopt_get_str("--outpath").c_str());
-
-    printf("before modify dt = %g\n", nrnopt_get_dbl("--dt"));
-    nrnopt_modify_dbl("--dt", 18.1);
-    printf("after modify to 18.1, dt = %g\n", nrnopt_get_dbl("--dt"));
-
-    nrnopt_show();
-
-    nrnopt_delete();
-    return 0;
-}
-
-#endif  // test

--- a/coreneuron/nrniv/profiler_interface.cpp
+++ b/coreneuron/nrniv/profiler_interface.cpp
@@ -1,5 +1,5 @@
 #include <stdio.h>
-
+#include "coreneuron/nrnmpi/nrnmpi.h"
 #ifdef CUDA_PROFILING
 #include "coreneuron/nrniv/cuda_profile.h"
 #endif
@@ -19,7 +19,6 @@ static int cray_acc_debug_orig = 0;
 static int cray_acc_debug_zero = 0;
 #endif
 
-extern int nrnmpi_myid;
 
 void start_profile() {
     if (nrnmpi_myid == 0)

--- a/coreneuron/nrnoc/eion.c
+++ b/coreneuron/nrnoc/eion.c
@@ -31,7 +31,8 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "coreneuron/coreneuron.h"
 #include "coreneuron/nrnoc/nrnoc_decl.h"
-
+#include "coreneuron/nrnmpi/nrnmpi.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #if !defined(LAYOUT)
 /* 1 means AoS, >1 means AoSoA, <= 0 means SOA */
 #define LAYOUT 1
@@ -67,7 +68,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #define _PRAGMA_FOR_SEC_ORDER_CUR_ACC_LOOP_ _Pragma("")
 #endif
 
-extern void hoc_register_prop_size(int, int, int);
 
 #define nparm 5
 static char* mechanism[] = {/*just a template*/
@@ -205,7 +205,6 @@ void nrn_wrote_conc(int type,
                     int _cntml_padded) {
 #ifndef _OPENACC
     static int flag = 1;
-    extern int nrnmpi_myid;
     if (flag && nrnmpi_myid == 0) {
         /** need to check this as this kernel was failing */
         printf("\n WARNING: nrn_nrn_wrote_conc support on GPU need to validate!\n");

--- a/coreneuron/nrnoc/fadvance_core.c
+++ b/coreneuron/nrnoc/fadvance_core.c
@@ -32,10 +32,9 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/nrnoc/nrnoc_decl.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/coreneuron.h"
-
+extern nrn_flush_reports(double t); // TODO remove when this file goes as cpp 
 static void* nrn_fixed_step_thread(NrnThread*);
 static void* nrn_fixed_step_group_thread(NrnThread*);
-extern void nrn_flush_reports(double);
 
 void dt2thread(double adt) { /* copied from nrnoc/fadvance.c */
     if (adt != nrn_threads[0]._dt) {
@@ -203,7 +202,6 @@ void nrn_ba(NrnThread* nt, int bat) {
 static void* nrn_fixed_step_thread(NrnThread* nth) {
     /* check thresholds and deliver all (including binqueue)
        events up to t+dt/2 */
-    extern int secondorder;
     deliver_net_events(nth);
     nth->_t += .5 * nth->_dt;
 

--- a/coreneuron/nrnoc/multicore.c
+++ b/coreneuron/nrnoc/multicore.c
@@ -31,7 +31,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/nrnoc/nrnpthread.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrnmpi/nrnmpi.h"
-
+#include "coreneuron/nrnoc/nrnoc_decl.h"
 /*
 Now that threads have taken over the actual_v, v_node, etc, it might
 be a good time to regularize the method of freeing, allocating, and
@@ -71,13 +71,6 @@ the handling of v_structure_change as long as possible.
 int nrn_nthread = 0;
 NrnThread* nrn_threads = NULL;
 void (*nrn_mk_transfer_thread_data_)();
-
-extern int v_structure_change;
-extern int diam_changed;
-
-extern void nrn_threads_free();
-extern void nrn_old_thread_save();
-extern double nrn_timeus();
 
 static int nrn_thread_parallel_;
 static int table_check_cnt_;

--- a/coreneuron/nrnoc/nrnoc_aux.c
+++ b/coreneuron/nrnoc/nrnoc_aux.c
@@ -30,12 +30,9 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrnoc/multicore.h"
-
-extern void nrnmpi_finalize(void);
+#include "coreneuron/nrnmpi/nrnmpidec.h"
 
 int stoprun;
-int nrn_nthread;
-NrnThread* nrn_threads;
 int v_structure_change;
 int diam_changed;
 #define MAXERRCOUNT 5
@@ -156,7 +153,6 @@ double hoc_Exp(double x) {
  * abort in case of missmatch
  */
 void check_bbcore_write_version(const char* version) {
-    extern int nrnmpi_myid;
 
     if (strcmp(version, bbcore_write_version) != 0) {
         if (nrnmpi_myid == 0)

--- a/coreneuron/nrnoc/register_mech.c
+++ b/coreneuron/nrnoc/register_mech.c
@@ -127,7 +127,6 @@ void add_nrn_fornetcons(int type, int indx) {
 }
 
 /* array is parallel to memb_func. All are 0 except 1 for ARTIFICIAL_CELL */
-short* nrn_is_artificial_;
 short* nrn_artcell_qindex_;
 
 void add_nrn_artcell(int type, int qi) {

--- a/coreneuron/utils/reports/nrnreport.cpp
+++ b/coreneuron/utils/reports/nrnreport.cpp
@@ -26,6 +26,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include "coreneuron/nrniv/netcon.h"
 #include "coreneuron/nrniv/nrn_assert.h"
 #include "coreneuron/nrniv/netcvode.h"
 #include "coreneuron/nrnoc/multicore.h"

--- a/coreneuron/utils/reports/nrnreport.h
+++ b/coreneuron/utils/reports/nrnreport.h
@@ -36,13 +36,18 @@
 #ifndef _H_NRN_REPORT_
 #define _H_NRN_REPORT_
 
-#include "coreneuron/nrniv/netcon.h"
-#include "coreneuron/nrniv/nrn_assert.h"
 #include <string>
 #include <vector>
 #include <set>
 #define MAX_REPORT_NAME_LEN 256
 #define MAX_REPORT_PATH_LEN 512
+
+#if defined(__cplusplus)
+#define EXTERN_C extern "C"
+#else
+#define EXTERN_C
+#endif
+
 
 // name of the variable in mod file that is used to indicate which synapse
 // is enabled or disable for reporting
@@ -77,6 +82,6 @@ std::vector<ReportConfiguration> create_report_configurations(const char* filena
                                                               const char* output_dir);
 void setup_report_engine(double dt_report, double mindelay);
 void finalize_report();
-extern "C" void nrn_flush_reports(double t);
+EXTERN_C void nrn_flush_reports(double t);
 
 #endif  //_H_NRN_REPORT_


### PR DESCRIPTION
in perspective of making coreneuron as a library, we need to be careful of potential symbol conflicts with Neuron.
This first step clean up potentially conflictual declarations.