### PR TITLE
nrnivmodl-core: adding -n name and dropping install script

### DIFF
--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -184,9 +184,9 @@ set_target_properties(coreneuron corenrnmech scopmath ${link_cudacoreneuron}
 # =============================================================================
 add_custom_command(TARGET coreneuron
                    POST_BUILD
-                   COMMAND ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core -i
-                           "-I${CORENEURON_PROJECT_SOURCE_DIR} -I${CORENRN_NMODL_INCLUDE}"
-                           -n ${CORENRN_NMODL_BINARY}
+                   COMMAND ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core
+                           -i "-I${CORENEURON_PROJECT_SOURCE_DIR} -I${CORENRN_NMODL_INCLUDE}"
+                           -m "${CORENRN_NMODL_BINARY}"
                            ${CORENEURON_PROJECT_SOURCE_DIR}/tests/integration/ring_gap/mod
                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
                    BYPRODUCTS ${CMAKE_BINARY_DIR}/bin/${CMAKE_SYSTEM_PROCESSOR}/special-core

--- a/extra/CMakeLists.txt
+++ b/extra/CMakeLists.txt
@@ -65,7 +65,7 @@ set(nmodl_binary_name ${nmodl_name})
 # =============================================================================
 
 configure_file(nrnivmodl_core_makefile.in ${CMAKE_BINARY_DIR}/share/coreneuron/nrnivmodl_core_makefile @ONLY)
-configure_file(nrnivmodl-core ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core COPYONLY)
+configure_file(nrnivmodl-core.in ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core @ONLY)
 
 install(FILES ${CMAKE_BINARY_DIR}/share/coreneuron/nrnivmodl_core_makefile DESTINATION share/coreneuron)
 install(PROGRAMS ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core DESTINATION bin)

--- a/extra/nrnivmodl-core.in
+++ b/extra/nrnivmodl-core.in
@@ -8,15 +8,18 @@ set -e
 APP_NAME=$(basename $0)
 _PARENT="$(dirname $BASH_SOURCE)/.."
 ROOTDIR=$(perl -e "use Cwd 'abs_path'; print abs_path('$_PARENT')")
-MAKE_OPTIONS="NMODL_BINARY OUTPUT INCFLAGS LINKFLAGS MODS_PATH VERBOSE"
+MAKE_OPTIONS="MECH_NAME NMODL_BINARY DESTDIR INCFLAGS LINKFLAGS MODS_PATH VERBOSE"
 PARALLELISM=4
+SAVE_FILE="@CMAKE_HOST_SYSTEM_PROCESSOR@/nrnivmodl_options.txt"
 
-while getopts "n:v:o:i:l:p:hV" OPT; do
+while getopts "n:m:v:d:i:l:p:hV" OPT; do
     case "$OPT" in
     n)
+        params_MECH_NAME="$OPTARG";;
+    m)
         params_NMODL_BINARY="$OPTARG";;
-    o)
-        params_OUTPUT="$OPTARG";;
+    d)
+        params_DESTDIR="$OPTARG";;
     i)
         params_INCFLAGS="$OPTARG";;
     l)
@@ -28,10 +31,12 @@ while getopts "n:v:o:i:l:p:hV" OPT; do
     h)
         echo "$APP_NAME [options, ...] [mods_path]"
         echo "Options:"
-        echo "  -n <binary>     NMODL code generation compiler path"
-        echo "  -o <output_dir> Set the output dir (default: <arch>-core)"
+        echo "  -n <name>       The model name, used as a suffix in the shared library"
+        echo "  -m <mod2c_bin>  NMODL code generation compiler path"
         echo "  -i <incl_flags> Definitions passed to the compiler, typically '-I dir..'"
         echo "  -l <link_flags> Definitions passed to the linker, typically '-Lx -lylib..'"
+        echo "  -d <dest_dir>   Install to dest_dir. Default: off - Only build in {ARCH}"\
+             "        Consider using this option on a second call. Params are preserved."
         echo "  -V              Verbose: show commands executed by make"
         echo "  -p <n_procs>    Make parallelism. Default: 4"
         exit 0;;
@@ -47,33 +52,39 @@ if [ $# -gt 1 ]; then
     exit 1
 fi
 
+# To support build + install later we save/restore options
+# Attempt to load previous definitions
+if [ -f "$SAVE_FILE" ]; then
+    while read line; do
+        echo "$line"
+        eval "$line"
+    done < "$SAVE_FILE"
+fi
+
 # If defined mods dir be in $1
 # Note: due to bug #712 makefile wont handle mod dir with spaces, so we let it fail here
 params_MODS_PATH=$1
+
+mkdir -p $(dirname "$SAVE_FILE")
+echo "# nrnivmodl-core options. Mods location: $params_MODS_PATH" > $SAVE_FILE
 
 make_params=("ROOT=${ROOTDIR}")
 
 for param in $MAKE_OPTIONS; do
     var="params_${param}"
-    [ "${!var+x}" ] && make_params+=("$param=${!var}")
+    if [ "${!var+x}" ]; then
+        make_params+=("$param=${!var}")
+        echo "$var=${!var}" >> $SAVE_FILE
+    fi
 done
 
+# If -I (install) provided, call "make install"
+if [ "$params_DESTDIR" ]; then
+    make_params+=("install")
+fi
+
 # warn if no mod files provided
-ls "${params_MODS_PATH:-.}"/*.mod || echo "Warning: No mods found!"
+ls "${params_MODS_PATH:-.}"/*.mod || echo "WARNING: No mods found!"
 make -j$PARALLELISM -f "${ROOTDIR}/share/coreneuron/nrnivmodl_core_makefile" "${make_params[@]}"
 
-# Create a little script to call make install (relinks w right RPATH)
-# This should allow splitting the build of special-core into two phases:
-# 1. build the binary from the libcoreneuron.so library and the compiled models
-# 2. install into the final destination directory and relinking as necessary
-# TODO: instead of outputting a script we could output an options file which would be read by
-# this script when installing to ensure the same arguments are being used.
-echo "#!/bin/bash
-set -e
-[ \$# -eq 1 ] || { echo 'Required install destination. Syntax: ' \$(basename \$0) '<directory>'; false; }
-set -x
-make -f '${ROOTDIR}/share/coreneuron/nrnivmodl_core_makefile' " $(printf "'%s' " "${make_params[@]}") "DESTDIR=\$1 install
-" > nrnivmech_install.sh
-chmod 755 nrnivmech_install.sh
-
-echo "mods built successfully. Install script written to nrnivmech_install.sh"
+echo "mods built successfully."

--- a/extra/nrnivmodl-core.in
+++ b/extra/nrnivmodl-core.in
@@ -65,7 +65,7 @@ fi
 # Note: due to bug #712 makefile wont handle mod dir with spaces, so we let it fail here
 params_MODS_PATH=$1
 
-mkdir -p $(dirname "$SAVE_FILE")
+mkdir -p "$(dirname "$SAVE_FILE")"
 echo "# nrnivmodl-core options. Mods location: $params_MODS_PATH" > $SAVE_FILE
 
 make_params=("ROOT=${ROOTDIR}")
@@ -74,9 +74,9 @@ for param in $MAKE_OPTIONS; do
     var="params_${param}"
     if [ "${!var+x}" ]; then
         make_params+=("$param=${!var}")
-        echo "$var=${!var}" >> $SAVE_FILE
+        echo "$var=\"${!var}\""
     fi
-done
+done >> "$SAVE_FILE"
 
 # If -I (install) provided, call "make install"
 if [ "$params_DESTDIR" ]; then

--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -5,6 +5,7 @@
 
 # Mechanisms version are by default 0.0, but should be overriden
 
+MECH_NAME =
 MODS_PATH = .
 OUTPUT = @CMAKE_HOST_SYSTEM_PROCESSOR@
 DESTDIR =
@@ -90,7 +91,7 @@ dimplic_c  = $(MODC_DIR)/_dimplic.cpp
 dimplic_o  = $(OBJS_DIR)/_dimplic.o
 
 special  = $(OUTPUT)/special-core
-coremech_libname = corenrnmech
+coremech_libname = corenrnmech$(if $(MECH_NAME),_$(MECH_NAME),)
 coremech_lib = $(OUTPUT)/lib$(coremech_libname)@CMAKE_SHARED_LIBRARY_SUFFIX@
 
 # If no DESTDIR (we are probably just building) we use $ORIGIN (@loader_path in OSX)

--- a/tests/jenkins/nrnivmodl-core.sh
+++ b/tests/jenkins/nrnivmodl-core.sh
@@ -6,10 +6,20 @@ set -e
 module load intel hpe-mpi
 TEST_DIR="$1"
 CORENRN_TYPE="$2"
+
 cd $WORKSPACE/${TEST_DIR}
-rm -rf $WORKSPACE/${TEST_DIR}/${CORENRN_TYPE}
+rm -rf ${CORENRN_TYPE}
+mkdir -p ${CORENRN_TYPE}
+
+pushd ${CORENRN_TYPE}
+
 if [ "${TEST_DIR}" = "ringtest" ]; then
-    $WORKSPACE/install_${CORENRN_TYPE}/bin/nrnivmodl-core -o ${CORENRN_TYPE} mod-ext
+    $WORKSPACE/install_${CORENRN_TYPE}/bin/nrnivmodl-core ../mod-ext
 else
-    $WORKSPACE/install_${CORENRN_TYPE}/bin/nrnivmodl-core -o ${CORENRN_TYPE} mod
+    $WORKSPACE/install_${CORENRN_TYPE}/bin/nrnivmodl-core ../mod
 fi
+
+# rpath $ORIGIN should make it relocatable
+find * -mindepth 1 -maxdepth 1 -type f -exec mv "{}" ./ \;
+
+popd


### PR DESCRIPTION
Install script was transformed into a config file being saved/loaded