### PR TITLE
Fix Jenkins pipeline

### DIFF
--- a/tests/jenkins/install.sh
+++ b/tests/jenkins/install.sh
@@ -7,7 +7,7 @@ set -e
 CORENRN_TYPE="$1"
 
 if [ "${CORENRN_TYPE}" = "GPU" ]; then
-    module load pgi cuda hpe-mpi cmake
+    module load pgi cuda/9.0.176 hpe-mpi cmake boost
 
     mkdir build_${CORENRN_TYPE}
 else


### PR DESCRIPTION
Load modules for GPU build based on the typical script for
building CoreNeuron with GPU support found here:
https://github.com/BlueBrain/CoreNeuron/issues/145#issuecomment-478051198