### PR TITLE
clang-format after moving to c++

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -63,7 +63,7 @@ KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: All
+NamespaceIndentation: None
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,8 +163,8 @@ add_definitions(-DCORENEURON_BUILD)
 option (ENABLE_SELECTIVE_GPU_PROFILING "Enable GPU profiling only for Solver" ON)
 option (ENABLE_OPENACC "Enable use of OpenACC" OFF)
 
-set(CLANG_FORMAT_MIN_VERSION "5.0")
-set(CLANG_FORMAT_MAX_VERSION "5.9")
+set(CLANG_FORMAT_MIN_VERSION "4.0")
+set(CLANG_FORMAT_MAX_VERSION "4.9")
 find_package(ClangFormat)
 
 if(CLANG_FORMAT_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,8 +163,8 @@ add_definitions(-DCORENEURON_BUILD)
 option (ENABLE_SELECTIVE_GPU_PROFILING "Enable GPU profiling only for Solver" ON)
 option (ENABLE_OPENACC "Enable use of OpenACC" OFF)
 
-set(CLANG_FORMAT_MIN_VERSION "4.0")
-set(CLANG_FORMAT_MAX_VERSION "4.9")
+set(CLANG_FORMAT_MIN_VERSION "5.0")
+set(CLANG_FORMAT_MAX_VERSION "5.9")
 find_package(ClangFormat)
 
 if(CLANG_FORMAT_FOUND)
@@ -185,7 +185,17 @@ if(CLANG_FORMAT_FOUND)
 
     # exclude ezoption header file
     list(REMOVE_ITEM SRC_FILES_FOR_CLANG_FORMAT
-        "${PROJECT_SOURCE_DIR}/coreneuron/utils/ezoption/ezOptionParser.hpp")
+        ${PROJECT_SOURCE_DIR}/coreneuron/utils/ezoption/ezOptionParser.hpp
+        ${PROJECT_SOURCE_DIR}/coreneuron/utils/endianness.h
+        ${PROJECT_SOURCE_DIR}/coreneuron/utils/swap_endian.h)
+
+    # exclude random123 files
+    file (GLOB_RECURSE RANDOM123_FILES
+        ${PROJECT_SOURCE_DIR}/coreneuron/utils/randoms/Random123/*.cpp
+        ${PROJECT_SOURCE_DIR}/coreneuron/utils/randoms/Random123/*.h)
+    foreach (R123_PATH ${RANDOM123_FILES})
+        list (REMOVE_ITEM SRC_FILES_FOR_CLANG_FORMAT ${R123_PATH})
+    endforeach(R123_PATH)
 
     add_custom_target(formatsource COMMAND ${CMAKE_COMMAND}
         -DSOURCE_FILES:STRING="${SRC_FILES_FOR_CLANG_FORMAT}"

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ If you have installed `clang-format`, you can reformat/reindent generated .c fil
 make formatbuild
 ```
 
-The `.clang-format` file in the source repository is compatible with version 3.9 and 4.0.
+The `.clang-format` file in the source repository is compatible with version 5.0.
 
 ## License
 * See LICENSE.txt

--- a/coreneuron/coreneuron.h
+++ b/coreneuron/coreneuron.h
@@ -67,6 +67,6 @@ extern void nrn_cur_ion(NrnThread* _nt, Memb_list* ml, int type);
 extern void nrn_alloc_ion(double* data, Datum* pdata, int type);
 extern void second_order_cur(NrnThread* _nt, int secondorder);
 
-} //namespace coreneuron
+}  // namespace coreneuron
 
 #endif

--- a/coreneuron/engine.h
+++ b/coreneuron/engine.h
@@ -4,9 +4,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-    extern int solve_core (int argc, char** argv);
+extern int solve_core(int argc, char** argv);
 #ifdef __cplusplus
-    } 
+}
 #endif
 
 #endif

--- a/coreneuron/mech/cfile/cabvars.h
+++ b/coreneuron/mech/cfile/cabvars.h
@@ -26,7 +26,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-
 namespace coreneuron {
 
 extern void capacitance_reg(void), _passive_reg(void),
@@ -43,4 +42,4 @@ static void (*mechanism[])(void) = {/* type will start at 3 */
 #endif
                                     _stim_reg, _hh_reg, _expsyn_reg, _netstim_reg, _exp2syn_reg, 0};
 
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/mech/mod2c_core_thread.h
+++ b/coreneuron/mech/mod2c_core_thread.h
@@ -139,6 +139,6 @@ extern void _modl_set_dt_thread(double, NrnThread*);
 
 void nrn_sparseobj_copyto_device(SparseObj* so);
 
-} // namespace coreneuron
+}  // namespace coreneuron
 
 #endif

--- a/coreneuron/nrnconf.h
+++ b/coreneuron/nrnconf.h
@@ -35,7 +35,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include <errno.h>
 #include <stdint.h>
 
-
 namespace coreneuron {
 
 #define NRNBBCORE 1
@@ -56,7 +55,6 @@ typedef char Symbol;
 #define VEC_V(i) (_nt->_actual_v[(i)])
 #define VEC_AREA(i) (_nt->_actual_area[(i)])
 #define VECTORIZE 1
-
 
 extern double celsius;
 
@@ -93,6 +91,6 @@ typedef struct Point_process {
 
 extern char* pnt_name(Point_process* pnt);
 
-} //namespace coreneuron
+}  // namespace coreneuron
 
 #endif

--- a/coreneuron/nrniv/balance.cpp
+++ b/coreneuron/nrniv/balance.cpp
@@ -103,4 +103,4 @@ size_t warp_balance(size_t ncell, VecTNode& nodevec) {
 
     return nwarp;
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/cellorder.cpp
+++ b/coreneuron/nrniv/cellorder.cpp
@@ -683,5 +683,5 @@ void solve_interleaved(int ith) {
         solve_interleaved1(ith);
     }
 }
-} //namespace coreneuron 
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrniv/cellorder.h
+++ b/coreneuron/nrniv/cellorder.h
@@ -57,5 +57,5 @@ void copy_array(T*& dest, T* src, size_t n) {
 #if INTERLEAVE_DEBUG
 void mk_cell_indices();
 #endif
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrniv/cellorder1.cpp
+++ b/coreneuron/nrniv/cellorder1.cpp
@@ -669,4 +669,4 @@ for (int i = 0; i <= nwarp; ++i){
 }
 #endif
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/cellorder2.cpp
+++ b/coreneuron/nrniv/cellorder2.cpp
@@ -530,4 +530,4 @@ void group_order2(VecTNode& nodevec, size_t groupsize, size_t ncell) {
     std::sort(nodevec.begin() + ncell, nodevec.end(), final_nodevec_cmp);
     set_nodeindex(nodevec);
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/cvodestb.cpp
+++ b/coreneuron/nrniv/cvodestb.cpp
@@ -35,7 +35,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 
-namespace coreneuron{
+namespace coreneuron {
 
 // for fixed step thread
 // check thresholds and deliver all (including binqueue) events
@@ -112,4 +112,4 @@ int at_time(NrnThread* nt, double te) {
     }
     return 0;
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/global_vars.cpp
+++ b/coreneuron/nrniv/global_vars.cpp
@@ -106,4 +106,4 @@ void set_globals(const char* path) {
     delete n2v;
     n2v = NULL;
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/have2want.h
+++ b/coreneuron/nrniv/have2want.h
@@ -260,4 +260,4 @@ static void have_to_want(HAVEWANT_t* have,
     recv_from_have_cnt = want_s_cnt;
     recv_from_have_displ = want_s_displ;
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/ivocvect.cpp
+++ b/coreneuron/nrniv/ivocvect.cpp
@@ -42,7 +42,7 @@ double* vector_vec(IvocVect* v) {
  * Retro-compatibility implementations
  */
 void* vector_new1(int n) {
-    return (void*) (new IvocVect(n));
+    return (void*)(new IvocVect(n));
 }
 
 int vector_capacity(void* v) {
@@ -52,4 +52,4 @@ double* vector_vec(void* v) {
     return ((IvocVect*)v)->data();
 }
 
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/ivocvect.h
+++ b/coreneuron/nrniv/ivocvect.h
@@ -29,7 +29,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef ivoc_vector_h
 #define ivoc_vector_h
 
-
 #include <stdio.h>
 #include "coreneuron/nrniv/nrnmutdec.h"
 namespace coreneuron {
@@ -93,6 +92,6 @@ extern void* vector_new1(int n);
 extern int vector_capacity(void* v);
 extern double* vector_vec(void* v);
 
-} //namespace coreneuron
+}  // namespace coreneuron
 
 #endif

--- a/coreneuron/nrniv/main1.cpp
+++ b/coreneuron/nrniv/main1.cpp
@@ -57,7 +57,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <climits>
 
-
 #if 0
 #include <fenv.h>
 #define NRN_FEEXCEPT (FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW)
@@ -242,7 +241,6 @@ void call_prcellstate_for_prcellgid(int prcellgid, int compute_gpu, int is_init)
     }
 }
 
-
 /* perform forwardskip and call prcellstate for prcellgid */
 void handle_forward_skip(double forwardskip, int prcellgid) {
     double savedt = dt;
@@ -267,11 +265,10 @@ void handle_forward_skip(double forwardskip, int prcellgid) {
 const char* nrn_version(int) {
     return "version id unimplemented";
 }
-} //namespace coreneuron
+}  // namespace coreneuron
 
 using namespace coreneuron;
 extern "C" int solve_core(int argc, char** argv) {
-
 #if NRNMPI
     nrnmpi_init(1, &argc, &argv);
 #endif
@@ -393,4 +390,3 @@ extern "C" int solve_core(int argc, char** argv) {
 
     return 0;
 }
-

--- a/coreneuron/nrniv/memory.h
+++ b/coreneuron/nrniv/memory.h
@@ -34,48 +34,48 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/nrniv/nrn_assert.h"
 
 namespace coreneuron {
-    /** Independent function to compute the needed chunkding,
-        the chunk argument is the number of doubles the chunk is chunkded upon.
-    */
-    template <int chunk>
-    inline int soa_padded_size(int cnt, int layout) {
-        int imod = cnt % chunk;
-        if (layout == 1)
-            return cnt;
-        if (imod) {
-            int idiv = cnt / chunk;
-            return (idiv + 1) * chunk;
-        }
+/** Independent function to compute the needed chunkding,
+    the chunk argument is the number of doubles the chunk is chunkded upon.
+*/
+template <int chunk>
+inline int soa_padded_size(int cnt, int layout) {
+    int imod = cnt % chunk;
+    if (layout == 1)
         return cnt;
+    if (imod) {
+        int idiv = cnt / chunk;
+        return (idiv + 1) * chunk;
     }
+    return cnt;
+}
 
-    /** Check for the pointer alignment.
-     */
-    inline bool is_aligned(void* pointer, size_t alignment) {
-        return (((uintptr_t)(const void*)(pointer)) % (alignment) == 0);
-    }
+/** Check for the pointer alignment.
+ */
+inline bool is_aligned(void* pointer, size_t alignment) {
+    return (((uintptr_t)(const void*)(pointer)) % (alignment) == 0);
+}
 
-    /** Allocate the aligned memory.
-     */
-    inline void* emalloc_align(size_t size, size_t alignment) {
-        void* memptr;
-        nrn_assert(posix_memalign(&memptr, alignment, size) == 0);
-        nrn_assert(is_aligned(memptr, alignment));
-        return memptr;
-    }
+/** Allocate the aligned memory.
+ */
+inline void* emalloc_align(size_t size, size_t alignment) {
+    void* memptr;
+    nrn_assert(posix_memalign(&memptr, alignment, size) == 0);
+    nrn_assert(is_aligned(memptr, alignment));
+    return memptr;
+}
 
-    /** Allocate the aligned memory and set it to 1.
-     */
-    inline void* ecalloc_align(size_t n, size_t alignment, size_t size) {
-        void* p;
-        if (n == 0) {
-            return (void*)0;
-        }
-        nrn_assert(posix_memalign(&p, alignment, n * size) == 0);
-        nrn_assert(is_aligned(p, alignment));
-        memset(p, 1, n * size);  // Avoid native division by zero (cyme...)
-        return p;
+/** Allocate the aligned memory and set it to 1.
+ */
+inline void* ecalloc_align(size_t n, size_t alignment, size_t size) {
+    void* p;
+    if (n == 0) {
+        return (void*)0;
     }
+    nrn_assert(posix_memalign(&p, alignment, n * size) == 0);
+    nrn_assert(is_aligned(p, alignment));
+    memset(p, 1, n * size);  // Avoid native division by zero (cyme...)
+    return p;
+}
 }  // namespace coreneuron
 
 #endif

--- a/coreneuron/nrniv/mk_mech.cpp
+++ b/coreneuron/nrniv/mk_mech.cpp
@@ -172,4 +172,4 @@ const char* nrn_get_mechname(int type) {
     }
     return NULL;
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/multisend.cpp
+++ b/coreneuron/nrniv/multisend.cpp
@@ -466,4 +466,4 @@ void nrn_multisend_setup() {
 #endif
 }
 #endif  // NRN_MULTISEND
-} // namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/multisend.h
+++ b/coreneuron/nrniv/multisend.h
@@ -19,5 +19,5 @@ void nrn_multisend_cleanup();
 void nrn_multisend_setup();
 
 void nrn_multisend_setup_targets(int use_phase2, int*& targets_phase1, int*& targets_phase2);
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif  // nrnmultisend_h

--- a/coreneuron/nrniv/multisend_setup.cpp
+++ b/coreneuron/nrniv/multisend_setup.cpp
@@ -702,5 +702,5 @@ static int setup_target_lists(int use_phase2, int** r_return) {
     *r_return = r;
     return sz;
 }
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif  // NRN_MULTISEND

--- a/coreneuron/nrniv/netcon.h
+++ b/coreneuron/nrniv/netcon.h
@@ -183,5 +183,5 @@ class NetParEvent : public DiscreteEvent {
 
     virtual void pr(const char*, double t, NetCvode*);
 };
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrniv/netcvode.cpp
+++ b/coreneuron/nrniv/netcvode.cpp
@@ -810,4 +810,4 @@ tryagain:
         (*net_buf_receive_[i])(nt);
     }
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/netcvode.h
+++ b/coreneuron/nrniv/netcvode.h
@@ -92,5 +92,5 @@ class NetCvode {
     void init_events();
     void point_receive(int, Point_process*, double*, double);
 };
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrniv/netpar.cpp
+++ b/coreneuron/nrniv/netpar.cpp
@@ -914,4 +914,4 @@ int nrnmpi_spike_compress(int nspike, bool gid_compress, int xchng_meth) {
     return 0;
 #endif
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/node_permute.cpp
+++ b/coreneuron/nrniv/node_permute.cpp
@@ -329,4 +329,4 @@ void permute_nodeindices(Memb_list* ml, int* p) {
     invert_permute(ml->_permute, ml->nodecount);
     permute_ptr(ml->nodeindices, ml->nodecount, ml->_permute);
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/node_permute.h
+++ b/coreneuron/nrniv/node_permute.h
@@ -18,5 +18,5 @@ void permute_ml(Memb_list* ml, int type, NrnThread& nt);
 int nrn_index_permute(int, int type, Memb_list* ml);
 
 int* inverse_permute(int* p, int n);
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrniv/nrn_acc_manager.cpp
+++ b/coreneuron/nrniv/nrn_acc_manager.cpp
@@ -991,5 +991,4 @@ void nrn_sparseobj_copyto_device(SparseObj* so) {
     }
 #endif
 }
-} //namespace coreneuron
-
+}  // namespace coreneuron

--- a/coreneuron/nrniv/nrn_acc_manager.h
+++ b/coreneuron/nrniv/nrn_acc_manager.h
@@ -20,5 +20,5 @@ void update_net_receive_buffer(NrnThread* _nt);
 void realloc_net_receive_buffer(NrnThread* nt, Memb_list* ml);
 void update_net_send_buffer_on_host(NrnThread* nt, NetSendBuffer_t* nsb);
 
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif  // _nrn_device_manager_

--- a/coreneuron/nrniv/nrn_checkpoint.cpp
+++ b/coreneuron/nrniv/nrn_checkpoint.cpp
@@ -44,7 +44,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 namespace coreneuron {
 bool nrn_checkpoint_arg_exists;
 int _nrn_skip_initmodel;
-}
+}  // namespace coreneuron
 #define UseFileHandlerWrap 0
 
 #if UseFileHandlerWrap
@@ -91,7 +91,7 @@ class FileHandlerWrap {
         return *this;
     }
 };
-} //namespace coreneuron
+}  // namespace coreneuron
 #else
 
 #define FileHandlerWrap FileHandler
@@ -888,4 +888,4 @@ bool checkpoint_initialize() {
 
     return checkpoint_restored_;
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/nrn_checkpoint.h
+++ b/coreneuron/nrniv/nrn_checkpoint.h
@@ -110,5 +110,5 @@ typedef struct NrnThreadChkpnt {
 } NrnThreadChkpnt;
 
 extern NrnThreadChkpnt* nrnthread_chkpnt;
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrniv/nrn_filehandler.cpp
+++ b/coreneuron/nrniv/nrn_filehandler.cpp
@@ -116,4 +116,4 @@ void FileHandler::read_checkpoint_assert() {
 void FileHandler::close() {
     F.close();
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/nrn_filehandler.h
+++ b/coreneuron/nrniv/nrn_filehandler.h
@@ -279,5 +279,5 @@ class FileHandler {
         F << "chkpnt " << chkpnt++ << "\n";
     }
 };
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif  // ifndef nrn_filehandler_h

--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -1070,9 +1070,9 @@ void read_phase2(FileHandler& F, int imult, NrnThread& nt) {
 
     if (shadow_rhs_cnt) {
         nt._shadow_rhs = (double*)ecalloc_align(nrn_soa_padded_size(shadow_rhs_cnt, 0),
-                                                            NRN_SOA_BYTE_ALIGN, sizeof(double));
+                                                NRN_SOA_BYTE_ALIGN, sizeof(double));
         nt._shadow_d = (double*)ecalloc_align(nrn_soa_padded_size(shadow_rhs_cnt, 0),
-                                                          NRN_SOA_BYTE_ALIGN, sizeof(double));
+                                              NRN_SOA_BYTE_ALIGN, sizeof(double));
         nt.shadow_rhs_cnt = shadow_rhs_cnt;
     }
 
@@ -1177,8 +1177,7 @@ void read_phase2(FileHandler& F, int imult, NrnThread& nt) {
         int szdp = nrn_prop_dparam_size_[type];
 
         if (!is_art) {
-            ml->nodeindices =
-                (int*)ecalloc_align(ml->nodecount, NRN_SOA_BYTE_ALIGN, sizeof(int));
+            ml->nodeindices = (int*)ecalloc_align(ml->nodecount, NRN_SOA_BYTE_ALIGN, sizeof(int));
             F.read_array<int>(ml->nodeindices, ml->nodecount);
         } else {
             ml->nodeindices = NULL;
@@ -1189,7 +1188,7 @@ void read_phase2(FileHandler& F, int imult, NrnThread& nt) {
 
         if (szdp) {
             ml->pdata = (int*)ecalloc_align(nrn_soa_padded_size(n, layout) * szdp,
-                                                        NRN_SOA_BYTE_ALIGN, sizeof(int));
+                                            NRN_SOA_BYTE_ALIGN, sizeof(int));
             mech_layout<int>(F, ml->pdata, n, szdp, layout);
 #if CHKPNTDEBUG  // Not substantive. Only for debugging.
             Memb_list_ckpnt* mlc = ntc.mlmap[type];
@@ -1983,4 +1982,4 @@ size_t model_size(void) {
 
     return nbyte;
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/nrn_setup.h
+++ b/coreneuron/nrniv/nrn_setup.h
@@ -58,93 +58,93 @@ extern void nrn_setup_cleanup();
 
 namespace coreneuron {
 
-    /// Reading phase number.
-    enum phase { one = 1, two, three, gap };
+/// Reading phase number.
+enum phase { one = 1, two, three, gap };
 
-    /// Get the phase number in form of the string.
-    template <phase P>
-    inline std::string getPhaseName();
+/// Get the phase number in form of the string.
+template <phase P>
+inline std::string getPhaseName();
 
-    template <>
-    inline std::string getPhaseName<one>() {
-        return "1";
-    }
+template <>
+inline std::string getPhaseName<one>() {
+    return "1";
+}
 
-    template <>
-    inline std::string getPhaseName<two>() {
-        return "2";
-    }
+template <>
+inline std::string getPhaseName<two>() {
+    return "2";
+}
 
-    template <>
-    inline std::string getPhaseName<three>() {
-        return "3";
-    }
+template <>
+inline std::string getPhaseName<three>() {
+    return "3";
+}
 
-    template <>
-    inline std::string getPhaseName<gap>() {
-        return "gap";
-    }
+template <>
+inline std::string getPhaseName<gap>() {
+    return "gap";
+}
 
-    /// Reading phase selector.
-    template <phase P>
-    inline void read_phase_aux(FileHandler& F, int imult, NrnThread& nt);
+/// Reading phase selector.
+template <phase P>
+inline void read_phase_aux(FileHandler& F, int imult, NrnThread& nt);
 
-    template <>
-    inline void read_phase_aux<one>(FileHandler& F, int imult, NrnThread& nt) {
-        read_phase1(F, imult, nt);
-    }
+template <>
+inline void read_phase_aux<one>(FileHandler& F, int imult, NrnThread& nt) {
+    read_phase1(F, imult, nt);
+}
 
-    template <>
-    inline void read_phase_aux<two>(FileHandler& F, int imult, NrnThread& nt) {
-        read_phase2(F, imult, nt);
-    }
+template <>
+inline void read_phase_aux<two>(FileHandler& F, int imult, NrnThread& nt) {
+    read_phase2(F, imult, nt);
+}
 
-    template <>
-    inline void read_phase_aux<three>(FileHandler& F, int imult, NrnThread& nt) {
-        read_phase3(F, imult, nt);
-    }
+template <>
+inline void read_phase_aux<three>(FileHandler& F, int imult, NrnThread& nt) {
+    read_phase3(F, imult, nt);
+}
 
-    template <>
-    inline void read_phase_aux<gap>(FileHandler& F, int imult, NrnThread& nt) {
-        read_phasegap(F, imult, nt);
-    }
+template <>
+inline void read_phase_aux<gap>(FileHandler& F, int imult, NrnThread& nt) {
+    read_phasegap(F, imult, nt);
+}
 
-    /// Reading phase wrapper for each neuron group.
-    template <phase P>
-    inline void* phase_wrapper_w(NrnThread* nt) {
-        int i = nt->id;
-        char fnamebuf[1000];
-        char check_fnamebuf[1000] = "";
-        if (i < ngroup_w) {
-            const char* data_dir = path_w;
-            // directory to read could be different for phase 2 if we are restoring
-            // all other phases still read from dataset directory because the data
-            // is constant
-            if (P == 2) {
-                data_dir = restore_path_w;
-            }
-
-            sd_ptr fname = sdprintf(fnamebuf, sizeof(fnamebuf),
-                                    std::string("%s/%d_" + getPhaseName<P>() + ".dat").c_str(),
-                                    data_dir, gidgroups_w[i]);
-
-            // if no file failed to open or not opened at all
-            file_reader_w[i].open(fname, byte_swap_w);
-
-            read_phase_aux<P>(file_reader_w[i], imult_w[i], *nt);
-            file_reader_w[i].close();
-            if (P == 2) {
-                setup_ThreadData(*nt);
-            }
+/// Reading phase wrapper for each neuron group.
+template <phase P>
+inline void* phase_wrapper_w(NrnThread* nt) {
+    int i = nt->id;
+    char fnamebuf[1000];
+    char check_fnamebuf[1000] = "";
+    if (i < ngroup_w) {
+        const char* data_dir = path_w;
+        // directory to read could be different for phase 2 if we are restoring
+        // all other phases still read from dataset directory because the data
+        // is constant
+        if (P == 2) {
+            data_dir = restore_path_w;
         }
-        return NULL;
-    }
 
-    /// Specific phase reading executed by threads.
-    template <phase P>
-    inline static void phase_wrapper() {
-        nrn_multithread_job(phase_wrapper_w<P>);
+        sd_ptr fname = sdprintf(fnamebuf, sizeof(fnamebuf),
+                                std::string("%s/%d_" + getPhaseName<P>() + ".dat").c_str(),
+                                data_dir, gidgroups_w[i]);
+
+        // if no file failed to open or not opened at all
+        file_reader_w[i].open(fname, byte_swap_w);
+
+        read_phase_aux<P>(file_reader_w[i], imult_w[i], *nt);
+        file_reader_w[i].close();
+        if (P == 2) {
+            setup_ThreadData(*nt);
+        }
     }
+    return NULL;
+}
+
+/// Specific phase reading executed by threads.
+template <phase P>
+inline static void phase_wrapper() {
+    nrn_multithread_job(phase_wrapper_w<P>);
+}
 }  // namespace coreneuron
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrniv/nrn_stats.cpp
+++ b/coreneuron/nrniv/nrn_stats.cpp
@@ -212,4 +212,4 @@ void report_cell_stats(void) {
     if (nrnmpi_myid == 0)
         printf("\n\n");
 }
-} //namespace
+}  // namespace coreneuron

--- a/coreneuron/nrniv/nrn_stats.h
+++ b/coreneuron/nrniv/nrn_stats.h
@@ -44,5 +44,5 @@ namespace coreneuron {
  */
 void report_cell_stats(void);
 
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif /* ifndef _H_NRN_STATS_ */

--- a/coreneuron/nrniv/nrniv_decl.h
+++ b/coreneuron/nrniv/nrniv_decl.h
@@ -75,7 +75,6 @@ extern void handle_forward_skip(double forwardskip, int prcellgid);
 extern int nrn_set_timeout(int);
 extern void nrn_fake_fire(int gid, double spiketime, int fake_out);
 
-
 extern void netpar_tid_gid2ps(int tid, int gid, PreSyn** ps, InputPreSyn** psi);
 extern double set_mindelay(double maxdelay);
 
@@ -83,5 +82,5 @@ extern int nrn_soa_padded_size(int cnt, int layout);
 
 extern int use_interleave_permute;
 extern int cellorder_nwarp;
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrniv/nrnoptarg.cpp
+++ b/coreneuron/nrniv/nrnoptarg.cpp
@@ -369,4 +369,4 @@ static void graceful_exit(int err) {
 #endif
     exit(nrnmpi_myid == 0 ? err : 0);
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/nrnoptarg.h
+++ b/coreneuron/nrniv/nrnoptarg.h
@@ -57,5 +57,5 @@ int nrnopt_get_int(const char* name);
 double nrnopt_get_dbl(const char* name);
 std::string nrnopt_get_str(const char* name);
 void nrnopt_modify_dbl(const char* name, double value);
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrniv/output_spikes.cpp
+++ b/coreneuron/nrniv/output_spikes.cpp
@@ -169,4 +169,4 @@ void validation(std::vector<std::pair<double, int> >& res) {
         if (spikevec_gid[i] > -1)
             res.push_back(std::make_pair(spikevec_time[i], spikevec_gid[i]));
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/output_spikes.h
+++ b/coreneuron/nrniv/output_spikes.h
@@ -42,5 +42,5 @@ void validation(std::vector<std::pair<double, int> >& res);
 
 void spikevec_lock();
 void spikevec_unlock();
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrniv/partrans.cpp
+++ b/coreneuron/nrniv/partrans.cpp
@@ -178,4 +178,4 @@ void nrn_partrans::gap_update_indices() {
         }
     }
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/partrans.h
+++ b/coreneuron/nrniv/partrans.h
@@ -10,52 +10,52 @@ namespace nrn_partrans {
 #endif
 
 #if NRNLONGSGID
-    typedef int64_t sgid_t;
+typedef int64_t sgid_t;
 #else
-    typedef int sgid_t;
+typedef int sgid_t;
 #endif
 
-    struct HalfGap_Info {
-        int layout;
-        int type;
-        int ix_vpre; /* AoS index for vpre from beginning of a HalfGap instance */
-        int sz;      /* size of a HalfGap instance */
-    };
-    extern HalfGap_Info* halfgap_info;
+struct HalfGap_Info {
+    int layout;
+    int type;
+    int ix_vpre; /* AoS index for vpre from beginning of a HalfGap instance */
+    int sz;      /* size of a HalfGap instance */
+};
+extern HalfGap_Info* halfgap_info;
 
-    class TransferThreadData {
-      public:
-        TransferThreadData();
-        ~TransferThreadData();
-        Memb_list* halfgap_ml;
-        int nsrc;             // number of places in outsrc_buf_ voltages get copied to.
-        int ntar;             // insrc_indices size (halfgap_ml->nodecount);
-        int* insrc_indices;   // halfgap_ml->nodecount indices into insrc_buf_
-        int* v_indices;       // indices into NrnThread._actual_v (may have duplications).
-        int* outbuf_indices;  // indices into outsrc_buf_
-        double* v_gather;     // _actual_v[v_indices]
-    };
-    extern TransferThreadData* transfer_thread_data_; /* array for threads */
+class TransferThreadData {
+  public:
+    TransferThreadData();
+    ~TransferThreadData();
+    Memb_list* halfgap_ml;
+    int nsrc;             // number of places in outsrc_buf_ voltages get copied to.
+    int ntar;             // insrc_indices size (halfgap_ml->nodecount);
+    int* insrc_indices;   // halfgap_ml->nodecount indices into insrc_buf_
+    int* v_indices;       // indices into NrnThread._actual_v (may have duplications).
+    int* outbuf_indices;  // indices into outsrc_buf_
+    double* v_gather;     // _actual_v[v_indices]
+};
+extern TransferThreadData* transfer_thread_data_; /* array for threads */
 
-    struct SetupInfo {
-        int nsrc;  // number of sources in this thread
-        int ntar;  // equal to memb_list nodecount
-        int type;
-        int ix_vpre;
-        sgid_t* sid_src;
-        int* v_indices;      // increasing order
-        sgid_t* sid_target;  // aleady in memb_list order
-    };
-    extern SetupInfo* setup_info_; /* array for threads exists only during setup*/
+struct SetupInfo {
+    int nsrc;  // number of sources in this thread
+    int ntar;  // equal to memb_list nodecount
+    int type;
+    int ix_vpre;
+    sgid_t* sid_src;
+    int* v_indices;      // increasing order
+    sgid_t* sid_target;  // aleady in memb_list order
+};
+extern SetupInfo* setup_info_; /* array for threads exists only during setup*/
 
-    extern void gap_mpi_setup(int ngroup);
-    extern void gap_thread_setup(NrnThread& nt);
-    extern void gap_indices_permute(NrnThread& nt);
-    extern void gap_update_indices();
+extern void gap_mpi_setup(int ngroup);
+extern void gap_thread_setup(NrnThread& nt);
+extern void gap_indices_permute(NrnThread& nt);
+extern void gap_update_indices();
 
-    extern double* insrc_buf_;   // Receive buffer for gap voltages
-    extern double* outsrc_buf_;  // Send buffer for gap voltages
-    extern int *insrccnt_, *insrcdspl_, *outsrccnt_, *outsrcdspl_;
+extern double* insrc_buf_;   // Receive buffer for gap voltages
+extern double* outsrc_buf_;  // Send buffer for gap voltages
+extern int *insrccnt_, *insrcdspl_, *outsrccnt_, *outsrcdspl_;
 }
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif /*partrans_h*/

--- a/coreneuron/nrniv/partrans_setup.cpp
+++ b/coreneuron/nrniv/partrans_setup.cpp
@@ -16,7 +16,7 @@ class SidData {
     std::vector<int> indices_;
 };
 
-} //namespace coreneuron
+}  // namespace coreneuron
 #if NRNLOGSGID
 #define sgid_alltoallv nrnmpi_long_alltoallv
 #else
@@ -290,4 +290,4 @@ void nrn_partrans::gap_indices_permute(NrnThread& nt) {
         delete[] oldisi;
     }
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/patternstim.cpp
+++ b/coreneuron/nrniv/patternstim.cpp
@@ -250,4 +250,4 @@ Point_process* nrn_artcell_instantiate(const char* mechname) {
 
     return pnt;
 }
-}
+}  // namespace coreneuron

--- a/coreneuron/nrniv/prcellstate.cpp
+++ b/coreneuron/nrniv/prcellstate.cpp
@@ -295,4 +295,4 @@ int prcellstate(int gid, const char* suffix) {
     }
     return 0;
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/profiler_interface.cpp
+++ b/coreneuron/nrniv/profiler_interface.cpp
@@ -18,10 +18,9 @@ namespace coreneuron {
 
 static int cray_acc_debug_orig = 0;
 static int cray_acc_debug_zero = 0;
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif
 namespace coreneuron {
-
 
 void start_profile() {
     if (nrnmpi_myid == 0)
@@ -65,4 +64,4 @@ void stop_profile() {
     TAU_DISABLE_INSTRUMENTATION();
 #endif
 }
-}//namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/profiler_interface.h
+++ b/coreneuron/nrniv/profiler_interface.h
@@ -3,6 +3,6 @@
 namespace coreneuron {
 void start_profile();
 void stop_profile();
-}
+}  // namespace coreneuron
 
 #endif

--- a/coreneuron/nrniv/tnode.h
+++ b/coreneuron/nrniv/tnode.h
@@ -36,5 +36,5 @@ size_t dist2child(TNode* nd);
 size_t warp_balance(size_t ncell, VecTNode& nodevec);
 
 #define warpsize 32
-}
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrniv/tqueue.cpp
+++ b/coreneuron/nrniv/tqueue.cpp
@@ -598,4 +598,4 @@ void spdelete(SPBLK* n, SPTREE* q) {
     }
 
 } /* spdelete */
-}//namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrniv/tqueue.h
+++ b/coreneuron/nrniv/tqueue.h
@@ -72,7 +72,6 @@ struct SPTREE {
 
     /* Statistics, not strictly necessary, but handy for tuning  */
     int enqcmps; /* compares in spenq */
-
 };
 
 #define spinit sptq_spinit
@@ -214,6 +213,6 @@ class TQueue {
     unsigned long ncompare, nleastsrch, nfind, nfindsrch, nmove, nfastmove;
 #endif
 };
-} //namespace coreneuron
+}  // namespace coreneuron
 #include "coreneuron/nrniv/tqueue.ipp"
 #endif

--- a/coreneuron/nrniv/tqueue.ipp
+++ b/coreneuron/nrniv/tqueue.ipp
@@ -358,5 +358,5 @@ inline TQItem* TQueue<pq_que>::atomic_dq(double tt) {
     MUTUNLOCK
     return q;
 }
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrniv/vrecitem.h
+++ b/coreneuron/nrniv/vrecitem.h
@@ -108,5 +108,5 @@ class VecPlayContinuous : public PlayRecord {
 
     PlayRecordEvent* e_;
 };
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrniv/vrecord.cpp
+++ b/coreneuron/nrniv/vrecord.cpp
@@ -116,7 +116,9 @@ void VecPlayContinuous::deliver(double tt, NetCvode* ns) {
     NrnThread* nt = nrn_threads + ith_;
     // printf("deliver %g\n", tt);
     last_index_ = ubound_index_;
+// clang-format off
     #pragma acc update device(last_index_) if (nt->compute_gpu)
+    // clang-format on
     if (discon_indices_) {
         if (discon_index_ < discon_indices_->size()) {
             ubound_index_ = (int)(*discon_indices_)[discon_index_++];
@@ -131,16 +133,20 @@ void VecPlayContinuous::deliver(double tt, NetCvode* ns) {
             e_->send((*t_)[ubound_index_], ns, nt);
         }
     }
+// clang-format off
     #pragma acc update device(ubound_index_) if (nt->compute_gpu)
+    // clang-format on
     continuous(tt);
 }
 
 void VecPlayContinuous::continuous(double tt) {
     NrnThread* nt = nrn_threads + ith_;
+// clang-format off
     #pragma acc kernels present(this) if(nt->compute_gpu)
     {
         *pd_ = interpolate(tt);
     }
+    // clang-format on
 }
 
 double VecPlayContinuous::interpolate(double tt) {
@@ -184,4 +190,4 @@ void VecPlayContinuous::pr() {
     printf("VecPlayContinuous ");
     // printf("%s.x[%d]\n", hoc_object_name(y_->obj_), last_index_);
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrnmpi/mpispike.cpp
+++ b/coreneuron/nrnmpi/mpispike.cpp
@@ -556,5 +556,5 @@ int nrnmpi_multisend_conserve(int nsend, int nrecv) {
 }
 
 #endif /*NRN_MULTISEND*/
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif /*NRNMPI*/

--- a/coreneuron/nrnmpi/mpispike.h
+++ b/coreneuron/nrnmpi/mpispike.h
@@ -38,13 +38,12 @@ THE POSSIBILITY OF SUCH DAMAGE.
 namespace coreneuron {
 
 #if nrn_spikebuf_size > 0
-struct NRNMPI_Spikebuf{
+struct NRNMPI_Spikebuf {
     int nspike;
     int gid[nrn_spikebuf_size];
     double spiketime[nrn_spikebuf_size];
 };
 #endif
-
 
 #define icapacity_ nrnmpi_i_capacity_
 #define spikeout_ nrnmpi_spikeout_
@@ -81,7 +80,7 @@ extern NRNMPI_Spikebuf* spbufout_;
 extern NRNMPI_Spikebuf* spbufin_;
 #endif
 
-} //namespace coreneuron
+}  // namespace coreneuron
 
 #endif  // NRNMPI
 #endif

--- a/coreneuron/nrnmpi/nrnmpi.cpp
+++ b/coreneuron/nrnmpi/nrnmpi.cpp
@@ -214,4 +214,4 @@ int nrnmpi_initialized() {
     return flag;
 }
 
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrnmpi/nrnmpi.h
+++ b/coreneuron/nrnmpi/nrnmpi.h
@@ -46,8 +46,7 @@ extern int nrnmpi_myid_bbs;       /* rank in nrn_bbs_comm of rank 0 of a subworl
 void nrn_abort(int errcode);
 void nrn_fatal_error(const char* msg);
 double nrn_wtime();
-} //namespace coreneuron
-
+}  // namespace coreneuron
 
 #if NRNMPI
 
@@ -59,7 +58,7 @@ typedef struct {
 
 extern int nrnmpi_use; /* NEURON does MPI init and terminate?*/
 
-} //namespace coreneuron
+}  // namespace coreneuron
 #include "coreneuron/nrnmpi/nrnmpidec.h"
 
 #endif /*NRNMPI*/

--- a/coreneuron/nrnmpi/nrnmpi_def_cinc.h
+++ b/coreneuron/nrnmpi/nrnmpi_def_cinc.h
@@ -52,4 +52,4 @@ int nrnmpi_ovfl_;
 unsigned char* nrnmpi_spikeout_fixed_;
 unsigned char* nrnmpi_spikein_fixed_;
 unsigned char* nrnmpi_spikein_fixed_ovfl_;
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrnmpi/nrnmpi_impl.h
+++ b/coreneuron/nrnmpi/nrnmpi_impl.h
@@ -35,7 +35,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 namespace coreneuron {
 extern MPI_Comm nrnmpi_world_comm;
 extern MPI_Comm nrnmpi_comm;
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif  // NRNMPI
 
 #endif

--- a/coreneuron/nrnmpi/nrnmpidec.h
+++ b/coreneuron/nrnmpi/nrnmpidec.h
@@ -129,6 +129,6 @@ extern int nrnmpi_multisend_single_advance(NRNMPI_Spike* spk);
 extern int nrnmpi_multisend_conserve(int nsend, int nrecv);
 #endif
 
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif
 #endif

--- a/coreneuron/nrnoc/capac.cpp
+++ b/coreneuron/nrnoc/capac.cpp
@@ -179,4 +179,4 @@ void nrn_alloc_capacitance(double* data, Datum* pdata, int type) {
     (void)type;       /* unused */
     data[0] = DEF_cm; /*default capacitance/cm^2*/
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrnoc/eion.cpp
+++ b/coreneuron/nrnoc/eion.cpp
@@ -394,5 +394,5 @@ void second_order_cur(NrnThread* _nt, int secondorder) {
             }
     }
 }
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrnoc/fadvance_core.cpp
+++ b/coreneuron/nrnoc/fadvance_core.cpp
@@ -81,7 +81,7 @@ integration interval before joining
 static int step_group_n;
 static int step_group_begin;
 static int step_group_end;
-static progressbar *progress;
+static progressbar* progress;
 
 void initialize_progress_bar(int nstep) {
     if (nrnmpi_myid == 0) {
@@ -268,4 +268,4 @@ void* nrn_fixed_step_lastpart(NrnThread* nth) {
     nrn_deliver_events(nth); /* up to but not past texit */
     return (void*)0;
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrnoc/finitialize.cpp
+++ b/coreneuron/nrnoc/finitialize.cpp
@@ -106,4 +106,4 @@ void nrn_finitialize(int setv, double v) {
     nrn_spike_exchange(nrn_threads);
 #endif
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrnoc/mech_mapping.cpp
+++ b/coreneuron/nrnoc/mech_mapping.cpp
@@ -63,4 +63,4 @@ void register_all_variables_offsets(int mech_id, SerializedNames variable_names)
     idx++;
 }
 
-}//namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrnoc/mech_mapping.hpp
+++ b/coreneuron/nrnoc/mech_mapping.hpp
@@ -25,12 +25,12 @@ typedef const char** SerializedNames;
 
 // return pointer to value of a variable's mechanism, or nullptr if not found
 extern double* get_var_location_from_var_name(int mech_id,
-                                                const char* variable_name,
-                                                Memb_list* ml,
-                                                int local_index);
+                                              const char* variable_name,
+                                              Memb_list* ml,
+                                              int local_index);
 
 // initialize mapping of variable names of mechanism, to their places in memory
 extern void register_all_variables_offsets(int mech_id, SerializedNames variable_names);
 
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrnoc/membfunc.h
+++ b/coreneuron/nrnoc/membfunc.h
@@ -147,16 +147,16 @@ double nrn_nernst(double ci, double co, double z, double celsius);
 extern void hoc_register_prop_size(int, int, int);
 extern void hoc_register_dparam_semantics(int type, int, const char* name);
 
-struct DoubScal{
+struct DoubScal {
     const char* name;
     double* pdoub;
 };
-struct DoubVec{
+struct DoubVec {
     const char* name;
     double* pdoub;
     int index1;
 };
-struct VoidFunc{
+struct VoidFunc {
     const char* name;
     void (*func)(void);
 };
@@ -216,6 +216,6 @@ extern void net_sem_from_gpu(int, int, int, int, int, double, double);
 extern void hoc_malchk(void); /* just a stub */
 extern void* hoc_Emalloc(size_t);
 
-} // namespace coreneuron
+}  // namespace coreneuron
 
 #endif /* nrn_memb_func_h */

--- a/coreneuron/nrnoc/multicore.cpp
+++ b/coreneuron/nrnoc/multicore.cpp
@@ -482,4 +482,4 @@ void nrn_multithread_job(void* (*job)(NrnThread*)) {
     }
 #endif
 }
-} // namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrnoc/multicore.h
+++ b/coreneuron/nrnoc/multicore.h
@@ -62,7 +62,9 @@ struct NrnThreadBAList {
 /* for OpenACC, in order to avoid an error while update PreSyn, with virtual base
  * class, we are adding helper with flag variable which could be updated on GPU
  */
-struct PreSynHelper { int flag_; };
+struct PreSynHelper {
+    int flag_;
+};
 
 struct NrnThread {
     double _t;
@@ -105,8 +107,8 @@ struct NrnThread {
                              compartment */
     int* _v_parent_index;
     int* _permute;
-    char* _sp13mat;                     /* handle to general sparse matrix */
-    Memb_list* _ecell_memb_list;        /* normally nil */
+    char* _sp13mat;              /* handle to general sparse matrix */
+    Memb_list* _ecell_memb_list; /* normally nil */
 
     double _ctime; /* computation time in seconds (using nrnmpi_wtime) */
 
@@ -121,9 +123,7 @@ struct NrnThread {
 
     int* _watch_types; /* NULL or 0 terminated array of integers */
     void* mapping;     /* section to segment mapping information */
-
 };
-
 
 extern void nrn_threads_create(int n, int parallel);
 extern int nrn_nthread;
@@ -135,6 +135,6 @@ extern void nrn_threads_free(void);
 
 extern int _nrn_skip_initmodel;
 
-} //namespace coreneuron
+}  // namespace coreneuron
 
 #endif

--- a/coreneuron/nrnoc/nrnoc_aux.cpp
+++ b/coreneuron/nrnoc/nrnoc_aux.cpp
@@ -32,7 +32,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrnmpi/nrnmpidec.h"
 
-
 namespace coreneuron {
 int stoprun;
 int v_structure_change;
@@ -155,7 +154,6 @@ double hoc_Exp(double x) {
  * abort in case of missmatch
  */
 void check_bbcore_write_version(const char* version) {
-
     if (strcmp(version, bbcore_write_version) != 0) {
         if (nrnmpi_myid == 0)
             fprintf(stderr,
@@ -164,4 +162,4 @@ void check_bbcore_write_version(const char* version) {
         abort();
     }
 }
-} // namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrnoc/nrnoc_decl.h
+++ b/coreneuron/nrnoc/nrnoc_decl.h
@@ -75,5 +75,5 @@ extern void nrn_fatal_error(const char* msg);
 extern void nrn_abort(int errcode);
 extern double nrn_wtime(void);
 
-}
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrnoc/nrnoc_ml.h
+++ b/coreneuron/nrnoc/nrnoc_ml.h
@@ -90,5 +90,5 @@ struct Memb_list {
     int nodecount; /* actual node count */
     int _nodecount_padded;
 };
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/nrnoc/nrntimeout.cpp
+++ b/coreneuron/nrnoc/nrntimeout.cpp
@@ -53,7 +53,7 @@ static struct itimerval value;
 static struct sigaction act, oact;
 
 static void timed_out(int sig) {
-    (void)sig; /* unused */
+    (void)sig;                     /* unused */
 #if 0
 printf("timed_out told=%g t=%g\n", told, t);
 #endif
@@ -96,6 +96,6 @@ printf("nrn_timeout %d\n", seconds);
 }
 
 #endif /* DISABLE_TIMEOUT */
-} // namespace coreneuron
+}  // namespace coreneuron
 
 #endif /*NRNMPI*/

--- a/coreneuron/nrnoc/nrntimeout.cpp
+++ b/coreneuron/nrnoc/nrntimeout.cpp
@@ -53,7 +53,7 @@ static struct itimerval value;
 static struct sigaction act, oact;
 
 static void timed_out(int sig) {
-    (void)sig;                     /* unused */
+    (void)sig; /* unused */
 #if 0
 printf("timed_out told=%g t=%g\n", told, t);
 #endif

--- a/coreneuron/nrnoc/register_mech.cpp
+++ b/coreneuron/nrnoc/register_mech.cpp
@@ -500,7 +500,8 @@ void _nrn_thread_reg1(int i, void (*f)(ThreadDatum*)) {
     memb_func[i].thread_mem_init_ = f;
 }
 
-void _nrn_thread_table_reg(int i, void (*f)(int, int, double*, Datum*, ThreadDatum*, NrnThread*, int)) {
+void _nrn_thread_table_reg(int i,
+                           void (*f)(int, int, double*, Datum*, ThreadDatum*, NrnThread*, int)) {
     if (i == -1)
         return;
 
@@ -513,4 +514,4 @@ void _nrn_setdata_reg(int i, void (*call)(double*, Datum*)) {
 
     memb_func[i].setdata_ = call;
 }
-} // namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrnoc/register_mech.hpp
+++ b/coreneuron/nrnoc/register_mech.hpp
@@ -2,11 +2,12 @@
 #define register_mech_h
 
 namespace coreneuron {
-    extern void hoc_reg_bbcore_read(int type, bbcore_read_t f);
-    extern void hoc_reg_bbcore_write(int type, bbcore_write_t f);
-    extern void _nrn_thread_table_reg(int i, void (*f)(int, int, double*, Datum*, ThreadDatum*, NrnThread*, int));
+extern void hoc_reg_bbcore_read(int type, bbcore_read_t f);
+extern void hoc_reg_bbcore_write(int type, bbcore_write_t f);
+extern void _nrn_thread_table_reg(
+    int i,
+    void (*f)(int, int, double*, Datum*, ThreadDatum*, NrnThread*, int));
 
-} // namespace coreneuron
+}  // namespace coreneuron
 
 #endif
-

--- a/coreneuron/nrnoc/solve_core.cpp
+++ b/coreneuron/nrnoc/solve_core.cpp
@@ -115,4 +115,4 @@ static void bksub(NrnThread* _nt) {
     #pragma acc wait(stream_id)
     // clang-format on
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrnoc/treeset_core.cpp
+++ b/coreneuron/nrnoc/treeset_core.cpp
@@ -166,4 +166,4 @@ void* setup_tree_matrix_minimal(NrnThread* _nt) {
 
     return (void*)0;
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrnomp/nrnomp.cpp
+++ b/coreneuron/nrnomp/nrnomp.cpp
@@ -40,4 +40,4 @@ int nrnomp_get_numthreads() {
     return 1;
 #endif
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/nrnomp/nrnomp.h
+++ b/coreneuron/nrnomp/nrnomp.h
@@ -34,7 +34,7 @@ namespace coreneuron {
 /// Get maximum number of OMP threads as defined by the OMP_NUM_THREAS environment variable
 int nrnomp_get_numthreads();
 
-} // namespace coreneuron
+}  // namespace coreneuron
 
 #include "coreneuron/nrnmpi/nrnmpidec.h"
 

--- a/coreneuron/scopmath_core/abort.cpp
+++ b/coreneuron/scopmath_core/abort.cpp
@@ -92,4 +92,4 @@ int abort_run(int code) {
     hoc_execerror("scopmath library error", (char*)0);
     return 0;
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/scopmath_core/crout_thread.cpp
+++ b/coreneuron/scopmath_core/crout_thread.cpp
@@ -233,4 +233,4 @@ void nrn_scopmath_solve_thread(int n,
         }
     }
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/scopmath_core/dimplic.cpp
+++ b/coreneuron/scopmath_core/dimplic.cpp
@@ -57,4 +57,4 @@ int euler_thread(int neqn, int* var, int* der, DIFUN fun, _threadargsproto_) {
     return 0;
 }
 
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/scopmath_core/errcodes.h
+++ b/coreneuron/scopmath_core/errcodes.h
@@ -9,7 +9,7 @@
  *
  ******************************************************************************/
 namespace coreneuron {
-    extern int abort_run(int);
+extern int abort_run(int);
 }
 #define ROUNDOFF 1.e-20
 #define ZERO 1.e-8

--- a/coreneuron/scopmath_core/newton_struct.h
+++ b/coreneuron/scopmath_core/newton_struct.h
@@ -51,6 +51,6 @@ extern void nrn_destroy_newtonspace(NewtonSpace* ns);
 
 void nrn_newtonspace_copyto_device(NewtonSpace* ns);
 
-} //namespace coreneuron
+}  // namespace coreneuron
 
 #endif

--- a/coreneuron/scopmath_core/newton_thread.cpp
+++ b/coreneuron/scopmath_core/newton_thread.cpp
@@ -244,4 +244,4 @@ void nrn_destroy_newtonspace(NewtonSpace* ns) {
     freevector(ns->rowmax);
     free((char*)ns);
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/scopmath_core/sparse_thread.cpp
+++ b/coreneuron/scopmath_core/sparse_thread.cpp
@@ -110,7 +110,7 @@ static List* newlist();
 static void freelist(List* list);
 static void linkitem(Item* item, Item* i);
 static void insert(SparseObj* so, Item* item);
-static void delete_item (Item* item);
+static void delete_item(Item* item);
 static void* myemalloc(unsigned n);
 static void myfree(void*);
 static void check_assert(SparseObj* so);
@@ -125,7 +125,7 @@ static SparseObj* create_sparseobj();
 #endif
 
 static Elm* nrn_pool_alloc(void* arg) {
-    return (Elm*) emalloc(sizeof(Elm));
+    return (Elm*)emalloc(sizeof(Elm));
 }
 
 /* sparse matrix dynamic allocation:
@@ -540,7 +540,7 @@ static void increase_order(SparseObj* so, unsigned row) {
     if (!so->do_flag)
         return;
     order = so->roworder[row];
-    delete_item (order);
+    delete_item(order);
     order->norder++;
     insert(so, order);
 }
@@ -552,7 +552,7 @@ static void reduce_order(SparseObj* so, unsigned row) {
     if (!so->do_flag)
         return;
     order = so->roworder[row];
-    delete_item (order);
+    delete_item(order);
     order->norder--;
     insert(so, order);
 }
@@ -616,7 +616,7 @@ static void get_next_pivot(SparseObj* so, unsigned i) {
 	printf("\n");
 }
 #endif
-    delete_item (order);
+    delete_item(order);
 }
 
 /* The following routines support the concept of a list.
@@ -682,7 +682,7 @@ static void insert(SparseObj* so, Item* item) {
     linkitem(i, item);
 }
 
-static void delete_item (Item* item) {
+static void delete_item(Item* item) {
     item->next->prev = item->prev;
     item->prev->next = item->next;
     item->prev = ITEM0;
@@ -801,7 +801,7 @@ static void re_link(SparseObj* so, unsigned i) {
 static SparseObj* create_sparseobj() {
     SparseObj* so;
 
-    so = (SparseObj*) myemalloc(sizeof(SparseObj));
+    so = (SparseObj*)myemalloc(sizeof(SparseObj));
     nrn_malloc_lock();
     nrn_malloc_unlock();
     so->rowst = 0;
@@ -847,4 +847,4 @@ void _nrn_destroy_sparseobj_thread(SparseObj* so) {
         freelist(so->orderlist);
     Free(so);
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/scopmath_core/ssimplic_thread.cpp
+++ b/coreneuron/scopmath_core/ssimplic_thread.cpp
@@ -78,4 +78,4 @@ void _modl_set_dt_thread(double dt, NrnThread* nt) {
 double _modl_get_dt_thread(NrnThread* nt) {
     return nt->_dt;
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/utils/data_layout.cpp
+++ b/coreneuron/utils/data_layout.cpp
@@ -16,4 +16,4 @@ int get_data_index(int node_index, int variable_index, int mtype, Memb_list* ml)
     assert(layout == SOA_LAYOUT);
     return variable_index * ml->_nodecount_padded + node_index;
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/utils/data_layout.hpp
+++ b/coreneuron/utils/data_layout.hpp
@@ -6,5 +6,5 @@
 namespace coreneuron {
 struct Memb_list;
 int get_data_index(int node_index, int variable_index, int mtype, Memb_list* ml);
-} // namespace coreneuron
+}  // namespace coreneuron
 #endif

--- a/coreneuron/utils/memory_utils.cpp
+++ b/coreneuron/utils/memory_utils.cpp
@@ -120,4 +120,4 @@ void report_mem_usage(const char* message, bool all_ranks) {
     }
     fflush(stdout);
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/utils/memory_utils.h
+++ b/coreneuron/utils/memory_utils.h
@@ -53,5 +53,5 @@ void report_mem_usage(const char* message, bool all_ranks = false);
  *  @return memory usage in KBs
  */
 double nrn_mallinfo(void);
-}
+}  // namespace coreneuron
 #endif /* ifndef NRN_MEMORY_UTILS */

--- a/coreneuron/utils/progressbar/progressbar.c
+++ b/coreneuron/utils/progressbar/progressbar.c
@@ -1,14 +1,14 @@
 /**
-* \file
-* \author Trevor Fountain
-* \author Johannes Buchner
-* \author Erik Garrison
-* \date 2010-2014
-* \copyright BSD 3-Clause
-*
-* progressbar -- a C class (by convention) for displaying progress
-* on the command line (to stdout).
-*/
+ * \file
+ * \author Trevor Fountain
+ * \author Johannes Buchner
+ * \author Erik Garrison
+ * \date 2010-2014
+ * \copyright BSD 3-Clause
+ *
+ * progressbar -- a C class (by convention) for displaying progress
+ * on the command line (to stdout).
+ */
 
 #include <assert.h>
 #include <limits.h>
@@ -45,10 +45,10 @@ typedef struct {
 static void progressbar_draw(const progressbar* bar);
 
 /**
-* Create a new progress bar with the specified label, max number of steps, and format string.
-* Note that `format` must be exactly three characters long, e.g. "<->" to render a progress
-* bar like "<---------->". Returns NULL if there isn't enough memory to allocate a progressbar
-*/
+ * Create a new progress bar with the specified label, max number of steps, and format string.
+ * Note that `format` must be exactly three characters long, e.g. "<->" to render a progress
+ * bar like "<---------->". Returns NULL if there isn't enough memory to allocate a progressbar
+ */
 progressbar* progressbar_new_with_format(const char* label, unsigned long max, const char* format) {
     progressbar* new = malloc(sizeof(progressbar));
     if (new == NULL) {
@@ -71,8 +71,8 @@ progressbar* progressbar_new_with_format(const char* label, unsigned long max, c
 }
 
 /**
-* Create a new progress bar with the specified label and max number of steps.
-*/
+ * Create a new progress bar with the specified label and max number of steps.
+ */
 progressbar* progressbar_new(const char* label, unsigned long max) {
     return progressbar_new_with_format(label, max, "|=|");
 }
@@ -82,15 +82,15 @@ void progressbar_update_label(progressbar* bar, const char* label) {
 }
 
 /**
-* Delete an existing progress bar.
-*/
+ * Delete an existing progress bar.
+ */
 void progressbar_free(progressbar* bar) {
     free(bar);
 }
 
 /**
-* Increment an existing progressbar by `value` steps.
-*/
+ * Increment an existing progressbar by `value` steps.
+ */
 void progressbar_update(progressbar* bar, unsigned long value, double t) {
     bar->value = value;
     bar->t = t;
@@ -98,8 +98,8 @@ void progressbar_update(progressbar* bar, unsigned long value, double t) {
 }
 
 /**
-* Increment an existing progressbar by a single step.
-*/
+ * Increment an existing progressbar by a single step.
+ */
 void progressbar_inc(progressbar* bar, double t) {
     progressbar_update(bar, bar->value + 1, t);
 }
@@ -194,8 +194,8 @@ static void progressbar_draw(const progressbar* bar) {
 }
 
 /**
-* Finish a progressbar, indicating 100% completion, and free it.
-*/
+ * Finish a progressbar, indicating 100% completion, and free it.
+ */
 void progressbar_finish(progressbar* bar) {
     // Make sure we fill the progressbar so things look complete.
     progressbar_draw(bar);

--- a/coreneuron/utils/progressbar/progressbar.h
+++ b/coreneuron/utils/progressbar/progressbar.h
@@ -1,14 +1,14 @@
 /**
-* \file
-* \author Trevor Fountain
-* \author Johannes Buchner
-* \author Erik Garrison
-* \date 2010-2014
-* \copyright BSD 3-Clause
-*
-* progressbar -- a C class (by convention) for displaying progress
-* on the command line (to stderr).
-*/
+ * \file
+ * \author Trevor Fountain
+ * \author Johannes Buchner
+ * \author Erik Garrison
+ * \date 2010-2014
+ * \copyright BSD 3-Clause
+ *
+ * progressbar -- a C class (by convention) for displaying progress
+ * on the command line (to stderr).
+ */
 
 #ifndef PROGRESSBAR_H
 #define PROGRESSBAR_H

--- a/coreneuron/utils/randoms/nrnran123.cpp
+++ b/coreneuron/utils/randoms/nrnran123.cpp
@@ -48,9 +48,9 @@ size_t nrnran123_state_size() {
 
 void nrnran123_set_globalindex(uint32_t gix) {
     k.v[0] = gix;
-    #if (defined(__CUDACC__) || defined(_OPENACC))
+#if (defined(__CUDACC__) || defined(_OPENACC))
     nrnran123_set_gpu_globalindex(gix);
-    #endif
+#endif
 }
 
 /* if one sets the global, one should reset all the stream sequences. */
@@ -158,4 +158,4 @@ double nrnran123_uint2dbl(uint32_t u) {
     /* min 2.3283064e-10 to max (1 - 2.3283064e-10) */
     return ((double)u + 1.0) * SHIFT32;
 }
-} //namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/utils/randoms/nrnran123.h
+++ b/coreneuron/utils/randoms/nrnran123.h
@@ -89,9 +89,7 @@ typedef struct nrnran123_State {
     char which_;
 } nrnran123_State;
 
-typedef struct nrnran123_array4x32 {
-    uint32_t v[4];
-} nrnran123_array4x32;
+typedef struct nrnran123_array4x32 { uint32_t v[4]; } nrnran123_array4x32;
 
 /* do this on launch to make nrnran123_newstream threadsafe */
 extern DEVICE void nrnran123_mutconstruct(void);

--- a/coreneuron/utils/randoms/nrnran123.h
+++ b/coreneuron/utils/randoms/nrnran123.h
@@ -89,7 +89,9 @@ typedef struct nrnran123_State {
     char which_;
 } nrnran123_State;
 
-typedef struct nrnran123_array4x32 { uint32_t v[4]; } nrnran123_array4x32;
+typedef struct nrnran123_array4x32 {
+    uint32_t v[4];
+} nrnran123_array4x32;
 
 /* do this on launch to make nrnran123_newstream threadsafe */
 extern DEVICE void nrnran123_mutconstruct(void);
@@ -155,6 +157,6 @@ extern DEVICE nrnran123_array4x32 nrnran123_iran(uint32_t seq, uint32_t id1, uin
 extern DEVICE double nrnran123_uint2dbl(uint32_t);
 extern void nrnran123_set_gpu_globalindex(uint32_t gix);
 
-} //namespace coreneuron
+}  // namespace coreneuron
 
 #endif

--- a/coreneuron/utils/reports/nrnreport.h
+++ b/coreneuron/utils/reports/nrnreport.h
@@ -52,7 +52,7 @@ namespace coreneuron {
 
 enum ReportType { SomaReport, CompartmentReport, SynapseReport };
 
-struct ReportConfiguration{
+struct ReportConfiguration {
     char name[MAX_REPORT_NAME_LEN];         // name of the report
     char output_path[MAX_REPORT_PATH_LEN];  // full path of the report
     char target_name[MAX_REPORT_NAME_LEN];  // target of the report
@@ -77,5 +77,5 @@ std::vector<ReportConfiguration> create_report_configurations(const char* filena
 void setup_report_engine(double dt_report, double mindelay);
 void finalize_report();
 void nrn_flush_reports(double t);
-} //namespace coreneuron
+}  // namespace coreneuron
 #endif  //_H_NRN_REPORT_

--- a/coreneuron/utils/reports/report_configuration_parser.cpp
+++ b/coreneuron/utils/reports/report_configuration_parser.cpp
@@ -117,4 +117,4 @@ std::vector<ReportConfiguration> create_report_configurations(const char* conf_f
     fclose(fp);
     return reports;
 }
-} //namespace coreneuron
+}  // namespace coreneuron


### PR DESCRIPTION
 - previous PR from Jeremy didn't update source style
 - disable indentation of namespaces
 - upgrade clang-format  to 5.0