### PR TITLE
Set number of reporting steps to record and stop reports before tstop if necessary

### DIFF
--- a/coreneuron/utils/reports/nrnreport.cpp
+++ b/coreneuron/utils/reports/nrnreport.cpp
@@ -375,6 +375,7 @@ void nrn_flush_reports(double t) {
 void setup_report_engine(double dt_report, double mindelay) {
 #ifdef ENABLE_REPORTING
     /** reportinglib setup */
+    records_set_mindelay(mindelay);
     records_setup_communicator();
     records_finish_and_share();
 #endif  // ENABLE_REPORTING

--- a/coreneuron/utils/reports/nrnreport.cpp
+++ b/coreneuron/utils/reports/nrnreport.cpp
@@ -375,7 +375,8 @@ void nrn_flush_reports(double t) {
 void setup_report_engine(double dt_report, double mindelay) {
 #ifdef ENABLE_REPORTING
     /** reportinglib setup */
-    records_set_mindelay(mindelay);
+    int min_steps_to_record = static_cast<int>(mindelay / dt_report + 0.5);
+    records_set_min_steps_to_record(min_steps_to_write);
     records_setup_communicator();
     records_finish_and_share();
 #endif  // ENABLE_REPORTING

--- a/coreneuron/utils/reports/nrnreport.cpp
+++ b/coreneuron/utils/reports/nrnreport.cpp
@@ -376,7 +376,7 @@ void setup_report_engine(double dt_report, double mindelay) {
 #ifdef ENABLE_REPORTING
     /** reportinglib setup */
     int min_steps_to_record = static_cast<int>(mindelay / dt_report + 0.5);
-    records_set_min_steps_to_record(min_steps_to_write);
+    records_set_min_steps_to_record(min_steps_to_record);
     records_setup_communicator();
     records_finish_and_share();
 #endif  // ENABLE_REPORTING

--- a/coreneuron/utils/reports/nrnreport.cpp
+++ b/coreneuron/utils/reports/nrnreport.cpp
@@ -42,6 +42,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
 #include <map>
 #include <set>
+#include <cmath>
 
 namespace coreneuron {
 
@@ -375,7 +376,7 @@ void nrn_flush_reports(double t) {
 void setup_report_engine(double dt_report, double mindelay) {
 #ifdef ENABLE_REPORTING
     /** reportinglib setup */
-    int min_steps_to_record = static_cast<int>(mindelay / dt_report + 0.5);
+    int min_steps_to_record = static_cast<int>(std::round(mindelay / dt_report));
     records_set_min_steps_to_record(min_steps_to_record);
     records_setup_communicator();
     records_finish_and_share();

--- a/coreneuron/utils/reports/nrnreport.cpp
+++ b/coreneuron/utils/reports/nrnreport.cpp
@@ -397,7 +397,7 @@ void register_report(double dt, double tstop, double delay, ReportConfiguration&
     if (report.start < t) {
         report.start = t;
     }
-    report.stop = tstop;
+    report.stop = std::min(report.stop, tstop);
 
     records_set_atomic_step(dt);
     report.mech_id = nrn_get_mechtype(report.mech_name);


### PR DESCRIPTION
- Calculate minimum number of steps to record/buffer due to mindelay
- Report tstop is now the minimum between the duration of the simulation and the report EndTime