### PR TITLE
use phase name to close the profiling phase

### DIFF
--- a/coreneuron/nrniv/profiler_interface.h
+++ b/coreneuron/nrniv/profiler_interface.h
@@ -279,11 +279,12 @@ using InstrumentorImpl = detail::Instrumentor<
 
 namespace Instrumentor {
 struct phase {
-    phase(const char* name) {
-        detail::InstrumentorImpl::phase_begin(name);
+    const char * phase_name;
+    phase(const char* name) : phase_name(name) {
+        detail::InstrumentorImpl::phase_begin(phase_name);
     }
     ~phase() {
-        detail::InstrumentorImpl::phase_end("");
+        detail::InstrumentorImpl::phase_end(phase_name);
     }
 };
 


### PR DESCRIPTION
Profiling tools such as LIKWID require the name of the phases at beginning and end of the profiling to match, in order to allow e.g. for nested phases.
So we are now storing the phase name at construction, to re-use it during destruction.