### PR TITLE
enforce c++ rules before migration

### DIFF
--- a/coreneuron/nrnoc/register_mech.c
+++ b/coreneuron/nrnoc/register_mech.c
@@ -214,11 +214,11 @@ int register_mech(const char** m,
 #if VECTORIZE
     memb_func[type].vectorized = vectorized ? 1 : 0;
     memb_func[type].thread_size_ = vectorized ? (vectorized - 1) : 0;
-    memb_func[type].thread_mem_init_ = (void*)0;
-    memb_func[type].thread_cleanup_ = (void*)0;
-    memb_func[type].thread_table_check_ = (void*)0;
+    memb_func[type].thread_mem_init_ = NULL;
+    memb_func[type].thread_cleanup_ = NULL;
+    memb_func[type].thread_table_check_ = NULL;
     memb_func[type].is_point = 0;
-    memb_func[type].setdata_ = (void*)0;
+    memb_func[type].setdata_ = NULL;
     memb_func[type].dparam_semantics = (int*)0;
     memb_list[type].nodecount = 0;
     memb_list[type]._thread = (ThreadDatum*)0;


### PR DESCRIPTION
* We enforce explicit casts: C is more tolerant than C++ on casts.
* We change variable names from C++ keywords into none conflicting names.
* explicit return type and arguments in declaration mandatory in C++