### PR TITLE
Direct1

### DIFF
--- a/coreneuron/nrniv/global_vars.cpp
+++ b/coreneuron/nrniv/global_vars.cpp
@@ -82,7 +82,7 @@ void set_globals(const char* path, bool cli_global_seed, int cli_global_seed_val
         double val;
         int n;
 
-        fscanf(f, "%s\n", line);
+        nrn_assert(fscanf(f, "%s\n", line) == 1);
         check_bbcore_write_version(line);
 
         for (;;) {

--- a/coreneuron/nrniv/main1.cpp
+++ b/coreneuron/nrniv/main1.cpp
@@ -367,30 +367,32 @@ void get_nrn_trajectory_requests(int bsize) {
   if (nrn2core_get_trajectory_requests_) {
     for (int tid=0; tid < nrn_nthread; ++tid) {
       NrnThread& nt = nrn_threads[tid];
-      int ntrajec;
+      int n_pr;
+      int n_trajec;
       int* types;
       int* indices;
       void** vpr;
       double** varrays;
 
-      (*nrn2core_get_trajectory_requests_)(tid, bsize, ntrajec, vpr, types, indices, varrays);
+      (*nrn2core_get_trajectory_requests_)(tid, bsize, n_pr, vpr, n_trajec, types, indices, varrays);
       delete_trajectory_requests(nt);
-      if (ntrajec) {
+      if (n_trajec) {
         TrajectoryRequests* tr = new TrajectoryRequests;
         nt.trajec_requests = tr;
         tr->bsize = bsize;
-        tr->ntrajec = ntrajec;
+        tr->n_pr = n_pr;
+        tr->n_trajec = n_trajec;
         tr->vsize = 0;
         tr->vpr = vpr;
-        tr->gather = new double*[ntrajec];
+        tr->gather = new double*[n_trajec];
         tr->values = NULL;
         tr->varrays = NULL;
         if (bsize) {
           tr->varrays = varrays;
         }else{
-          tr->values = new double[ntrajec];
+          tr->values = new double[n_trajec];
         }
-        for (int i=0; i < ntrajec; ++i) {
+        for (int i=0; i < n_trajec; ++i) {
           tr->gather[i] = stdindex2ptr(types[i], indices[i], nt);
         }
         delete [] types;
@@ -406,7 +408,7 @@ static void trajectory_return() {
       NrnThread& nt = nrn_threads[tid];
       TrajectoryRequests* tr = nt.trajec_requests;
       if (tr && tr->varrays) {
-        (*nrn2core_trajectory_return_)(tid, tr->ntrajec, tr->vsize, tr->vpr, nt._t);
+        (*nrn2core_trajectory_return_)(tid, tr->n_pr, tr->vsize, tr->vpr, nt._t);
       }
     }
   }

--- a/coreneuron/nrniv/main1.cpp
+++ b/coreneuron/nrniv/main1.cpp
@@ -373,10 +373,11 @@ void get_nrn_trajectory_requests(int bsize) {
       int* indices;
       void** vpr;
       double** varrays;
+      double** pvars;
 
       // bsize is passed by reference, the return value will determine if
       // per step return or entire trajectory return.
-      (*nrn2core_get_trajectory_requests_)(tid, bsize, n_pr, vpr, n_trajec, types, indices, varrays);
+      (*nrn2core_get_trajectory_requests_)(tid, bsize, n_pr, vpr, n_trajec, types, indices, pvars, varrays);
       delete_trajectory_requests(nt);
       if (n_trajec) {
         TrajectoryRequests* tr = new TrajectoryRequests;
@@ -387,13 +388,8 @@ void get_nrn_trajectory_requests(int bsize) {
         tr->vsize = 0;
         tr->vpr = vpr;
         tr->gather = new double*[n_trajec];
-        tr->values = NULL;
-        tr->varrays = NULL;
-        if (bsize) {
-          tr->varrays = varrays;
-        }else{
-          tr->values = new double[n_trajec];
-        }
+        tr->varrays = varrays;
+        tr->scatter = pvars;
         for (int i=0; i < n_trajec; ++i) {
           tr->gather[i] = stdindex2ptr(types[i], indices[i], nt);
         }

--- a/coreneuron/nrniv/main1.cpp
+++ b/coreneuron/nrniv/main1.cpp
@@ -64,6 +64,8 @@ const char* corenrn_version() {
     return coreneuron::bbcore_write_version;
 }
 
+void (*nrn2core_part2_clean_)();
+
 #ifdef ISPC_INTEROP
 // cf. utils/ispc_globals.c
 extern double ispc_celsius;
@@ -435,6 +437,7 @@ extern "C" int run_solve_core(int argc, char** argv) {
     // to allow processing in NEURON after simulation by CoreNEURON
     if (corenrn_embedded) {
         get_nrn_trajectory_requests();
+        (*nrn2core_part2_clean_)();
     }
 
     std::string checkpoint_path = nrnopt_get_str("--checkpoint");

--- a/coreneuron/nrniv/main1.cpp
+++ b/coreneuron/nrniv/main1.cpp
@@ -374,6 +374,8 @@ void get_nrn_trajectory_requests(int bsize) {
       void** vpr;
       double** varrays;
 
+      // bsize is passed by reference, the return value will determine if
+      // per step return or entire trajectory return.
       (*nrn2core_get_trajectory_requests_)(tid, bsize, n_pr, vpr, n_trajec, types, indices, varrays);
       delete_trajectory_requests(nt);
       if (n_trajec) {
@@ -492,11 +494,9 @@ extern "C" int run_solve_core(int argc, char** argv) {
         // In direct mode there are likely trajectory record requests
         // to allow processing in NEURON after simulation by CoreNEURON
         if (corenrn_embedded) {
-#if 1
+            // arg is vector size required but NEURON can instead
+            // specify that returns will be on a per time step basis.
             get_nrn_trajectory_requests(int(tstop/dt) + 2);
-#else
-            get_nrn_trajectory_requests(0);
-#endif
             (*nrn2core_part2_clean_)();
         }
 

--- a/coreneuron/nrniv/mk_mech.cpp
+++ b/coreneuron/nrniv/mk_mech.cpp
@@ -118,11 +118,14 @@ void mk_mech(const char* datpath) {
 
 // we are embedded in NEURON, get info as stringstream from nrnbbcore_write.cpp
 static void mk_mech() {
+    static bool done = false;
+    if (done) { return; }
     nrn_need_byteswap = 0;
     std::stringstream ss;
     nrn_assert(nrn2core_mkmech_info_);
     (*nrn2core_mkmech_info_)(ss);
     mk_mech(ss);
+    done = true;
 }
 
 static void mk_mech(std::istream& s) {

--- a/coreneuron/nrniv/nrn2core_direct.h
+++ b/coreneuron/nrniv/nrn2core_direct.h
@@ -98,15 +98,14 @@ extern void (*nrn2core_get_trajectory_requests_)(int tid,
                                                 int& n_trajec,
                                                 int*& types,
                                                 int*& indices,
+                                                double**& pvars,
                                                 double**& varrays);
 
 /* send values to NEURON on each time step */
 extern void (*nrn2core_trajectory_values_)(int tid,
                                           int n_pr,
                                           void** vpr,
-                                          double t,
-                                          int n_trajec,
-                                          double* values);
+                                          double t);
 
 /* Filled the Vector data arrays and send back the sizes at end of run */
 extern void (*nrn2core_trajectory_return_)(int tid,

--- a/coreneuron/nrniv/nrn2core_direct.h
+++ b/coreneuron/nrniv/nrn2core_direct.h
@@ -88,6 +88,8 @@ extern int (*nrn2core_get_dat2_vecplay_inst_)(int tid,
                                               double*& yvec,
                                               double*& tvec);
 
+extern void (*nrn2core_part2_clean_)();
+
 /* what variables to send back to NEURON on each time step */
 extern void (*nrn2core_get_trajectory_requests_)(int tid,
                                                 int& cnt,

--- a/coreneuron/nrniv/nrn2core_direct.h
+++ b/coreneuron/nrniv/nrn2core_direct.h
@@ -93,22 +93,24 @@ extern void (*nrn2core_part2_clean_)();
 /* what variables to send back to NEURON on each time step */
 extern void (*nrn2core_get_trajectory_requests_)(int tid,
                                                 int bsize,
-                                                int& ntrajec,
+                                                int& n_pr,
                                                 void**& vpr,
+                                                int& n_trajec,
                                                 int*& types,
                                                 int*& indices,
                                                 double**& varrays);
 
 /* send values to NEURON on each time step */
 extern void (*nrn2core_trajectory_values_)(int tid,
-                                          int ntrajec,
+                                          int n_pr,
                                           void** vpr,
                                           double t,
+                                          int n_trajec,
                                           double* values);
 
 /* Filled the Vector data arrays and send back the sizes at end of run */
 extern void (*nrn2core_trajectory_return_)(int tid,
-                                          int ntrajec,
+                                          int n_pr,
                                           int vecsz,
                                           void** vpr,
                                           double t);

--- a/coreneuron/nrniv/nrn2core_direct.h
+++ b/coreneuron/nrniv/nrn2core_direct.h
@@ -92,7 +92,7 @@ extern void (*nrn2core_part2_clean_)();
 
 /* what variables to send back to NEURON on each time step */
 extern void (*nrn2core_get_trajectory_requests_)(int tid,
-                                                int bsize,
+                                                int& bsize,
                                                 int& n_pr,
                                                 void**& vpr,
                                                 int& n_trajec,

--- a/coreneuron/nrniv/nrn2core_direct.h
+++ b/coreneuron/nrniv/nrn2core_direct.h
@@ -87,6 +87,21 @@ extern int (*nrn2core_get_dat2_vecplay_inst_)(int tid,
                                               int& sz,
                                               double*& yvec,
                                               double*& tvec);
+
+/* what variables to send back to NEURON on each time step */
+extern void (*nrn2core_get_trajectory_requests_)(int tid,
+                                                int& cnt,
+                                                void**& vpr,
+                                                int*& types,
+                                                int*& indices);
+
+/* send values to NEURON on each time step */
+extern void (*nrn2core_trajectory_values_)(int tid,
+                                          int cnt,
+                                          void** vpr,
+                                          double t,
+                                          double* values);
+
 }
 
 #endif /* nrn2core_direct_h */

--- a/coreneuron/nrniv/nrn2core_direct.h
+++ b/coreneuron/nrniv/nrn2core_direct.h
@@ -92,17 +92,26 @@ extern void (*nrn2core_part2_clean_)();
 
 /* what variables to send back to NEURON on each time step */
 extern void (*nrn2core_get_trajectory_requests_)(int tid,
-                                                int& cnt,
+                                                int bsize,
+                                                int& ntrajec,
                                                 void**& vpr,
                                                 int*& types,
-                                                int*& indices);
+                                                int*& indices,
+                                                double**& varrays);
 
 /* send values to NEURON on each time step */
 extern void (*nrn2core_trajectory_values_)(int tid,
-                                          int cnt,
+                                          int ntrajec,
                                           void** vpr,
                                           double t,
                                           double* values);
+
+/* Filled the Vector data arrays and send back the sizes at end of run */
+extern void (*nrn2core_trajectory_return_)(int tid,
+                                          int ntrajec,
+                                          int vecsz,
+                                          void** vpr,
+                                          double t);
 
 }
 

--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -1154,6 +1154,7 @@ void nrn_cleanup(bool clean_ion_global_map) {
 
     if (pnttype2presyn) {
         free(pnttype2presyn);
+        pnttype2presyn = NULL;
     }
 }
 

--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -312,7 +312,7 @@ void nrn_read_filesdat(int& ngrp, int*& grp, int multiple, int*& imult, const ch
     }
 
     char version[256];
-    fscanf(fp, "%s\n", version);
+    nrn_assert(fscanf(fp, "%s\n", version) == 1);
     check_bbcore_write_version(version);
 
     int iNumFiles = 0;
@@ -350,8 +350,8 @@ void nrn_read_filesdat(int& ngrp, int*& grp, int multiple, int*& imult, const ch
         if ((iNum + 1) % iNumFiles == 0) {
             // re-read file for each multiple (skipping the two header lines)
             rewind(fp);
-            fscanf(fp, "%*s\n");
-            fscanf(fp, "%*d\n");
+            nrn_assert(fscanf(fp, "%*s\n") == 0);
+            nrn_assert(fscanf(fp, "%*d\n") == 0);
         }
     }
 
@@ -1178,7 +1178,9 @@ void read_phase2(FileHandler& F, int imult, NrnThread& nt) {
     ntc.n_outputgids = n_outputgid;
     ntc.nmech = nmech;
 #endif
-    nrn_assert(n_outputgid > 0);  // avoid n_outputgid unused warning
+    if (!direct) {
+        nrn_assert(n_outputgid > 0);  // avoid n_outputgid unused warning
+    }
 
     /// Checkpoint in coreneuron is defined for both phase 1 and phase 2 since they are written
     /// together

--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -130,20 +130,22 @@ int (*nrn2core_get_dat2_vecplay_inst_)(int tid,
 
 void (*nrn2core_get_trajectory_requests_)(int tid,
                                                 int bsize,
-                                                int& ntrajec,
+                                                int& n_pr,
                                                 void**& vpr,
+                                                int& n_trajec,
                                                 int*& types,
                                                 int*& indices,
                                                 double**& varrays);
 
 void (*nrn2core_trajectory_values_)(int tid,
-                                          int ntrajec,
+                                          int n_pr,
                                           void** vpr,
                                           double t,
+                                          int n_trajec,
                                           double* values);
 
 void (*nrn2core_trajectory_return_)(int tid,
-                                          int ntrajec,
+                                          int n_pr,
                                           int vecsz,
                                           void** vpr,
                                           double t);
@@ -1177,7 +1179,7 @@ void nrn_cleanup(bool clean_ion_global_map) {
 void delete_trajectory_requests(NrnThread& nt) {
   if (nt.trajec_requests) {
     TrajectoryRequests* tr = nt.trajec_requests;
-    if (tr->ntrajec) {
+    if (tr->n_trajec) {
       delete [] tr->vpr;
       if (tr->values) {delete [] tr->values;}
       if (tr->varrays) {delete [] tr->varrays;}

--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -135,14 +135,13 @@ void (*nrn2core_get_trajectory_requests_)(int tid,
                                                 int& n_trajec,
                                                 int*& types,
                                                 int*& indices,
+                                                double**& pvars,
                                                 double**& varrays);
 
 void (*nrn2core_trajectory_values_)(int tid,
                                           int n_pr,
                                           void** vpr,
-                                          double t,
-                                          int n_trajec,
-                                          double* values);
+                                          double t);
 
 void (*nrn2core_trajectory_return_)(int tid,
                                           int n_pr,
@@ -931,7 +930,7 @@ int nrn_i_layout(int icnt, int cnt, int isz, int sz, int layout) {
 }
 
 // take into account alignment, layout, permutation
-// only voltage or mechanism data index allowed.
+// only voltage or mechanism data index allowed. (mtype 0 means time)
 double* stdindex2ptr(int mtype, int index, NrnThread& nt) {
     if (mtype == -5) { // voltage
         int v0 = nt._actual_v - nt._data;
@@ -1183,7 +1182,7 @@ void delete_trajectory_requests(NrnThread& nt) {
     TrajectoryRequests* tr = nt.trajec_requests;
     if (tr->n_trajec) {
       delete [] tr->vpr;
-      if (tr->values) {delete [] tr->values;}
+      if (tr->scatter) {delete [] tr->scatter;}
       if (tr->varrays) {delete [] tr->varrays;}
       delete [] tr->gather;
     }

--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -994,6 +994,7 @@ inline void mech_layout(FileHandler& F, T* data, int cnt, int sz, int layout) {
  * things up first. */
 
 void nrn_cleanup(bool clean_ion_global_map) {
+    clear_event_queue(); // delete left-over TQItem
     gid2in.clear();
     gid2out.clear();
 

--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -949,6 +949,8 @@ double* stdindex2ptr(int mtype, int index, NrnThread& nt) {
             ix = nrn_index_permute(ix, mtype, ml);
         }
         return ml->data + ix;
+    }else if (mtype == 0) { // time
+        return &nt._t;
     }else{
         printf("stdindex2ptr does not handle mtype=%d\n", mtype);
         nrn_assert(0);

--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -129,16 +129,24 @@ int (*nrn2core_get_dat2_vecplay_inst_)(int tid,
                                        double*& tvec);
 
 void (*nrn2core_get_trajectory_requests_)(int tid,
-                                                int& cnt,
+                                                int bsize,
+                                                int& ntrajec,
                                                 void**& vpr,
                                                 int*& types,
-                                                int*& indices);
+                                                int*& indices,
+                                                double**& varrays);
 
 void (*nrn2core_trajectory_values_)(int tid,
-                                          int cnt,
+                                          int ntrajec,
                                           void** vpr,
                                           double t,
                                           double* values);
+
+void (*nrn2core_trajectory_return_)(int tid,
+                                          int ntrajec,
+                                          int vecsz,
+                                          void** vpr,
+                                          double t);
 
 
 // file format defined in cooperation with nrncore/src/nrniv/nrnbbcore_write.cpp
@@ -1169,9 +1177,10 @@ void nrn_cleanup(bool clean_ion_global_map) {
 void delete_trajectory_requests(NrnThread& nt) {
   if (nt.trajec_requests) {
     TrajectoryRequests* tr = nt.trajec_requests;
-    if (tr->cnt) {
+    if (tr->ntrajec) {
       delete [] tr->vpr;
-      delete [] tr->values;
+      if (tr->values) {delete [] tr->values;}
+      if (tr->varrays) {delete [] tr->varrays;}
       delete [] tr->gather;
     }
     delete nt.trajec_requests;

--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -128,6 +128,19 @@ int (*nrn2core_get_dat2_vecplay_inst_)(int tid,
                                        double*& yvec,
                                        double*& tvec);
 
+void (*nrn2core_get_trajectory_requests_)(int tid,
+                                                int& cnt,
+                                                void**& vpr,
+                                                int*& types,
+                                                int*& indices);
+
+void (*nrn2core_trajectory_values_)(int tid,
+                                          int cnt,
+                                          void** vpr,
+                                          double t,
+                                          double* values);
+
+
 // file format defined in cooperation with nrncore/src/nrniv/nrnbbcore_write.cpp
 // single integers are ascii one per line. arrays are binary int or double
 // Note that regardless of the gid contents of a group, since all gids are
@@ -900,6 +913,32 @@ int nrn_i_layout(int icnt, int cnt, int isz, int sz, int layout) {
     return 0;
 }
 
+// take into account alignment, layout, permutation
+// only voltage or mechanism data index allowed.
+double* stdindex2ptr(int mtype, int index, NrnThread& nt) {
+    if (mtype == -5) { // voltage
+        int v0 = nt._actual_v - nt._data;
+        int ix = index;  // relative to _actual_v
+        nrn_assert((ix >= 0) && (ix < nt.end));
+        if (nt._permute) {
+             node_permute(&ix, 1, nt._permute);
+        }
+        return nt._data + (v0 + ix);  // relative to nt._data
+    }else if (mtype  > 0 && mtype < n_memb_func) { // 
+        Memb_list* ml = nt._ml_list[mtype];
+        nrn_assert(ml);
+        int ix = nrn_param_layout(index, mtype, ml);
+        if (ml->_permute) {
+            ix = nrn_index_permute(ix, mtype, ml);
+        }
+        return ml->data + ix;
+    }else{
+        printf("stdindex2ptr does not handle mtype=%d\n", mtype);
+        nrn_assert(0);
+    }
+    return NULL;
+}
+
 // from i to (icnt, isz)
 void nrn_inverse_i_layout(int i, int& icnt, int cnt, int& isz, int sz, int layout) {
     if (layout == 1) {
@@ -967,6 +1006,7 @@ void nrn_cleanup(bool clean_ion_global_map) {
     for (int it = 0; it < nrn_nthread; ++it) {
         NrnThread* nt = nrn_threads + it;
         NrnThreadMembList* next_tml = NULL;
+	delete_trajectory_requests(*nt);
         for (NrnThreadMembList* tml = nt->tml; tml; tml = next_tml) {
             Memb_list* ml = tml->ml;
 
@@ -1115,6 +1155,19 @@ void nrn_cleanup(bool clean_ion_global_map) {
     if (pnttype2presyn) {
         free(pnttype2presyn);
     }
+}
+
+void delete_trajectory_requests(NrnThread& nt) {
+  if (nt.trajec_requests) {
+    TrajectoryRequests* tr = nt.trajec_requests;
+    if (tr->cnt) {
+      delete [] tr->vpr;
+      delete [] tr->values;
+      delete [] tr->gather;
+    }
+    delete nt.trajec_requests;
+    nt.trajec_requests = NULL;
+  }
 }
 
 void read_phase2(FileHandler& F, int imult, NrnThread& nt) {

--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -129,7 +129,7 @@ int (*nrn2core_get_dat2_vecplay_inst_)(int tid,
                                        double*& tvec);
 
 void (*nrn2core_get_trajectory_requests_)(int tid,
-                                                int bsize,
+                                                int& bsize,
                                                 int& n_pr,
                                                 void**& vpr,
                                                 int& n_trajec,

--- a/coreneuron/nrniv/nrn_setup.cpp
+++ b/coreneuron/nrniv/nrn_setup.cpp
@@ -694,7 +694,9 @@ void nrn_setup(const char* filesdat,
     maxgid = 0x7fffffff / nrn_setup_multiple;
     nrn_read_filesdat(ngroup, gidgroups, nrn_setup_multiple, imult, filesdat);
 
-    MUTCONSTRUCT(1)
+    if (!MUTCONSTRUCTED) {
+        MUTCONSTRUCT(1)
+    }
     // temporary bug work around. If any process has multiple threads, no
     // process can have a single thread. So, for now, if one thread, make two.
     // Fortunately, empty threads work fine.
@@ -808,7 +810,12 @@ void nrn_setup(const char* filesdat,
     delete[] file_reader;
 
     model_size();
-    delete[] gidgroups;
+    delete [] gidgroups;
+    delete [] imult;
+    if (nrnthread_chkpnt) {
+        delete [] nrnthread_chkpnt;
+        nrnthread_chkpnt = NULL;
+    }
 
     if (nrnmpi_myid == 0) {
         printf(" Setup Done   : %.2lf seconds \n", nrn_wtime() - time);

--- a/coreneuron/nrniv/nrniv_decl.h
+++ b/coreneuron/nrniv/nrniv_decl.h
@@ -55,6 +55,8 @@ extern void nrn_setup(const char* filesdat,
                       bool is_mapping_needed,
                       int byte_swap,
                       bool run_setup_cleanup = true);
+extern double* stdindex2ptr(int mtype, int index, NrnThread&);
+extern void delete_trajectory_requests(NrnThread&);
 extern int nrn_setup_multiple;
 extern int nrn_setup_extracon;
 extern void nrn_cleanup(bool clean_ion_global_map = true);

--- a/coreneuron/nrniv/output_spikes.cpp
+++ b/coreneuron/nrniv/output_spikes.cpp
@@ -57,7 +57,9 @@ static MUTDEC
     } catch (const std::length_error& le) {
         std::cerr << "Lenght error" << le.what() << std::endl;
     }
-    MUTCONSTRUCT(1);
+    if (!MUTCONSTRUCTED) {
+        MUTCONSTRUCT(1);
+    }
 }
 
 void spikevec_lock() {

--- a/coreneuron/nrniv/tqueue.ipp
+++ b/coreneuron/nrniv/tqueue.ipp
@@ -78,6 +78,11 @@ TQueue<C>::~TQueue() {
     }
     delete binq_;
 
+    if (least_) {
+      delete least_;
+      least_ = NULL;
+    }
+
     /// Clear the splay tree
     while ((q = spdeq(&sptree_->root)) != NULL) {
         delete q;

--- a/coreneuron/nrnoc/fadvance_core.cpp
+++ b/coreneuron/nrnoc/fadvance_core.cpp
@@ -235,7 +235,7 @@ void nrncore2nrn_send_values(NrnThread* nth) {
     // if per time step transfer, need to call nrn_record_init() in NEURON.
     // if storing full trajectories in CoreNEURON, need to initialize
     // vsize for all the trajectory requests.
-    (*nrn2core_trajectory_values_)(-1, 0, NULL, 0.0, 0, NULL);
+    (*nrn2core_trajectory_values_)(-1, 0, NULL, 0.0);
     for (int tid = 0; tid < nrn_nthread; ++tid) {
       NrnThread& nt = nrn_threads[tid];
       if (nt.trajec_requests) {
@@ -253,12 +253,12 @@ void nrncore2nrn_send_values(NrnThread* nth) {
       for (int i=0; i < tr->n_trajec; ++i) {
         va[i][vs] = *(tr->gather[i]);
       }
-    }else if (tr->values){ // values for each step sent back to NEURON
+    }else if (tr->scatter){ // scatter to NEURON and notify each step.
       nrn_assert(nrn2core_trajectory_values_);
       for (int i=0; i < tr->n_trajec; ++i) {
-        tr->values[i] = *(tr->gather[i]);
+        *(tr->scatter[i]) = *(tr->gather[i]);
       }
-      (*nrn2core_trajectory_values_) (nth->id, tr->n_pr, tr->vpr, nth->_t, tr->n_trajec, tr->values);
+      (*nrn2core_trajectory_values_) (nth->id, tr->n_pr, tr->vpr, nth->_t);
     }
   }
 }

--- a/coreneuron/nrnoc/fadvance_core.cpp
+++ b/coreneuron/nrnoc/fadvance_core.cpp
@@ -231,16 +231,20 @@ void nrn_ba(NrnThread* nt, int bat) {
 }
 
 void nrncore2nrn_send_init() {
-    // if per time step transfer, need to call nrn_record_init() in NEURON.
-    // if storing full trajectories in CoreNEURON, need to initialize
-    // vsize for all the trajectory requests.
-    (*nrn2core_trajectory_values_)(-1, 0, NULL, 0.0);
-    for (int tid = 0; tid < nrn_nthread; ++tid) {
-      NrnThread& nt = nrn_threads[tid];
-      if (nt.trajec_requests) {
-        nt.trajec_requests->vsize = 0;
-      }
+  if (nrn2core_trajectory_values_ == nullptr) {
+      // standalone execution : no callbacks
+      return;
+  }
+  // if per time step transfer, need to call nrn_record_init() in NEURON.
+  // if storing full trajectories in CoreNEURON, need to initialize
+  // vsize for all the trajectory requests.
+  (*nrn2core_trajectory_values_)(-1, 0, NULL, 0.0);
+  for (int tid = 0; tid < nrn_nthread; ++tid) {
+    NrnThread& nt = nrn_threads[tid];
+    if (nt.trajec_requests) {
+      nt.trajec_requests->vsize = 0;
     }
+  }
 }
 
 void nrncore2nrn_send_values(NrnThread* nth) {

--- a/coreneuron/nrnoc/fadvance_core.cpp
+++ b/coreneuron/nrnoc/fadvance_core.cpp
@@ -231,6 +231,11 @@ void nrn_ba(NrnThread* nt, int bat) {
 }
 
 void nrncore2nrn_send_values(NrnThread* nth) {
+  if (nrn2core_trajectory_values_ == nullptr) {
+      // standalone execution : no callbacks
+      return;
+  }
+
   if (nth == NULL) {
     // if per time step transfer, need to call nrn_record_init() in NEURON.
     // if storing full trajectories in CoreNEURON, need to initialize

--- a/coreneuron/nrnoc/fadvance_core.cpp
+++ b/coreneuron/nrnoc/fadvance_core.cpp
@@ -235,7 +235,7 @@ void nrncore2nrn_send_values(NrnThread* nth) {
     // if per time step transfer, need to call nrn_record_init() in NEURON.
     // if storing full trajectories in CoreNEURON, need to initialize
     // vsize for all the trajectory requests.
-    (*nrn2core_trajectory_values_)(-1, 0, NULL, 0.0, NULL);
+    (*nrn2core_trajectory_values_)(-1, 0, NULL, 0.0, 0, NULL);
     for (int tid = 0; tid < nrn_nthread; ++tid) {
       NrnThread& nt = nrn_threads[tid];
       if (nt.trajec_requests) {
@@ -254,15 +254,15 @@ void nrncore2nrn_send_values(NrnThread* nth) {
       double** va = tr->varrays;
       int vs = tr->vsize++;
       assert(vs < tr->bsize);
-      for (int i=0; i < tr->ntrajec; ++i) {
+      for (int i=0; i < tr->n_trajec; ++i) {
         va[i][vs] = *(tr->gather[i]);
       }
     }else if (tr->values){ // values for each step sent back to NEURON
       nrn_assert(nrn2core_trajectory_values_);
-      for (int i=0; i < tr->ntrajec; ++i) {
+      for (int i=0; i < tr->n_trajec; ++i) {
         tr->values[i] = *(tr->gather[i]);
       }
-      (*nrn2core_trajectory_values_) (nth->id, tr->ntrajec, tr->vpr, nth->_t, tr->values);
+      (*nrn2core_trajectory_values_) (nth->id, tr->n_pr, tr->vpr, nth->_t, tr->n_trajec, tr->values);
     }
   }
 }

--- a/coreneuron/nrnoc/fadvance_core.cpp
+++ b/coreneuron/nrnoc/fadvance_core.cpp
@@ -242,7 +242,6 @@ void nrncore2nrn_send_values(NrnThread* nth) {
       for (int i=0; i < tr->cnt; ++i) {
         tr->values[i] = *(tr->gather[i]);
       }
-if (nth->_t == 0.0) { printf("nrncore2nrn_send_values t=0\n");}
       (*nrn2core_trajectory_values_) (nth->id, tr->cnt, tr->vpr, nth->_t, tr->values);
     }
   }

--- a/coreneuron/nrnoc/fadvance_core.cpp
+++ b/coreneuron/nrnoc/fadvance_core.cpp
@@ -247,10 +247,6 @@ void nrncore2nrn_send_values(NrnThread* nth) {
   TrajectoryRequests* tr = nth->trajec_requests;
   if (tr) {
     if (tr->varrays) { // full trajectories into Vector data
-      if (nth == NULL) { // initialize counter
-        tr->vsize = 0;
-        return;
-      }
       double** va = tr->varrays;
       int vs = tr->vsize++;
       assert(vs < tr->bsize);

--- a/coreneuron/nrnoc/fadvance_core.cpp
+++ b/coreneuron/nrnoc/fadvance_core.cpp
@@ -230,13 +230,7 @@ void nrn_ba(NrnThread* nt, int bat) {
     }
 }
 
-void nrncore2nrn_send_values(NrnThread* nth) {
-  if (nrn2core_trajectory_values_ == nullptr) {
-      // standalone execution : no callbacks
-      return;
-  }
-
-  if (nth == NULL) {
+void nrncore2nrn_send_init() {
     // if per time step transfer, need to call nrn_record_init() in NEURON.
     // if storing full trajectories in CoreNEURON, need to initialize
     // vsize for all the trajectory requests.
@@ -247,8 +241,14 @@ void nrncore2nrn_send_values(NrnThread* nth) {
         nt.trajec_requests->vsize = 0;
       }
     }
-    return;
+}
+
+void nrncore2nrn_send_values(NrnThread* nth) {
+  if (nrn2core_trajectory_values_ == nullptr) {
+      // standalone execution : no callbacks
+      return;
   }
+
   TrajectoryRequests* tr = nth->trajec_requests;
   if (tr) {
     if (tr->varrays) { // full trajectories into Vector data

--- a/coreneuron/nrnoc/finitialize.cpp
+++ b/coreneuron/nrnoc/finitialize.cpp
@@ -108,7 +108,7 @@ void nrn_finitialize(int setv, double v) {
 #if NRNMPI
     nrn_spike_exchange(nrn_threads);
 #endif
-    nrncore2nrn_send_values(NULL);
+    nrncore2nrn_send_init();
     for (i=0; i < nrn_nthread; ++i) {
         nrncore2nrn_send_values(nrn_threads + i);
     }

--- a/coreneuron/nrnoc/finitialize.cpp
+++ b/coreneuron/nrnoc/finitialize.cpp
@@ -108,6 +108,10 @@ void nrn_finitialize(int setv, double v) {
 #if NRNMPI
     nrn_spike_exchange(nrn_threads);
 #endif
+    nrncore2nrn_send_values(NULL);
+    for (i=0; i < nrn_nthread; ++i) {
+        nrncore2nrn_send_values(nrn_threads + i);
+    }
     Instrumentor::phase_end("finitialize");
 }
 }  // namespace coreneuron

--- a/coreneuron/nrnoc/multicore.cpp
+++ b/coreneuron/nrnoc/multicore.cpp
@@ -137,6 +137,7 @@ void nrn_threads_create(int n) {
                 nt->_net_send_buffer_cnt = 0;
                 nt->_watch_types = NULL;
                 nt->mapping = NULL;
+                nt->trajec_requests = NULL;
             }
         }
         v_structure_change = 1;

--- a/coreneuron/nrnoc/multicore.h
+++ b/coreneuron/nrnoc/multicore.h
@@ -64,7 +64,8 @@ struct TrajectoryRequests {
     double* values; /* if bsize == 0, buffer of values returned to NEURON each time step */
     double** varrays; /* if bsize > 0, the Vector data pointers. */
     double** gather; /* pointers to values that get copied into values */
-    int ntrajec; /* number of trajectories requestedt */
+    int n_pr; /* number of PlayRecord instances */
+    int n_trajec; /* number of trajectories requested */
     int bsize; /* buffer size of the Vector data */
     int vsize; /* number of elements in varrays so far */
 };

--- a/coreneuron/nrnoc/multicore.h
+++ b/coreneuron/nrnoc/multicore.h
@@ -59,6 +59,13 @@ struct NrnThreadBAList {
     NrnThreadBAList* next;
 };
 
+struct TrajectoryRequests {
+    void** vpr; /* PlayRecord Objects known by NEURON */
+    double* values; /* buffer of values returned to NEURON each time step */
+    double** gather; /* pointers to values that get copied into valuse */
+    int cnt; /* request count */
+};
+
 /* for OpenACC, in order to avoid an error while update PreSyn, with virtual base
  * class, we are adding helper with flag variable which could be updated on GPU
  */
@@ -123,6 +130,7 @@ struct NrnThread {
 
     int* _watch_types; /* NULL or 0 terminated array of integers */
     void* mapping;     /* section to segment mapping information */
+    TrajectoryRequests* trajec_requests; /* per time step values returned to NEURON */
 };
 
 extern void nrn_threads_create(int n);

--- a/coreneuron/nrnoc/multicore.h
+++ b/coreneuron/nrnoc/multicore.h
@@ -61,9 +61,9 @@ struct NrnThreadBAList {
 
 struct TrajectoryRequests {
     void** vpr; /* PlayRecord Objects known by NEURON */
-    double* values; /* if bsize == 0, buffer of values returned to NEURON each time step */
+    double** scatter; /* if bsize == 0, each time step */
     double** varrays; /* if bsize > 0, the Vector data pointers. */
-    double** gather; /* pointers to values that get copied into values */
+    double** gather; /* pointers to values that get scattered to NEURON */
     int n_pr; /* number of PlayRecord instances */
     int n_trajec; /* number of trajectories requested */
     int bsize; /* buffer size of the Vector data */

--- a/coreneuron/nrnoc/multicore.h
+++ b/coreneuron/nrnoc/multicore.h
@@ -61,9 +61,12 @@ struct NrnThreadBAList {
 
 struct TrajectoryRequests {
     void** vpr; /* PlayRecord Objects known by NEURON */
-    double* values; /* buffer of values returned to NEURON each time step */
-    double** gather; /* pointers to values that get copied into valuse */
-    int cnt; /* request count */
+    double* values; /* if bsize == 0, buffer of values returned to NEURON each time step */
+    double** varrays; /* if bsize > 0, the Vector data pointers. */
+    double** gather; /* pointers to values that get copied into values */
+    int ntrajec; /* number of trajectories requestedt */
+    int bsize; /* buffer size of the Vector data */
+    int vsize; /* number of elements in varrays so far */
 };
 
 /* for OpenACC, in order to avoid an error while update PreSyn, with virtual base

--- a/coreneuron/nrnoc/nrnoc_decl.h
+++ b/coreneuron/nrnoc/nrnoc_decl.h
@@ -58,6 +58,7 @@ extern void nrn_finitialize(int setv, double v);
 extern void nrn_fixed_step_group_minimal(int n);
 extern void nrn_fixed_step_minimal(void);
 extern void* nrn_fixed_step_lastpart(NrnThread*);
+extern void nrncore2nrn_send_values(NrnThread*);
 extern void update(NrnThread*);
 extern void* setup_tree_matrix_minimal(NrnThread*);
 extern void alloc_mech(int);

--- a/coreneuron/nrnoc/nrnoc_decl.h
+++ b/coreneuron/nrnoc/nrnoc_decl.h
@@ -58,6 +58,7 @@ extern void nrn_finitialize(int setv, double v);
 extern void nrn_fixed_step_group_minimal(int n);
 extern void nrn_fixed_step_minimal(void);
 extern void* nrn_fixed_step_lastpart(NrnThread*);
+extern void nrncore2nrn_send_init();
 extern void nrncore2nrn_send_values(NrnThread*);
 extern void update(NrnThread*);
 extern void* setup_tree_matrix_minimal(NrnThread*);


### PR DESCRIPTION
CoreNEURON direct mode trajectory requests allow CoreNEURON to send back information
during (or after) a simulation to allow plotting of trajectories and movies in NEURON as well as
Vector.record. Should be extended/tested for GPU but this pull request is needed to be consistent
with current communication layer in NEURON.