### PR TITLE
Gap junction fix

### DIFF
--- a/coreneuron/mech/modfile/hh.mod
+++ b/coreneuron/mech/modfile/hh.mod
@@ -24,7 +24,7 @@ NEURON {
         SUFFIX hh
         USEION na READ ena WRITE ina
         USEION k READ ek WRITE ik
-        ELECTRODE_CURRENT il
+        NONSPECIFIC_CURRENT il
         RANGE gnabar, gkbar, gl, el, gna, gk
         :GLOBAL minf, hinf, ninf, mtau, htau, ntau
         RANGE minf, hinf, ninf, mtau, htau, ntau

--- a/coreneuron/mech/modfile/hh.mod
+++ b/coreneuron/mech/modfile/hh.mod
@@ -24,7 +24,7 @@ NEURON {
         SUFFIX hh
         USEION na READ ena WRITE ina
         USEION k READ ek WRITE ik
-        NONSPECIFIC_CURRENT il
+        ELECTRODE_CURRENT il
         RANGE gnabar, gkbar, gl, el, gna, gk
         :GLOBAL minf, hinf, ninf, mtau, htau, ntau
         RANGE minf, hinf, ninf, mtau, htau, ntau

--- a/coreneuron/nrniv/nrn_filehandler.cpp
+++ b/coreneuron/nrniv/nrn_filehandler.cpp
@@ -43,7 +43,7 @@ int str_ends_with(const char *s, const char *suffix) {
     return suffix_len <= slen && !strcmp(s + slen - suffix_len, suffix);
 }
 
-bool FileHandler::open(const char* filename, bool reorder, std::ios::openmode mode) {
+void FileHandler::open(const char* filename, bool reorder, std::ios::openmode mode) {
     nrn_assert((mode & (std::ios::in | std::ios::out)));
     reorder_bytes = reorder;
     close();
@@ -52,7 +52,7 @@ bool FileHandler::open(const char* filename, bool reorder, std::ios::openmode mo
         fprintf(stderr, "cannot open file %s\n", filename);
     nrn_assert(F.is_open() || str_ends_with(filename, "_gap.dat"));
     if (!F.is_open() && str_ends_with(filename, "_gap.dat")) {
-        return false;
+        return;
     }
     current_mode = mode;
     char version[256];
@@ -64,7 +64,6 @@ bool FileHandler::open(const char* filename, bool reorder, std::ios::openmode mo
     if (current_mode & std::ios::out) {
         F << bbcore_write_version << "\n";
     }
-    return true;
 }
 
 bool FileHandler::eof() {

--- a/coreneuron/nrniv/nrn_filehandler.cpp
+++ b/coreneuron/nrniv/nrn_filehandler.cpp
@@ -36,14 +36,21 @@ FileHandler::FileHandler(const char* filename, bool reorder) {
     stored_chkpnt = 0;
 }
 
+int str_ends_with(const char *s, const char *suffix) {
+    size_t slen = strlen(s);
+    size_t suffix_len = strlen(suffix);
+
+    return suffix_len <= slen && !strcmp(s + slen - suffix_len, suffix);
+}
+
 void FileHandler::open(const char* filename, bool reorder, std::ios::openmode mode) {
     nrn_assert((mode & (std::ios::in | std::ios::out)));
     reorder_bytes = reorder;
     close();
     F.open(filename, mode | std::ios::binary);
-    if (!F.is_open())
+    if (!F.is_open() && !str_ends_with(filename, "_gap.dat"))
         fprintf(stderr, "cannot open file %s\n", filename);
-    nrn_assert(F.is_open());
+    nrn_assert(F.is_open() && !str_ends_with(filename, "_gap.dat"));
     current_mode = mode;
     char version[256];
     if (current_mode & std::ios::in) {

--- a/coreneuron/nrniv/nrn_filehandler.cpp
+++ b/coreneuron/nrniv/nrn_filehandler.cpp
@@ -43,7 +43,7 @@ int str_ends_with(const char *s, const char *suffix) {
     return suffix_len <= slen && !strcmp(s + slen - suffix_len, suffix);
 }
 
-void FileHandler::open(const char* filename, bool reorder, std::ios::openmode mode) {
+bool FileHandler::open(const char* filename, bool reorder, std::ios::openmode mode) {
     nrn_assert((mode & (std::ios::in | std::ios::out)));
     reorder_bytes = reorder;
     close();
@@ -51,6 +51,9 @@ void FileHandler::open(const char* filename, bool reorder, std::ios::openmode mo
     if (!F.is_open() && !str_ends_with(filename, "_gap.dat"))
         fprintf(stderr, "cannot open file %s\n", filename);
     nrn_assert(F.is_open() || str_ends_with(filename, "_gap.dat"));
+    if (!F.is_open() && !str_ends_with(filename, "_gap.dat")) {
+        return false;
+    }
     current_mode = mode;
     char version[256];
     if (current_mode & std::ios::in) {
@@ -61,6 +64,7 @@ void FileHandler::open(const char* filename, bool reorder, std::ios::openmode mo
     if (current_mode & std::ios::out) {
         F << bbcore_write_version << "\n";
     }
+    return true;
 }
 
 bool FileHandler::eof() {

--- a/coreneuron/nrniv/nrn_filehandler.cpp
+++ b/coreneuron/nrniv/nrn_filehandler.cpp
@@ -51,7 +51,7 @@ bool FileHandler::open(const char* filename, bool reorder, std::ios::openmode mo
     if (!F.is_open() && !str_ends_with(filename, "_gap.dat"))
         fprintf(stderr, "cannot open file %s\n", filename);
     nrn_assert(F.is_open() || str_ends_with(filename, "_gap.dat"));
-    if (!F.is_open() && !str_ends_with(filename, "_gap.dat")) {
+    if (!F.is_open() && str_ends_with(filename, "_gap.dat")) {
         return false;
     }
     current_mode = mode;

--- a/coreneuron/nrniv/nrn_filehandler.cpp
+++ b/coreneuron/nrniv/nrn_filehandler.cpp
@@ -50,7 +50,7 @@ void FileHandler::open(const char* filename, bool reorder, std::ios::openmode mo
     F.open(filename, mode | std::ios::binary);
     if (!F.is_open() && !str_ends_with(filename, "_gap.dat"))
         fprintf(stderr, "cannot open file %s\n", filename);
-    nrn_assert(F.is_open() && !str_ends_with(filename, "_gap.dat"));
+    nrn_assert(F.is_open() || str_ends_with(filename, "_gap.dat"));
     current_mode = mode;
     char version[256];
     if (current_mode & std::ios::in) {

--- a/coreneuron/nrniv/nrn_filehandler.cpp
+++ b/coreneuron/nrniv/nrn_filehandler.cpp
@@ -36,11 +36,9 @@ FileHandler::FileHandler(const char* filename, bool reorder) {
     stored_chkpnt = 0;
 }
 
-int str_ends_with(const char *s, const char *suffix) {
-    size_t slen = strlen(s);
-    size_t suffix_len = strlen(suffix);
-
-    return suffix_len <= slen && !strcmp(s + slen - suffix_len, suffix);
+bool FileHandler::file_exist(const char* filename) const {
+    struct stat buffer;
+    return (stat(filename, &buffer) == 0);
 }
 
 void FileHandler::open(const char* filename, bool reorder, std::ios::openmode mode) {
@@ -48,12 +46,9 @@ void FileHandler::open(const char* filename, bool reorder, std::ios::openmode mo
     reorder_bytes = reorder;
     close();
     F.open(filename, mode | std::ios::binary);
-    if (!F.is_open() && !str_ends_with(filename, "_gap.dat"))
+    if (!F.is_open())
         fprintf(stderr, "cannot open file %s\n", filename);
-    nrn_assert(F.is_open() || str_ends_with(filename, "_gap.dat"));
-    if (!F.is_open() && str_ends_with(filename, "_gap.dat")) {
-        return;
-    }
+    nrn_assert(F.is_open());
     current_mode = mode;
     char version[256];
     if (current_mode & std::ios::in) {

--- a/coreneuron/nrniv/nrn_filehandler.h
+++ b/coreneuron/nrniv/nrn_filehandler.h
@@ -78,7 +78,7 @@ class FileHandler {
     explicit FileHandler(const char* filename, bool reorder = false);
 
     /** Preserving chkpnt state, move to a new file. */
-    void open(const char* filename, bool reorder, std::ios::openmode mode = std::ios::in);
+    bool open(const char* filename, bool reorder, std::ios::openmode mode = std::ios::in);
 
     /** Is the file not open */
     bool fail() const {

--- a/coreneuron/nrniv/nrn_filehandler.h
+++ b/coreneuron/nrniv/nrn_filehandler.h
@@ -78,7 +78,7 @@ class FileHandler {
     explicit FileHandler(const char* filename, bool reorder = false);
 
     /** Preserving chkpnt state, move to a new file. */
-    bool open(const char* filename, bool reorder, std::ios::openmode mode = std::ios::in);
+    void open(const char* filename, bool reorder, std::ios::openmode mode = std::ios::in);
 
     /** Is the file not open */
     bool fail() const {

--- a/coreneuron/nrniv/nrn_filehandler.h
+++ b/coreneuron/nrniv/nrn_filehandler.h
@@ -32,6 +32,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <sys/stat.h>
 #include "coreneuron/utils/endianness.h"
 #include "coreneuron/utils/swap_endian.h"
 #include "coreneuron/nrniv/nrn_assert.h"
@@ -84,6 +85,8 @@ class FileHandler {
     bool fail() const {
         return F.fail();
     }
+
+    bool file_exist(const char* filename) const;
 
     /** nothing more to read */
     bool eof();

--- a/coreneuron/nrniv/nrn_setup.h
+++ b/coreneuron/nrniv/nrn_setup.h
@@ -134,9 +134,6 @@ inline void* phase_wrapper_w(NrnThread* nt) {
             // Avoid trying to open the gid_gap.dat file if it doesn't exist when there are no
             // gap junctions in this gid
             if (P == gap && !file_reader_w[i].file_exist(fname)) {
-                std::cout << gidgroups_w[i] << "_gap.dat"
-                          << " doesn't exist. " << gidgroups_w[i]
-                          << " hasn't got any gap junctions.\n";
                 file_reader_w[i].close();
             } else {
                 // if no file failed to open or not opened at all

--- a/coreneuron/nrniv/nrn_setup.h
+++ b/coreneuron/nrniv/nrn_setup.h
@@ -115,6 +115,7 @@ template <phase P>
 inline void* phase_wrapper_w(NrnThread* nt) {
     bool no_open = do_not_open;
     int i = nt->id;
+    bool ret = true;
     char fnamebuf[1000];
     char check_fnamebuf[1000] = "";
     if (i < ngroup_w) {
@@ -132,9 +133,11 @@ inline void* phase_wrapper_w(NrnThread* nt) {
                                     data_dir, gidgroups_w[i]);
 
             // if no file failed to open or not opened at all
-            file_reader_w[i].open(fname, byte_swap_w);
+            ret = file_reader_w[i].open(fname, byte_swap_w);
         }
-        read_phase_aux<P>(file_reader_w[i], imult_w[i], *nt);
+        if (P == gap && ret) {
+            read_phase_aux<P>(file_reader_w[i], imult_w[i], *nt);
+        }
         if (!no_open) {
             file_reader_w[i].close();
         }

--- a/coreneuron/nrniv/nrn_setup.h
+++ b/coreneuron/nrniv/nrn_setup.h
@@ -134,8 +134,10 @@ inline void* phase_wrapper_w(NrnThread* nt) {
             // Avoid trying to open the gid_gap.dat file if it doesn't exist when there are no
             // gap junctions in this gid
             if (P == gap && !file_reader_w[i].file_exist(fname)) {
-                std::cout << fname.get() << " doesn't exist. " << gidgroups_w[i]
+                std::cout << gidgroups_w[i] << "_gap.dat"
+                          << " doesn't exist. " << gidgroups_w[i]
                           << " hasn't got any gap junctions.\n";
+                file_reader_w[i].close();
             } else {
                 // if no file failed to open or not opened at all
                 file_reader_w[i].open(fname, byte_swap_w);

--- a/coreneuron/nrniv/nrn_setup.h
+++ b/coreneuron/nrniv/nrn_setup.h
@@ -131,8 +131,15 @@ inline void* phase_wrapper_w(NrnThread* nt) {
                                     std::string("%s/%d_" + getPhaseName<P>() + ".dat").c_str(),
                                     data_dir, gidgroups_w[i]);
 
-            // if no file failed to open or not opened at all
-            file_reader_w[i].open(fname, byte_swap_w);
+            // Avoid trying to open the gid_gap.dat file if it doesn't exist when there are no
+            // gap junctions in this gid
+            if (P == gap && !file_reader_w[i].file_exist(fname)) {
+                std::cout << fname.get() << " doesn't exist. " << gidgroups_w[i]
+                          << " hasn't got any gap junctions.\n";
+            } else {
+                // if no file failed to open or not opened at all
+                file_reader_w[i].open(fname, byte_swap_w);
+            }
         }
         read_phase_aux<P>(file_reader_w[i], imult_w[i], *nt);
         if (!no_open) {

--- a/coreneuron/nrniv/nrn_setup.h
+++ b/coreneuron/nrniv/nrn_setup.h
@@ -115,7 +115,6 @@ template <phase P>
 inline void* phase_wrapper_w(NrnThread* nt) {
     bool no_open = do_not_open;
     int i = nt->id;
-    bool ret = true;
     char fnamebuf[1000];
     char check_fnamebuf[1000] = "";
     if (i < ngroup_w) {
@@ -133,7 +132,7 @@ inline void* phase_wrapper_w(NrnThread* nt) {
                                     data_dir, gidgroups_w[i]);
 
             // if no file failed to open or not opened at all
-            ret = file_reader_w[i].open(fname, byte_swap_w);
+            file_reader_w[i].open(fname, byte_swap_w);
         }
         read_phase_aux<P>(file_reader_w[i], imult_w[i], *nt);
         if (!no_open) {

--- a/coreneuron/nrniv/nrn_setup.h
+++ b/coreneuron/nrniv/nrn_setup.h
@@ -135,9 +135,7 @@ inline void* phase_wrapper_w(NrnThread* nt) {
             // if no file failed to open or not opened at all
             ret = file_reader_w[i].open(fname, byte_swap_w);
         }
-        if (P == gap && ret) {
-            read_phase_aux<P>(file_reader_w[i], imult_w[i], *nt);
-        }
+        read_phase_aux<P>(file_reader_w[i], imult_w[i], *nt);
         if (!no_open) {
             file_reader_w[i].close();
         }

--- a/coreneuron/nrniv/partrans.h
+++ b/coreneuron/nrniv/partrans.h
@@ -16,10 +16,10 @@ typedef int sgid_t;
 #endif
 
 struct HalfGap_Info {
-    int layout;
-    int type;
-    int ix_vpre; /* AoS index for vpre from beginning of a HalfGap instance */
-    int sz;      /* size of a HalfGap instance */
+    int layout = 0;
+    int type = 0;
+    int ix_vpre = 0; /* AoS index for vpre from beginning of a HalfGap instance */
+    int sz = 0;      /* size of a HalfGap instance */
 };
 extern HalfGap_Info* halfgap_info;
 
@@ -27,24 +27,24 @@ class TransferThreadData {
   public:
     TransferThreadData();
     ~TransferThreadData();
-    Memb_list* halfgap_ml;
-    int nsrc;             // number of places in outsrc_buf_ voltages get copied to.
-    int ntar;             // insrc_indices size (halfgap_ml->nodecount);
-    int* insrc_indices;   // halfgap_ml->nodecount indices into insrc_buf_
-    int* v_indices;       // indices into NrnThread._actual_v (may have duplications).
-    int* outbuf_indices;  // indices into outsrc_buf_
-    double* v_gather;     // _actual_v[v_indices]
+    Memb_list* halfgap_ml = nullptr;
+    int nsrc = 0;             // number of places in outsrc_buf_ voltages get copied to.
+    int ntar = 0;             // insrc_indices size (halfgap_ml->nodecount);
+    int* insrc_indices = nullptr;   // halfgap_ml->nodecount indices into insrc_buf_
+    int* v_indices = nullptr;       // indices into NrnThread._actual_v (may have duplications).
+    int* outbuf_indices = nullptr;  // indices into outsrc_buf_
+    double* v_gather = nullptr;     // _actual_v[v_indices]
 };
 extern TransferThreadData* transfer_thread_data_; /* array for threads */
 
 struct SetupInfo {
-    int nsrc;  // number of sources in this thread
-    int ntar;  // equal to memb_list nodecount
-    int type;
-    int ix_vpre;
-    sgid_t* sid_src;
-    int* v_indices;      // increasing order
-    sgid_t* sid_target;  // aleady in memb_list order
+    int nsrc = 0;  // number of sources in this thread
+    int ntar = 0;  // equal to memb_list nodecount
+    int type = 0;
+    int ix_vpre = 0;
+    sgid_t* sid_src = nullptr;
+    int* v_indices = nullptr;      // increasing order
+    sgid_t* sid_target = nullptr;  // aleady in memb_list order
 };
 extern SetupInfo* setup_info_; /* array for threads exists only during setup*/
 

--- a/coreneuron/nrniv/partrans.h
+++ b/coreneuron/nrniv/partrans.h
@@ -27,13 +27,13 @@ class TransferThreadData {
   public:
     TransferThreadData();
     ~TransferThreadData();
-    Memb_list* halfgap_ml = nullptr;
-    int nsrc = 0;             // number of places in outsrc_buf_ voltages get copied to.
-    int ntar = 0;             // insrc_indices size (halfgap_ml->nodecount);
-    int* insrc_indices = nullptr;   // halfgap_ml->nodecount indices into insrc_buf_
-    int* v_indices = nullptr;       // indices into NrnThread._actual_v (may have duplications).
-    int* outbuf_indices = nullptr;  // indices into outsrc_buf_
-    double* v_gather = nullptr;     // _actual_v[v_indices]
+    Memb_list* halfgap_ml;
+    int nsrc;             // number of places in outsrc_buf_ voltages get copied to.
+    int ntar;             // insrc_indices size (halfgap_ml->nodecount);
+    int* insrc_indices;   // halfgap_ml->nodecount indices into insrc_buf_
+    int* v_indices;       // indices into NrnThread._actual_v (may have duplications).
+    int* outbuf_indices;  // indices into outsrc_buf_
+    double* v_gather;     // _actual_v[v_indices]
 };
 extern TransferThreadData* transfer_thread_data_; /* array for threads */
 

--- a/coreneuron/nrniv/partrans_setup.cpp
+++ b/coreneuron/nrniv/partrans_setup.cpp
@@ -60,7 +60,7 @@ void nrn_partrans::gap_mpi_setup(int ngroup) {
 
     // This can happen until bug is fixed. ie. if one process has more than
     // one thread then all processes must have more than one thread
-    if (ngroup < nrn_nthread) {
+    if (ngroup < nrn_nthread || si.ntar != 0 ) {
         transfer_thread_data_[ngroup].nsrc = 0;
         transfer_thread_data_[ngroup].halfgap_ml = NULL;
     }
@@ -231,9 +231,11 @@ void nrn_partrans::gap_mpi_setup(int ngroup) {
     // cleanup
     for (int tid = 0; tid < ngroup; ++tid) {
         SetupInfo& si = setup_info_[tid];
-        delete[] si.sid_src;
-        delete[] si.v_indices;
-        delete[] si.sid_target;
+        if (si.ntar) {
+            delete[] si.sid_src;
+            delete[] si.v_indices;
+            delete[] si.sid_target;
+        }
     }
     delete[] send_to_want;
     delete[] recv_from_have;

--- a/coreneuron/nrniv/partrans_setup.cpp
+++ b/coreneuron/nrniv/partrans_setup.cpp
@@ -60,7 +60,7 @@ void nrn_partrans::gap_mpi_setup(int ngroup) {
 
     // This can happen until bug is fixed. ie. if one process has more than
     // one thread then all processes must have more than one thread
-    if (ngroup < nrn_nthread || si.ntar != 0 ) {
+    if (ngroup < nrn_nthread) {
         transfer_thread_data_[ngroup].nsrc = 0;
         transfer_thread_data_[ngroup].halfgap_ml = NULL;
     }
@@ -246,7 +246,11 @@ void nrn_partrans::gap_thread_setup(NrnThread& nt) {
     // printf("%d gap_thread_setup tid=%d\n", nrnmpi_myid, nt.id);
     nrn_partrans::TransferThreadData& ttd = transfer_thread_data_[nt.id];
 
-    ttd.halfgap_ml = nt._ml_list[halfgap_info->type];
+    if (transfer_thread_data_[nt.id].ntar) {
+        ttd.halfgap_ml = nt._ml_list[halfgap_info->type];
+    } else {
+        ttd.halfgap_ml = nullptr;
+    }
 #if 0
   int ntar = ttd.halfgap_ml->nodecount;
   assert(ntar == ttd.ntar);


### PR DESCRIPTION
Fixes issue where `CoreNeuron` crashed when it didn't find a `<gid>_gap.dat` because this `gid` didn't have any gap junctions.

Thanks @pramodk for the help!

- Fixes #206 