### PR TITLE
Changed pinned parallel version of neuron to generic parallel version

### DIFF
--- a/tests/jenkins/nrnivmodl.sh
+++ b/tests/jenkins/nrnivmodl.sh
@@ -7,7 +7,7 @@ TEST_DIR="$1"
 
 . /gpfs/bbp.cscs.ch/apps/hpc/jenkins/config/modules.sh
 module load intel
-module load `module av 2>&1 | grep -o 'neuron.*/parallel'`
+module load `module av neuron 2>&1 | grep -o -m 1 'neuron.*/parallel' | awk -F' ' '{print $1}'`
 
 unset $(env|awk -F= '/^(PMI|SLURM)_/ {if ($1 != "SLURM_ACCOUNT") print $1}')
 

--- a/tests/jenkins/nrnivmodl.sh
+++ b/tests/jenkins/nrnivmodl.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/bash
 
 set -e
-set +x
+set -x
 
 TEST_DIR="$1"
 
 . /gpfs/bbp.cscs.ch/apps/hpc/jenkins/config/modules.sh
 module load intel
-module load `module av neuron 2>&1 | grep -o -m 1 'neuron.*/parallel' | awk -F' ' '{print $1}'`
+
+neuron_version=$(module av neuron 2>&1 | grep -o -m 1 '^neuron.*/parallel$' | awk -F' ' '{print $1}')
+if [[ $neuron_version ]]; then
+    module load $neuron_version
+else
+    echo "No compatible neuron version found."
+    exit 1
+fi
 
 unset $(env|awk -F= '/^(PMI|SLURM)_/ {if ($1 != "SLURM_ACCOUNT") print $1}')
 

--- a/tests/jenkins/nrnivmodl.sh
+++ b/tests/jenkins/nrnivmodl.sh
@@ -6,7 +6,8 @@ set +x
 TEST_DIR="$1"
 
 . /gpfs/bbp.cscs.ch/apps/hpc/jenkins/config/modules.sh
-module load neuron/2018-10/python3/parallel intel
+module load intel
+module load `module av 2>&1 | grep -o 'neuron.*/parallel'`
 
 unset $(env|awk -F= '/^(PMI|SLURM)_/ {if ($1 != "SLURM_ACCOUNT") print $1}')
 

--- a/tests/jenkins/nrnivmodl.sh
+++ b/tests/jenkins/nrnivmodl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 set -e
-set -x
+set +x
 
 TEST_DIR="$1"
 
@@ -11,8 +11,10 @@ module load intel
 neuron_version=$(module av neuron 2>&1 | grep -o -m 1 '^neuron.*/parallel$' | awk -F' ' '{print $1}')
 if [[ $neuron_version ]]; then
     module load $neuron_version
+    module list
 else
     echo "No compatible neuron version found."
+    module list
     exit 1
 fi
 

--- a/tests/jenkins/nrnivmodl.sh
+++ b/tests/jenkins/nrnivmodl.sh
@@ -13,7 +13,7 @@ if [[ $neuron_version ]]; then
     module load $neuron_version
     module list
 else
-    echo "No compatible neuron version found."
+    echo "Error: no compatible neuron version found." >&2
     module list
     exit 1
 fi


### PR DESCRIPTION
Instead of using a specific version of neuron, query the available modules to find a parallel neuron module