### PR TITLE
Run simulation with different mod files if they are not used

### DIFF
--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -263,6 +263,9 @@ std::vector<NetCon*> netcon_in_presyn_order_;
 /// Only for setup vector of netcon source gids
 std::vector<int*> netcon_srcgid;
 
+/// Vector storing indexes (IDs) of different mod files between Neuron and CoreNeuron
+extern std::vector<int> different_mod_files;
+
 // Wrap read_phase1 and read_phase2 calls to allow using  nrn_multithread_job.
 // Args marshaled by store_phase_args are used by phase1_wrapper
 // and phase2_wrapper.
@@ -1140,6 +1143,11 @@ void read_phase2(FileHandler& F, int imult, NrnThread& nt) {
         for (int i = 0; i < nmech; ++i) {
             tml_index[i] = F.read_int();
             ml_nodecount[i] = F.read_int();
+            auto found_different_mod_file =
+                std::find(different_mod_files.begin(), different_mod_files.end(), tml_index[i]);
+            if (found_different_mod_file != different_mod_files.end()) {
+                exit(1);
+            }
         }
         nt._nidata = F.read_int();
         nt._nvdata = F.read_int();

--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -263,8 +263,10 @@ std::vector<NetCon*> netcon_in_presyn_order_;
 /// Only for setup vector of netcon source gids
 std::vector<int*> netcon_srcgid;
 
-/// Vector storing indexes (IDs) of different mod files between Neuron and CoreNeuron
-extern std::vector<int> different_mod_files;
+/// Vector storing indexes (IDs) of different mechanisms of mod files between Neuron and CoreNeuron
+extern std::vector<int> different_mechanism_type;
+
+static void graceful_exit(int);
 
 // Wrap read_phase1 and read_phase2 calls to allow using  nrn_multithread_job.
 // Args marshaled by store_phase_args are used by phase1_wrapper
@@ -1144,17 +1146,25 @@ void read_phase2(FileHandler& F, int imult, NrnThread& nt) {
         for (int i = 0; i < nmech; ++i) {
             tml_index[i] = F.read_int();
             ml_nodecount[i] = F.read_int();
-            auto found_different_mod_file =
-                std::find(different_mod_files.begin(), different_mod_files.end(), tml_index[i]);
-            if (found_different_mod_file != different_mod_files.end()) {
-                printf("Error: %s is different version of MOD file than the one used by NEURON!\n",
-                       nrn_get_mechname(tml_index[i]));
+            if (std::find(different_mechanism_type.begin(), different_mechanism_type.end(),
+                          tml_index[i]) != different_mechanism_type.end()) {
+                if (nrnmpi_myid == 0) {
+                    printf("Error: %s is a different MOD file than used by NEURON!\n",
+                           nrn_get_mechname(tml_index[i]));
+                }
                 diff_modfiles_count++;
             }
         }
+
         if (diff_modfiles_count > 0) {
-            exit(1);
+            if (nrnmpi_myid == 0) {
+                printf(
+                    "Error : NEURON and CoreNEURON must use same mod files for compatibility, %d different mod file(s) found. Re-compile special and special-core!\n",
+                    diff_modfiles_count);
+            }
+            graceful_exit(1);
         }
+
         nt._nidata = F.read_int();
         nt._nvdata = F.read_int();
         nt.n_weight = F.read_int();
@@ -2217,5 +2227,13 @@ size_t model_size(void) {
 #endif
 
     return nbyte;
+}
+
+static void graceful_exit(int err) {
+#if NRNMPI
+    // actually, only avoid mpi message when all ranks exit(0)
+    nrnmpi_finalize();
+#endif
+    exit(nrnmpi_myid == 0 ? err : 0);
 }
 }  // namespace coreneuron

--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -1140,14 +1140,20 @@ void read_phase2(FileHandler& F, int imult, NrnThread& nt) {
         nmech = F.read_int();
         tml_index = new int[nmech];
         ml_nodecount = new int[nmech];
+        int diff_modfiles_count = 0;
         for (int i = 0; i < nmech; ++i) {
             tml_index[i] = F.read_int();
             ml_nodecount[i] = F.read_int();
             auto found_different_mod_file =
                 std::find(different_mod_files.begin(), different_mod_files.end(), tml_index[i]);
             if (found_different_mod_file != different_mod_files.end()) {
-                exit(1);
+                printf("Error: %s is different version of MOD file than the one used by NEURON!\n",
+                       nrn_get_mechname(tml_index[i]));
+                diff_modfiles_count++;
             }
+        }
+        if (diff_modfiles_count > 0) {
+            exit(1);
         }
         nt._nidata = F.read_int();
         nt._nvdata = F.read_int();

--- a/coreneuron/nrnoc/register_mech.cpp
+++ b/coreneuron/nrnoc/register_mech.cpp
@@ -279,10 +279,6 @@ void hoc_register_prop_size(int type, int psize, int dpsize) {
     pold = nrn_prop_param_size_[type];
     dpold = nrn_prop_dparam_size_[type];
     if (psize != pold || dpsize != dpold) {
-        printf("%s prop sizes differ psize %d %d   dpsize %d %d\n", memb_func[type].sym, psize,
-               pold, dpsize, dpold);
-        printf("Error: %s is different version of MOD file than the one used by NEURON!\n",
-               memb_func[type].sym);
         different_mod_files.push_back(type);
     }
     nrn_prop_param_size_[type] = psize;

--- a/coreneuron/nrnoc/register_mech.cpp
+++ b/coreneuron/nrnoc/register_mech.cpp
@@ -279,6 +279,8 @@ void hoc_register_prop_size(int type, int psize, int dpsize) {
     pold = nrn_prop_param_size_[type];
     dpold = nrn_prop_dparam_size_[type];
     if (psize != pold || dpsize != dpold) {
+        printf("%s prop sizes differ psize %d %d   dpsize %d %d\n", memb_func[type].sym, psize,
+               pold, dpsize, dpold);
         different_mod_files.push_back(type);
     }
     nrn_prop_param_size_[type] = psize;

--- a/coreneuron/nrnoc/register_mech.cpp
+++ b/coreneuron/nrnoc/register_mech.cpp
@@ -87,8 +87,9 @@ static int ion_write_depend_size_;
 static int** ion_write_depend_;
 static void ion_write_depend(int type, int etype);
 
-/* Vector keeping the types (IDs) of different mod files between Neuron and CoreNeuron */
-std::vector<int> different_mod_files;
+/* Vector keeping the types (IDs) of different mechanisms of mod files between Neuron and CoreNeuron
+ */
+std::vector<int> different_mechanism_type;
 
 bbcore_read_t* nrn_bbcore_read_;
 bbcore_write_t* nrn_bbcore_write_;
@@ -279,9 +280,7 @@ void hoc_register_prop_size(int type, int psize, int dpsize) {
     pold = nrn_prop_param_size_[type];
     dpold = nrn_prop_dparam_size_[type];
     if (psize != pold || dpsize != dpold) {
-        printf("%s prop sizes differ psize %d %d   dpsize %d %d\n", memb_func[type].sym, psize,
-               pold, dpsize, dpold);
-        different_mod_files.push_back(type);
+        different_mechanism_type.push_back(type);
     }
     nrn_prop_param_size_[type] = psize;
     nrn_prop_dparam_size_[type] = dpsize;

--- a/coreneuron/nrnoc/register_mech.cpp
+++ b/coreneuron/nrnoc/register_mech.cpp
@@ -35,6 +35,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/nrnmpi/nrnmpi.h"
 #include "coreneuron/nrnoc/mech_mapping.hpp"
 #include "coreneuron/nrnoc/membfunc.h"
+#include <vector>
 
 namespace coreneuron {
 int secondorder = 0;
@@ -85,6 +86,9 @@ short* nrn_is_artificial_;
 static int ion_write_depend_size_;
 static int** ion_write_depend_;
 static void ion_write_depend(int type, int etype);
+
+/* Vector keeping the types (IDs) of different mod files between Neuron and CoreNeuron */
+std::vector<int> different_mod_files;
 
 bbcore_read_t* nrn_bbcore_read_;
 bbcore_write_t* nrn_bbcore_write_;
@@ -279,7 +283,7 @@ void hoc_register_prop_size(int type, int psize, int dpsize) {
                pold, dpsize, dpold);
         printf("Error: %s is different version of MOD file than the one used by NEURON!\n",
                memb_func[type].sym);
-        exit(1);
+        different_mod_files.push_back(type);
     }
     nrn_prop_param_size_[type] = psize;
     nrn_prop_dparam_size_[type] = dpsize;


### PR DESCRIPTION
Fixes issue with simulation not running if a mod file is different between Neuron and CoreNeuron even if it is not used in the simulation.