### PR TITLE
Bug fix in parallel spike sorting and memory leak fixes

### DIFF
--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -805,8 +805,9 @@ void setup_ThreadData(NrnThread& nt) {
                 MUTLOCK (*mf.thread_mem_init_)(ml->_thread);
                 MUTUNLOCK
             }
-        } else
+        } else {
             ml->_thread = NULL;
+        }
     }
 }
 
@@ -970,6 +971,11 @@ void nrn_cleanup(bool clean_ion_global_map) {
             if (ml->_permute) {
                 delete[] ml->_permute;
                 ml->_permute = NULL;
+            }
+
+            if (ml->_thread) {
+                free (ml->_thread);
+                ml->_thread = NULL;
             }
 
             NetReceiveBuffer_t* nrb = ml->_net_receive_buffer;

--- a/coreneuron/nrniv/output_spikes.cpp
+++ b/coreneuron/nrniv/output_spikes.cpp
@@ -103,6 +103,7 @@ void sort_spikes(std::vector<double>& spikevec_time, std::vector<int>& spikevec_
     std::vector<int> rcv_dsps(nrnmpi_numprocs);
 
     double bin_t = (max_time - min_time) / nrnmpi_numprocs;
+    bin_t = bin_t ? bin_t : 1;
     // first find number of spikes in each time window
     for (const auto& st : spikevec_time) {
         int idx = (int)(st - min_time) / bin_t;
@@ -199,6 +200,7 @@ void output_spikes_parallel(const char* outpath) {
     }
 
     MPI_File_close(&fh);
+    free(spike_data);
 }
 #endif
 

--- a/coreneuron/nrnmpi/nrnmpi.cpp
+++ b/coreneuron/nrnmpi/nrnmpi.cpp
@@ -131,6 +131,9 @@ void nrnmpi_finalize(void) {
         int flag = 0;
         MPI_Initialized(&flag);
         if (flag) {
+            MPI_Comm_free(&nrnmpi_world_comm);
+            MPI_Comm_free(&nrnmpi_comm);
+            MPI_Comm_free(&nrn_bbs_comm);
             MPI_Finalize();
         }
     }


### PR DESCRIPTION
@ohm314  : below snippet will cause divide by zero when min_time and max_time is same (e.g. single spike across all ranks or all spikes at the same time):

```
    double bin_t = (max_time - min_time) / nrnmpi_numprocs;
    for (const auto& st : spikevec_time) {
        int idx = (int)(st - min_time) / bin_t;
```
check if there is any other corner cases.

I pushed other memory leak fixes as part of this PR.