### PR TITLE
Fixed SWAP_ENDIAN_DISABLE_ASM error when using PGI

### DIFF
--- a/tests/unit/endian/swap_endian_noasm.cpp
+++ b/tests/unit/endian/swap_endian_noasm.cpp
@@ -31,7 +31,10 @@ THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #define SWAP_ENDIAN_CONFIG DisableAsm
+
+#ifndef SWAP_ENDIAN_DISABLE_ASM
 #define SWAP_ENDIAN_DISABLE_ASM
+#endif
 
 #include "swap_endian_common.ipp"
 


### PR DESCRIPTION
Small fix to solve errors when compiling tests with PGI.