### PR TITLE
Changes to Random123 to support bgclang

### DIFF
--- a/coreneuron/utils/randoms/Random123/features/compilerfeatures.h
+++ b/coreneuron/utils/randoms/Random123/features/compilerfeatures.h
@@ -209,7 +209,7 @@ added to each of the *features.h files, AND to examples/ut_features.cpp.
 #include "sunprofeatures.h"
 #elif defined(__OPEN64__)
 #include "open64features.h"
-#elif defined(__clang__)
+#elif defined(__clang__) || defined(__bgclang__)
 #include "clangfeatures.h"
 #elif defined(_CRAYC)
 #include "crayfeatures.h"

--- a/coreneuron/utils/randoms/Random123/features/gccfeatures.h
+++ b/coreneuron/utils/randoms/Random123/features/gccfeatures.h
@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   Please let the authors know of any successes (or failures). */
 #endif
 
-#ifdef __powerpc__
+#if defined(__powerpc__) && !defined(__bgclang__)
 #include <ppu_intrinsics.h>
 #endif
 

--- a/coreneuron/utils/randoms/nrnran123.h
+++ b/coreneuron/utils/randoms/nrnran123.h
@@ -51,6 +51,11 @@ of the full distribution available from
 http://www.deshawresearch.com/resources_random123.html
 */
 
+#ifdef __bgclang__
+#define R123_USE_MULHILO64_MULHI_INTRIN 0
+#define R123_USE_GNU_UINT128 1
+#endif
+
 #include "Random123/philox.h"
 #include <inttypes.h>
 


### PR DESCRIPTION
bgclang defines a new constant `__bgclang__`, which has to be used instead
of `__clang__`. Additionally we use a known workaround for BG\Q for
Random123 reported elsewhere.

just for completeness: https://lists.alcf.anl.gov/pipermail/llvm-bgq-discuss/2017-January/000679.html