### PR TITLE
Fix Jenkins plan manual launch variable

### DIFF
--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
         label 'bb5'
     }
     parameters {
-        string(name: 'CORENEURON_BRANCH', defaultValue: '',
+        string(name: 'sha1', defaultValue: 'master',
                description: 'What branch of CoreNeuron to test.')
         string(name: 'SPACK_BRANCH', defaultValue: 'develop',
                description: 'Which branch of spack to use.')


### PR DESCRIPTION
I tried adding a new variable named `CORENEURON_BRANCH` and export it to the user to launch the CI based on that branch. Adding another branch to the `Git SCM` module of based on the `CORENEURON_BRANCH` variable while it seemed to work in the beginning, at some point broke and PRs were not launched with the correct branch.
Reverted the `sha1` variable and used only this to get the `Jenkinsfile` in jenkins configuration.