### PR TITLE
Added instrumentor::phase struct API implementation

### DIFF
--- a/coreneuron/nrniv/main1.cpp
+++ b/coreneuron/nrniv/main1.cpp
@@ -477,7 +477,6 @@ extern "C" int run_solve_core(int argc, char** argv) {
         // Report global cell statistics
         report_cell_stats();
 
-
         // prcellstate after end of solver
         call_prcellstate_for_prcellgid(nrnopt_get_int("--prcellgid"), compute_gpu, 0);
     }

--- a/coreneuron/nrniv/main1.cpp
+++ b/coreneuron/nrniv/main1.cpp
@@ -399,9 +399,10 @@ extern "C" int run_solve_core(int argc, char** argv) {
     }
 
     // initializationa and loading functions moved to separate
-    Instrumentor::phase_begin("load-model");
-    nrn_init_and_load_data(argc, argv, !configs.empty());
-    Instrumentor::phase_end("load-model");
+    {
+        Instrumentor::phase p("load-model");
+        nrn_init_and_load_data(argc, argv, !configs.empty());
+    }
 
     std::string checkpoint_path = nrnopt_get_str("--checkpoint");
     if (strlen(checkpoint_path.c_str())) {
@@ -482,13 +483,15 @@ extern "C" int run_solve_core(int argc, char** argv) {
     }
 
     // write spike information to outpath
-    Instrumentor::phase_begin("output-spike");
-    output_spikes(output_dir.c_str());
-    Instrumentor::phase_end("output-spike");
+    {
+        Instrumentor::phase p("output-spike");
+        output_spikes(output_dir.c_str());
+    }
 
-    Instrumentor::phase_begin("checkpoint");
-    write_checkpoint(nrn_threads, nrn_nthread, checkpoint_path.c_str(), nrn_need_byteswap);
-    Instrumentor::phase_end("checkpoint");
+    {
+        Instrumentor::phase p("checkpoint");
+        write_checkpoint(nrn_threads, nrn_nthread, checkpoint_path.c_str(), nrn_need_byteswap);
+    }
 
     // must be done after checkpoint (to avoid deleting events)
     if (reports_needs_finalize) {

--- a/coreneuron/nrniv/profiler_interface.h
+++ b/coreneuron/nrniv/profiler_interface.h
@@ -27,15 +27,17 @@ namespace coreneuron {
 
 namespace detail {
 
-    /*! \class Instrumentor
-     *  \brief Instrumentation infrastructure for benchmarking and profiling.
-     *
-     *  The Instrumentor class exposes static methods that can be used to
-     *  toggle with fine-grained resolution the profiling of specific
-     *  areas within the code.
-     */
+/*! \class Instrumentor
+ *  \brief Instrumentation infrastructure for benchmarking and profiling.
+ *
+ *  The Instrumentor class exposes static methods that can be used to
+ *  toggle with fine-grained resolution the profiling of specific
+ *  areas within the code.
+ */
 template <class... TProfilerImpl>
 struct Instrumentor {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
     /*! \fn phase_begin
      *  \brief Activate the collection of profiling data within a code region.
      *
@@ -128,6 +130,7 @@ struct Instrumentor {
     inline static void finalize_profile() {
         std::initializer_list<int>{(TProfilerImpl::finalize_profile(), 0)...};
     }
+#pragma clang diagnostic pop
 };
 
 #if defined(CORENEURON_CALIPER)
@@ -220,29 +223,26 @@ struct Tau {
 #if defined(LIKWID_PERFMON)
 
 struct Likwid {
-    inline static void phase_begin(const char* name){
+    inline static void phase_begin(const char* name) {
         LIKWID_MARKER_START(name);
     };
 
-    inline static void phase_end(const char* name){
+    inline static void phase_end(const char* name) {
         LIKWID_MARKER_STOP(name);
     };
 
-    inline static void start_profile() {};
+    inline static void start_profile(){};
 
-    inline static void stop_profile() {};
+    inline static void stop_profile(){};
 
-    inline static void init_profile(){
+    inline static void init_profile() {
         LIKWID_MARKER_INIT;
 
 #pragma omp parallel
-        {
-            LIKWID_MARKER_THREADINIT;
-        }
-
+        { LIKWID_MARKER_THREADINIT; }
     };
 
-    inline static void finalize_profile(){
+    inline static void finalize_profile() {
         LIKWID_MARKER_CLOSE;
     };
 };
@@ -257,7 +257,6 @@ struct NullInstrumentor {
     inline static void init_profile(){};
     inline static void finalize_profile(){};
 };
-
 
 using InstrumentorImpl = detail::Instrumentor<
 #if defined CORENEURON_CALIPER
@@ -279,38 +278,38 @@ using InstrumentorImpl = detail::Instrumentor<
 }  // namespace detail
 
 namespace Instrumentor {
-    struct phase {
-        phase(const char* name) {
-            detail::InstrumentorImpl::phase_begin(name);
-        }
-        ~phase() {
-            detail::InstrumentorImpl::phase_end("");
-        }
-    };
-
-    inline static void start_profile() {
-        detail::InstrumentorImpl::start_profile();
-    }
-
-    inline static void stop_profile() {
-        detail::InstrumentorImpl::stop_profile();
-    }
-
-    inline static void phase_begin(const char* name) {
+struct phase {
+    phase(const char* name) {
         detail::InstrumentorImpl::phase_begin(name);
     }
-
-    inline static void phase_end(const char* name) {
-        detail::InstrumentorImpl::phase_end(name);
+    ~phase() {
+        detail::InstrumentorImpl::phase_end("");
     }
+};
 
-    inline static void init_profile() {
-        detail::InstrumentorImpl::init_profile();
-    }
+inline static void start_profile() {
+    detail::InstrumentorImpl::start_profile();
+}
 
-    inline static void finalize_profile() {
-        detail::InstrumentorImpl::finalize_profile();
-    }
+inline static void stop_profile() {
+    detail::InstrumentorImpl::stop_profile();
+}
+
+inline static void phase_begin(const char* name) {
+    detail::InstrumentorImpl::phase_begin(name);
+}
+
+inline static void phase_end(const char* name) {
+    detail::InstrumentorImpl::phase_end(name);
+}
+
+inline static void init_profile() {
+    detail::InstrumentorImpl::init_profile();
+}
+
+inline static void finalize_profile() {
+    detail::InstrumentorImpl::finalize_profile();
+}
 }
 
 }  // namespace coreneuron

--- a/coreneuron/nrniv/profiler_interface.h
+++ b/coreneuron/nrniv/profiler_interface.h
@@ -120,17 +120,6 @@ struct NullInstrumentor {
 
 }  // namespace detail
 
-namespace Instrumentor {
-    struct phase {
-        phase(const char* name) {
-            detail::Instrumentor::phase_begin(name);
-        }
-        ~phase() {
-            detail::Instrumentor::phase_end();
-        }
-    }
-}
-
 using Instrumentor = detail::Instrumentor<
 #if defined CORENEURON_CALIPER
     detail::Caliper,
@@ -145,5 +134,17 @@ using Instrumentor = detail::Instrumentor<
     detail::Tau,
 #endif
     detail::NullInstrumentor>;
+
+namespace Instrumentor {
+    struct phase {
+        phase(const char* name) {
+            detail::Instrumentor::phase_begin(name);
+        }
+        ~phase() {
+            detail::Instrumentor::phase_end();
+        }
+    };
+}
+
 
 }  // namespace coreneuron

--- a/coreneuron/nrniv/profiler_interface.h
+++ b/coreneuron/nrniv/profiler_interface.h
@@ -258,9 +258,8 @@ struct NullInstrumentor {
     inline static void finalize_profile(){};
 };
 
-}  // namespace detail
 
-using Instrumentor = detail::Instrumentor<
+using InstrumentorImpl = detail::Instrumentor<
 #if defined CORENEURON_CALIPER
     detail::Caliper,
 #endif
@@ -277,17 +276,41 @@ using Instrumentor = detail::Instrumentor<
     detail::Likwid,
 #endif
     detail::NullInstrumentor>;
+}  // namespace detail
 
 namespace Instrumentor {
     struct phase {
         phase(const char* name) {
-            detail::Instrumentor::phase_begin(name);
+            detail::InstrumentorImpl::phase_begin(name);
         }
         ~phase() {
-            detail::Instrumentor::phase_end();
+            detail::InstrumentorImpl::phase_end("");
         }
     };
-}
 
+    inline static void start_profile() {
+        detail::InstrumentorImpl::start_profile();
+    }
+
+    inline static void stop_profile() {
+        detail::InstrumentorImpl::stop_profile();
+    }
+
+    inline static void phase_begin(const char* name) {
+        detail::InstrumentorImpl::phase_begin(name);
+    }
+
+    inline static void phase_end(const char* name) {
+        detail::InstrumentorImpl::phase_end(name);
+    }
+
+    inline static void init_profile() {
+        detail::InstrumentorImpl::init_profile();
+    }
+
+    inline static void finalize_profile() {
+        detail::InstrumentorImpl::finalize_profile();
+    }
+}
 
 }  // namespace coreneuron

--- a/coreneuron/nrniv/profiler_interface.h
+++ b/coreneuron/nrniv/profiler_interface.h
@@ -122,8 +122,8 @@ struct NullInstrumentor {
 
 namespace Instrumentor {
     struct phase {
-        phase() {
-            detail::Instrumentor::phase_begin();
+        phase(const char* name) {
+            detail::Instrumentor::phase_begin(name);
         }
         ~phase() {
             detail::Instrumentor::phase_end();

--- a/coreneuron/nrniv/profiler_interface.h
+++ b/coreneuron/nrniv/profiler_interface.h
@@ -37,6 +37,7 @@ struct Instrumentor {
     inline static void stop_profile() {
         std::initializer_list<int>{(TProfilerImpl::stop_profile(), 0)...};
     }
+
 };
 
 #if defined(CORENEURON_CALIPER)
@@ -118,6 +119,17 @@ struct NullInstrumentor {
 };
 
 }  // namespace detail
+
+namespace Instrumentor {
+    struct phase {
+        phase() {
+            detail::Instrumentor::phase_begin();
+        }
+        ~phase() {
+            detail::Instrumentor::phase_end();
+        }
+    }
+}
 
 using Instrumentor = detail::Instrumentor<
 #if defined CORENEURON_CALIPER

--- a/coreneuron/nrnmpi/mpispike.cpp
+++ b/coreneuron/nrnmpi/mpispike.cpp
@@ -116,9 +116,11 @@ void wait_before_spike_exchange() {
 int nrnmpi_spike_exchange() {
     int i, n;
     Instrumentor::phase_begin("spike-exchange");
-    Instrumentor::phase_begin("imbalance");
-    wait_before_spike_exchange();
-    Instrumentor::phase_end("imbalance");
+
+    {
+        Instrumentor::phase p("imbalance");
+        wait_before_spike_exchange();
+    }
 
     Instrumentor::phase_begin("communication");
 #if nrn_spikebuf_size > 0

--- a/coreneuron/nrnmpi/mpispike.cpp
+++ b/coreneuron/nrnmpi/mpispike.cpp
@@ -33,6 +33,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/nrnmpi/nrnmpidec.h"
 #include "coreneuron/nrnmpi/nrnmpi_impl.h"
 #include "coreneuron/nrnmpi/mpispike.h"
+#include "coreneuron/nrniv/profiler_interface.h"
 
 #if NRNMPI
 #include <mpi.h>
@@ -114,8 +115,12 @@ void wait_before_spike_exchange() {
 
 int nrnmpi_spike_exchange() {
     int i, n;
+    Instrumentor::phase_begin("spike-exchange");
+    Instrumentor::phase_begin("imbalance");
     wait_before_spike_exchange();
+    Instrumentor::phase_end("imbalance");
 
+    Instrumentor::phase_begin("communication");
 #if nrn_spikebuf_size > 0
     int n1, novfl;
 #endif
@@ -176,6 +181,8 @@ int nrnmpi_spike_exchange() {
     }
     ovfl_ = novfl;
 #endif
+    Instrumentor::phase_end("communication");
+    Instrumentor::phase_end("spike-exchange");
     return n;
 }
 

--- a/coreneuron/nrnoc/fadvance_core.cpp
+++ b/coreneuron/nrnoc/fadvance_core.cpp
@@ -195,9 +195,8 @@ void update(NrnThread* _nt) {
 void nonvint(NrnThread* _nt) {
     NrnThreadMembList* tml;
     if (nrn_have_gaps) {
-        Instrumentor::phase_begin("gap-v-transfer");
+        Instrumentor::phase p("gap-v-transfer");
         nrnthread_v_transfer(_nt);
-        Instrumentor::phase_end("gap-v-transfer");
     }
     errno = 0;
 
@@ -207,9 +206,10 @@ void nonvint(NrnThread* _nt) {
             mod_f_t s = memb_func[tml->index].state;
             std::string ss("state-");
             ss += nrn_get_mechname(tml->index);
-            Instrumentor::phase_begin(ss.c_str());
-            (*s)(_nt, tml->ml, tml->index);
-            Instrumentor::phase_end(ss.c_str());
+            {
+                Instrumentor::phase p(ss.c_str())
+                (*s)(_nt, tml->ml, tml->index);
+            }
 #ifdef DEBUG
             if (errno) {
                 hoc_warning("errno set during calculation of states", (char*)0);
@@ -234,9 +234,10 @@ static void* nrn_fixed_step_thread(NrnThread* nth) {
        events up to t+dt/2 */
     Instrumentor::phase_begin("timestep");
 
-    Instrumentor::phase_begin("deliver_events");
-    deliver_net_events(nth);
-    Instrumentor::phase_end("deliver_events");
+    {
+        Instrumentor::phase p("deliver_events");
+        deliver_net_events(nth);
+    }
 
     nth->_t += .5 * nth->_dt;
 
@@ -251,21 +252,25 @@ static void* nrn_fixed_step_thread(NrnThread* nth) {
 #endif
         fixed_play_continuous(nth);
 
-        Instrumentor::phase_begin("setup_tree_matrix");
-        setup_tree_matrix_minimal(nth);
-        Instrumentor::phase_end("setup_tree_matrix");
+        {
+            Instrumentor::phase p("setup_tree_matrix")
+            setup_tree_matrix_minimal(nth);
+        }
 
-        Instrumentor::phase_begin("matrix-solver");
-        nrn_solve_minimal(nth);
-        Instrumentor::phase_end("matrix-solver");
+        {
+            Instrumentor::phase p("matrix-solver");
+            nrn_solve_minimal(nth);
+        }
 
-        Instrumentor::phase_begin("second_order_cur");
-        second_order_cur(nth, secondorder);
-        Instrumentor::phase_end("second_order_cur");
+        {
+            Instrumentor::phase p("second_order_cur");
+            second_order_cur(nth, secondorder);
+        }
 
-        Instrumentor::phase_begin("update");
-        update(nth);
-        Instrumentor::phase_end("update");
+        {
+            Instrumentor::phase p("update");
+            update(nth);
+        }
     }
     if (!nrn_have_gaps) {
         nrn_fixed_step_lastpart(nth);
@@ -293,9 +298,11 @@ void* nrn_fixed_step_lastpart(NrnThread* nth) {
         nrn_ba(nth, BEFORE_STEP);
     }
 
-    Instrumentor::phase_begin("deliver_events");
-    nrn_deliver_events(nth); /* up to but not past texit */
-    Instrumentor::phase_end("deliver_events");
-    return (void*)0;
+		{
+        Instrumentor::phase p("deliver_events");
+        nrn_deliver_events(nth); /* up to but not past texit */
+    }
+
+		return (void*)0;
 }
 }  // namespace coreneuron

--- a/coreneuron/nrnoc/fadvance_core.cpp
+++ b/coreneuron/nrnoc/fadvance_core.cpp
@@ -207,7 +207,7 @@ void nonvint(NrnThread* _nt) {
             std::string ss("state-");
             ss += nrn_get_mechname(tml->index);
             {
-                Instrumentor::phase p(ss.c_str())
+                Instrumentor::phase p(ss.c_str());
                 (*s)(_nt, tml->ml, tml->index);
             }
 #ifdef DEBUG
@@ -253,7 +253,7 @@ static void* nrn_fixed_step_thread(NrnThread* nth) {
         fixed_play_continuous(nth);
 
         {
-            Instrumentor::phase p("setup_tree_matrix")
+            Instrumentor::phase p("setup_tree_matrix");
             setup_tree_matrix_minimal(nth);
         }
 

--- a/coreneuron/nrnoc/fadvance_core.cpp
+++ b/coreneuron/nrnoc/fadvance_core.cpp
@@ -191,7 +191,6 @@ void update(NrnThread* _nt) {
     }
 }
 
-
 void nonvint(NrnThread* _nt) {
     NrnThreadMembList* tml;
     if (nrn_have_gaps) {
@@ -298,11 +297,11 @@ void* nrn_fixed_step_lastpart(NrnThread* nth) {
         nrn_ba(nth, BEFORE_STEP);
     }
 
-		{
+    {
         Instrumentor::phase p("deliver_events");
         nrn_deliver_events(nth); /* up to but not past texit */
     }
 
-		return (void*)0;
+    return (void*)0;
 }
 }  // namespace coreneuron

--- a/coreneuron/nrnoc/treeset_core.cpp
+++ b/coreneuron/nrnoc/treeset_core.cpp
@@ -74,9 +74,8 @@ static void nrn_rhs(NrnThread* _nt) {
             mod_f_t s = memb_func[tml->index].current;
             std::string ss("cur-");
             ss += nrn_get_mechname(tml->index);
-            Instrumentor::phase_begin(ss.c_str());
+            Instrumentor::phase p(ss.c_str());
             (*s)(_nt, tml->ml, tml->index);
-            Instrumentor::phase_end(ss.c_str());
 #ifdef DEBUG
             if (errno) {
                 hoc_warning("errno set during calculation of currents", (char*)0);
@@ -130,9 +129,8 @@ static void nrn_lhs(NrnThread* _nt) {
             mod_f_t s = memb_func[tml->index].jacob;
             std::string ss("cur-");
             ss += nrn_get_mechname(tml->index);
-            Instrumentor::phase_begin(ss.c_str());
+            Instrumentor::phase p(ss.c_str());
             (*s)(_nt, tml->ml, tml->index);
-            Instrumentor::phase_end(ss.c_str());
 #ifdef DEBUG
             if (errno) {
                 hoc_warning("errno set during calculation of jacobian", (char*)0);

--- a/coreneuron/utils/ispc/globals.cpp
+++ b/coreneuron/utils/ispc/globals.cpp
@@ -6,5 +6,5 @@
  */
 
 extern "C" {
-    double ispc_celsius;
+double ispc_celsius;
 }


### PR DESCRIPTION
As there is existing implementation of `instrumentor` struct, I have created a `namespace` named `instrumentor` other than `detail` and kept `phase` struct inside it. Please let me know if you think the design should be different.

Fix https://github.com/BlueBrain/CoreNeuron/issues/158.