### PR TITLE
correct variable in CMAkelists.txt MPI_C_LIBRARY -> MPI_CXX_LIBRARY, …

### DIFF
--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -279,7 +279,7 @@ endif()
 if(ENABLE_REPORTINGLIB)
   set(link_reportinglib ${REPORTINGLIB_LIBRARIES})
 endif()
-target_link_libraries(coreneuron ${MPI_C_LIBRARIES}
+target_link_libraries(coreneuron ${MPI_CXX_LIBRARIES}
     ${link_reportinglib} ${link_cudacoreneuron} ${CUDA_LIBRARIES} )
 
 

--- a/tests/unit/cmdline_interface/CMakeLists.txt
+++ b/tests/unit/cmdline_interface/CMakeLists.txt
@@ -30,7 +30,7 @@
 FILE(GLOB cmd_interface_test_src "*.cpp")
 
 add_executable(cmd_interface_test_bin ${cmd_interface_test_src})
-target_link_libraries(cmd_interface_test_bin ${MPI_C_LIBRARIES} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} coreneuron ${reportinglib_LIBRARY})
+target_link_libraries(cmd_interface_test_bin ${MPI_CXX_LIBRARIES} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} coreneuron ${reportinglib_LIBRARY})
 
 add_test(NAME cmd_interface_test COMMAND ${TEST_EXEC_PREFIX} ${CMAKE_CURRENT_BINARY_DIR}/cmd_interface_test_bin)
 

--- a/tests/unit/interleave_info/CMakeLists.txt
+++ b/tests/unit/interleave_info/CMakeLists.txt
@@ -28,7 +28,7 @@
 FILE(GLOB interleave_info_src "*.cpp")
 
 add_executable(interleave_info_bin ${interleave_info_src})
-target_link_libraries(interleave_info_bin ${MPI_C_LIBRARIES} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} coreneuron ${reportinglib_LIBRARY})
+target_link_libraries(interleave_info_bin ${MPI_CXX_LIBRARIES} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} coreneuron ${reportinglib_LIBRARY})
 
 add_test(NAME interleave_info_constructor_test COMMAND ${TEST_EXEC_PREFIX} ${CMAKE_CURRENT_BINARY_DIR}/interleave_info_bin)
 


### PR DESCRIPTION
…that worked transparently for some compilers but not all of them.