### PR TITLE
fix for checkpoint saving issue in neurodamus-py:

### DIFF
--- a/coreneuron/nrniv/nrn_checkpoint.cpp
+++ b/coreneuron/nrniv/nrn_checkpoint.cpp
@@ -428,21 +428,26 @@ static void write_phase2(NrnThread& nt, FileHandlerWrap& fh) {
     for (int i = 0; i < nnetcon; ++i) {
         NetCon& nc = nt.netcons[i];
         Point_process* pnt = nc.target_;
-        assert(pnt);  // nrn_setup.cpp allows type <=0 which generates nullptr target.
-        pnttype[i] = pnt->_type;
+        if (pnt == nullptr) {
+            // nrn_setup.cpp allows type <=0 which generates nullptr target.
+            pnttype[i] = 0;
+            pntindex[i] = -1;
+        } else {
+            pnttype[i] = pnt->_type;
 
 #if 0
-        // todo: this seems most natural, but does not work. Perhaps should look
-        // into how pntindex determined in nrnbbcore_write.cpp and change there.
-        int ix = pnt->_i_instance;
-        if (ml_pinv[pnt->_type]) {
-            ix = ml_pinv[pnt->_type][ix];
-        }
+            // todo: this seems most natural, but does not work. Perhaps should look
+            // into how pntindex determined in nrnbbcore_write.cpp and change there.
+            int ix = pnt->_i_instance;
+            if (ml_pinv[pnt->_type]) {
+                ix = ml_pinv[pnt->_type][ix];
+            }
 #else
-        // follow the inverse of nrn_setup.cpp using pnt_offset computed above.
-        int ix = (pnt - nt.pntprocs) - pnt_offset[pnt->_type];
+            // follow the inverse of nrn_setup.cpp using pnt_offset computed above.
+            int ix = (pnt - nt.pntprocs) - pnt_offset[pnt->_type];
 #endif
-        pntindex[i] = ix;
+            pntindex[i] = ix;
+        }
         delay[i] = nc.delay_;
     }
     fh.write_array<int>(pnttype, nnetcon);

--- a/coreneuron/nrniv/nrn_checkpoint.cpp
+++ b/coreneuron/nrniv/nrn_checkpoint.cpp
@@ -435,17 +435,15 @@ static void write_phase2(NrnThread& nt, FileHandlerWrap& fh) {
         } else {
             pnttype[i] = pnt->_type;
 
-#if 0
             // todo: this seems most natural, but does not work. Perhaps should look
             // into how pntindex determined in nrnbbcore_write.cpp and change there.
-            int ix = pnt->_i_instance;
-            if (ml_pinv[pnt->_type]) {
-                ix = ml_pinv[pnt->_type][ix];
-            }
-#else
+            // int ix = pnt->_i_instance;
+            // if (ml_pinv[pnt->_type]) {
+            //     ix = ml_pinv[pnt->_type][ix];
+            // }
+
             // follow the inverse of nrn_setup.cpp using pnt_offset computed above.
             int ix = (pnt - nt.pntprocs) - pnt_offset[pnt->_type];
-#endif
             pntindex[i] = ix;
         }
         delay[i] = nc.delay_;


### PR DESCRIPTION
  NetCon with no target is allowed  in checkpoint
  set to pnttype = 0 and pntindex = -1