### PR TITLE
Patternstim fix : allow restore phases to provide new pattern-stim

### DIFF
--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -265,7 +265,7 @@ void nrn_init_and_load_data(int argc,
 
     // Invoke PatternStim
     if (!corenrn_param.patternstim.empty()) {
-        nrn_mkPatternStim(corenrn_param.patternstim.c_str());
+        nrn_mkPatternStim(corenrn_param.patternstim.c_str(), corenrn_param.tstop);
     }
 
     /// Setting the timeout

--- a/coreneuron/mechanism/mech/modfile/pattern.mod
+++ b/coreneuron/mechanism/mech/modfile/pattern.mod
@@ -116,6 +116,7 @@ void pattern_stim_setup_helper(int size, double* tv, int* gv, _threadargsproto_)
 	info->size = size;
 	info->tvec = tv;
 	info->gidvec = gv;
+	artcell_net_send ( _tqitem, -1, (Point_process*) _nt->_vdata[_ppvar[1*_STRIDE]], t +  0.0 , 1.0 ) ;
 }
 } // namespace coreneuron
 ENDVERBATIM

--- a/coreneuron/mechanism/mech/modfile/pattern.mod
+++ b/coreneuron/mechanism/mech/modfile/pattern.mod
@@ -116,6 +116,7 @@ void pattern_stim_setup_helper(int size, double* tv, int* gv, _threadargsproto_)
 	info->size = size;
 	info->tvec = tv;
 	info->gidvec = gv;
+    // initiate event chain (needed in case of restore)
 	artcell_net_send ( _tqitem, -1, (Point_process*) _nt->_vdata[_ppvar[1*_STRIDE]], t +  0.0 , 1.0 ) ;
 }
 } // namespace coreneuron

--- a/coreneuron/nrniv/nrniv_decl.h
+++ b/coreneuron/nrniv/nrniv_decl.h
@@ -70,7 +70,7 @@ extern int nrn_setup_extracon;
 extern void nrn_cleanup();
 extern void nrn_cleanup_ion_map();
 extern void BBS_netpar_solve(double);
-extern void nrn_mkPatternStim(const char* filename);
+extern void nrn_mkPatternStim(const char* filename, double tstop);
 extern int nrn_extra_thread0_vdata;
 extern void nrn_set_extra_thread0_vdata(void);
 extern Point_process* nrn_artcell_instantiate(const char* mechname);

--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -320,7 +320,7 @@ pipeline {
                         }
                     }
                 }
-                stage('patstim'){
+                stage('patstim save restore'){
                     stages{
                         stage('neuron'){
                             steps{
@@ -337,12 +337,6 @@ pipeline {
                                 sh 'sh tests/jenkins/run_corenrn.sh testcorenrn SoA patstim 6'
                             }
                         }
-                        stage('corenrn save-restore'){
-                            steps{
-                                sh 'sh tests/jenkins/run_corenrn.sh testcorenrn SoA patstim_save_restore 6'
-                            }
-                        }
-
                     }
                 }
                 stage('ringtest parallel'){

--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -337,6 +337,12 @@ pipeline {
                                 sh 'sh tests/jenkins/run_corenrn.sh testcorenrn SoA patstim 6'
                             }
                         }
+                        stage('corenrn save-restore'){
+                            steps{
+                                sh 'sh tests/jenkins/run_corenrn.sh testcorenrn SoA patstim_save_restore 6'
+                            }
+                        }
+
                     }
                 }
                 stage('ringtest parallel'){

--- a/tests/jenkins/run_corenrn.sh
+++ b/tests/jenkins/run_corenrn.sh
@@ -26,11 +26,20 @@ elif [ "${TEST}" = "patstim_save_restore" ]; then
     echo 1000 > patstim.2.spk
     sed -n 1002,2001p patstim.spk  >> patstim.2.spk
 
-    # run test with checkpoint restore
+    # run test with checkpoint : part 1
     mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 50 --pattern patstim.1.spk -d test${TEST}dat -o ${TEST} --checkpoint checkpoint
     mv out.dat out.1.dat
+
+    # run test with restore : part 2
     mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 100 --pattern patstim.2.spk -d test${TEST}dat -o ${TEST} --restore checkpoint
     mv out.dat out.2.dat
+
+    # run additional restore by providing full patternstim : part 3
+    mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 100 --pattern patstim.spk -d test${TEST}dat -o ${TEST} --restore checkpoint
+    mv out.dat out.3.dat
+
+    # part 2 and part 3 should be same (part 3 ignore extra events)
+    diff -w out.2.dat out.3.dat
 
     # combine spikes
     cat out.1.dat out.2.dat > out.dat

--- a/tests/jenkins/run_corenrn.sh
+++ b/tests/jenkins/run_corenrn.sh
@@ -28,21 +28,21 @@ elif [ "${TEST}" = "patstim_save_restore" ]; then
 
     # run test with checkpoint : part 1
     mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 50 --pattern patstim.1.spk -d testpatstimdat -o ${TEST} --checkpoint checkpoint
-    mv out.dat out.1.dat
+    mv ${TEST}/out.dat ${TEST}/out.1.dat
 
     # run test with restore : part 2
     mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 100 --pattern patstim.2.spk -d testpatstimdat -o ${TEST} --restore checkpoint
-    mv out.dat out.2.dat
+    mv ${TEST}/out.dat ${TEST}/out.2.dat
 
     # run additional restore by providing full patternstim : part 3
     mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 100 --pattern patstim.spk -d testpatstimdat -o ${TEST} --restore checkpoint
-    mv out.dat out.3.dat
+    mv ${TEST}/out.dat ${TEST}/out.3.dat
 
     # part 2 and part 3 should be same (part 3 ignore extra events)
-    diff -w out.2.dat out.3.dat
+    diff -w ${TEST}/out.2.dat ${TEST}/out.3.dat
 
     # combine spikes
-    cat out.1.dat out.2.dat > out.dat
+    cat ${TEST}/out.1.dat ${TEST}/out.2.dat > ${TEST}/out.dat
 elif [ "${TEST}" = "ringtest" ]; then
     mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 100 -d coredat -o ${TEST}
 elif [ "${TEST}" = "tqperf" ]; then

--- a/tests/jenkins/run_corenrn.sh
+++ b/tests/jenkins/run_corenrn.sh
@@ -21,14 +21,14 @@ if [ "${TEST}" = "patstim" ]; then
     # first run full run
     mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 100 --pattern patstim.spk -d testpatstimdat -o ${TEST}
 
-    # split patternstim file into two parts : total 2000 events, split at line no 1000 (i.e. 50 msec)
+    # split patternstim file into two parts : total 2000 events, split at line no 1001 i.e. before events for 50 msec
     echo 1000 > patstim.1.spk
     sed -n 2,1001p patstim.spk  >> patstim.1.spk
     echo 1000 > patstim.2.spk
     sed -n 1002,2001p patstim.spk  >> patstim.2.spk
 
     # run test with checkpoint : part 1
-    mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 50 --pattern patstim.1.spk -d testpatstimdat -o ${TEST}_part1 --checkpoint checkpoint
+    mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 49 --pattern patstim.1.spk -d testpatstimdat -o ${TEST}_part1 --checkpoint checkpoint
 
     # run test with restore : part 2
     mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 100 --pattern patstim.2.spk -d testpatstimdat -o ${TEST}_part2 --restore checkpoint

--- a/tests/jenkins/run_corenrn.sh
+++ b/tests/jenkins/run_corenrn.sh
@@ -18,7 +18,7 @@ else
 fi
 
 if [ "${TEST}" = "patstim" ]; then
-    mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 100 --pattern patstim.spk -d test${TEST}dat -o ${TEST}
+    mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 100 --pattern patstim.spk -d testpatstimdat -o ${TEST}
 elif [ "${TEST}" = "patstim_save_restore" ]; then
     # split patternstim file into two parts : total 2000 events, split at line no 1000 (i.e. 50 msec)
     echo 1000 > patstim.1.spk
@@ -27,15 +27,15 @@ elif [ "${TEST}" = "patstim_save_restore" ]; then
     sed -n 1002,2001p patstim.spk  >> patstim.2.spk
 
     # run test with checkpoint : part 1
-    mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 50 --pattern patstim.1.spk -d test${TEST}dat -o ${TEST} --checkpoint checkpoint
+    mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 50 --pattern patstim.1.spk -d testpatstimdat -o ${TEST} --checkpoint checkpoint
     mv out.dat out.1.dat
 
     # run test with restore : part 2
-    mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 100 --pattern patstim.2.spk -d test${TEST}dat -o ${TEST} --restore checkpoint
+    mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 100 --pattern patstim.2.spk -d testpatstimdat -o ${TEST} --restore checkpoint
     mv out.dat out.2.dat
 
     # run additional restore by providing full patternstim : part 3
-    mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 100 --pattern patstim.spk -d test${TEST}dat -o ${TEST} --restore checkpoint
+    mpirun -n ${MPI_RANKS} ./${CORENRN_TYPE}/special-core --mpi -e 100 --pattern patstim.spk -d testpatstimdat -o ${TEST} --restore checkpoint
     mv out.dat out.3.dat
 
     # part 2 and part 3 should be same (part 3 ignore extra events)


### PR DESCRIPTION
This allows specifying separate patternstim file for restore part:
  - start event chain by sending event at t+0
  - discard events from file that arrive before t

Here is internal ticket: https://bbpteam.epfl.ch/project/issues/browse/CNEUR-313

```
Current implementation of coreneuron expects whole spike-replay file provided on command line. We have fixed this by https://github.com/BlueBrain/CoreNeuron/pull/121.
But this might result in loss of spikes in case of:
  * user specify tstop = 100 for part0
  * simulator stop at 100.1
  * pattern.dat in part1 has event at 100.05
One way to avoid this error is to always provide whole pattern.dat file to coreneuron. Is that feasible solution? (note that the implementation in coreneuron needs to be updated to avoid storing whole file)
```

@nrnhines : do we need to consider above corner case?