### PR TITLE
Add cmake option to set external MOD2C

### DIFF
--- a/CMake/config/DeclareMod2CSubModule.cmake
+++ b/CMake/config/DeclareMod2CSubModule.cmake
@@ -28,21 +28,22 @@ include(FindPkgConfig)
 
 find_path(MOD2C_PROJ NAMES CMakeLists.txt PATHS "${PROJECT_SOURCE_DIR}/external/mod2c")
 find_package_handle_standard_args(MOD2C REQUIRED_VARS MOD2C_PROJ)
+
 if (NOT MOD2C_FOUND)
   message (FATAL_ERROR "missing mod2c submodule :run on top directory of your sources (git > 1.8.2 required):
       git submodule update --init --remote
       ")
 endif()
+
 set(ExternalProjectCMakeArgs
      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
      -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/external/mod2c
      -DCMAKE_C_COMPILER=${FRONTEND_C_COMPILER} -DCMAKE_CXX_COMPILER=${FRONTEND_CXX_COMPILER}
-   )
+)
 
 ExternalProject_Add(mod2c
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/mod2c
   GIT_SUBMODULES
   CMAKE_ARGS ${ExternalProjectCMakeArgs}
-  CMAKE_CACHE_ARGS ${ExternalProjectCMakeArgs}
-  )
+)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,9 @@ set(FRONTEND_CXX_COMPILER g++ CACHE FILEPATH "C++ compiler for building mod2c [f
 set(ADDITIONAL_MECHPATH "" CACHE PATH "Search path for optional additional mechanism MOD files")
 set(ADDITIONAL_MECHS "" CACHE FILEPATH "File containing list of additional mechanism MOD files")
 
+# mod2c path (if external)
+set(MOD2C "" CACHE FILEPATH "Path of MOD2C binary")
+
 # test compilations
 option(UNIT_TESTS "Enable unit tests compilation and execution" ON)
 option(FUNCTIONAL_TESTS "Enable functional tests compilation and execution" ON)

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -37,10 +37,16 @@ file(GLOB_RECURSE coreneuron_cuda_files "*.cu")
 # Compile and include MOD files
 
 # set mod2c binary and files from built in
-set (MOD2C ${PROJECT_BINARY_DIR}/external/mod2c/bin/mod2c_core)
+if(NOT EXISTS ${MOD2C})
+    set (MOD2C ${PROJECT_BINARY_DIR}/external/mod2c/bin/mod2c_core)
+endif()
+
 get_filename_component(mod2c_install_prefix ${MOD2C} DIRECTORY)
 set (MOD2C_UNITS "${PROJECT_BINARY_DIR}/external/mod2c/share/nrnunits.lib")
 set(MOD2C env "MODLUNIT=${MOD2C_UNITS}" ${MOD2C})
+
+message(STATUS "USING MOD2C ${MOD2C}")
+
 # Macro sets up build rule for .c files from .mod files.
 # Parameters:
 #    name     An arbitrary name to keep track of output .c files


### PR DESCRIPTION
Remove CMAKE_CACHE_ARGS to avoid long warnings like:

```
CMake Warning at /usr/local/Cellar/cmake/3.12.3/share/cmake/Modules/ExternalProject.cmake:1702 (message):
  Line 'CMAKE_C_COMPILER=gcc' does not match regex.  Ignoring.
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.12.3/share/cmake/Modules/ExternalProject.cmake:2766 (_ep_command_line_to_initial_cache)
  /usr/local/Cellar/cmake/3.12.3/share/cmake/Modules/ExternalProject.cmake:2840 (_ep_extract_configure_command)
```

The drawback of this approach is that cmake shows different compiler that make for external project.