### PR TITLE
Fix bug when spikes vector is empty

### DIFF
--- a/coreneuron/nrniv/output_spikes.cpp
+++ b/coreneuron/nrniv/output_spikes.cpp
@@ -95,8 +95,12 @@ void local_spikevec_sort(std::vector<double>& isvect,
 #if NRNMPI
 
 void sort_spikes(std::vector<double>& spikevec_time, std::vector<int>& spikevec_gid) {
-    double lmin_time = *(std::min_element(spikevec_time.begin(), spikevec_time.end()));
-    double lmax_time = *(std::max_element(spikevec_time.begin(), spikevec_time.end()));
+    double lmin_time = std::numeric_limits<double>::max();
+    double lmax_time = std::numeric_limits<double>::min();
+    if(!spikevec_time.empty()) {
+        lmin_time = *(std::min_element(spikevec_time.begin(), spikevec_time.end()));
+        lmax_time = *(std::max_element(spikevec_time.begin(), spikevec_time.end()));
+    }	
     double min_time = nrnmpi_dbl_allmin(lmin_time);
     double max_time = nrnmpi_dbl_allmax(lmax_time);
 


### PR DESCRIPTION
The bug is reproduced when calling std::min/max_element() when spikevec_time is empty.

The use of those functions with an empty range returns the end iterator. Attempting to dereference this iterator is undefined behavior (segmentation fault in most cases).