### PR TITLE
Auto checkpointing

### DIFF
--- a/coreneuron/io/file_utils.cpp
+++ b/coreneuron/io/file_utils.cpp
@@ -72,3 +72,13 @@ int mkdir_p(const char* path) {
     delete[] dirpath;
     return 0;
 }
+
+bool fs_exists(const char* path) {
+    struct stat buffer;
+    return (stat (path, &buffer) == 0);
+}
+
+bool fs_isdir(const char* path) {
+    struct stat buffer;
+    return (stat (path, &buffer) == 0 && S_ISDIR(buffer.st_mode));
+}

--- a/coreneuron/io/file_utils.hpp
+++ b/coreneuron/io/file_utils.hpp
@@ -41,4 +41,15 @@ THE POSSIBILITY OF SUCH DAMAGE.
  */
 int mkdir_p(const char* path);
 
+/**
+ * @brief Checks whether a path exists
+ */
+bool fs_exists(const char* path);
+
+/**
+ * @brief Checks whether a path is a directory
+ */
+bool fs_isdir(const char* path) ;
+
+
 #endif /* ifndef NRN_FILE_UTILS */

--- a/coreneuron/io/nrn_checkpoint.cpp
+++ b/coreneuron/io/nrn_checkpoint.cpp
@@ -896,4 +896,12 @@ bool checkpoint_initialize() {
 
     return checkpoint_restored_;
 }
+
+
+std::string get_checkpoint_path(const std::string& suffix) {
+    static std::string base_loc = nrnopt_get_str("--outpath");
+    return base_loc + "/checkpoint" + (suffix.empty()? "" : ("_" + suffix));
+}
+
+
 }  // namespace coreneuron

--- a/coreneuron/io/nrn_checkpoint.hpp
+++ b/coreneuron/io/nrn_checkpoint.hpp
@@ -54,6 +54,12 @@ bool checkpoint_initialize();
  */
 double restore_time(const char* restore_path);
 
+/**
+ * @return The checkpoint path, optionally with a suffix
+ */
+std::string get_checkpoint_path(const std::string& suffix="");
+
+
 extern int patstimtype;
 
 #ifndef CHKPNTDEBUG

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -677,6 +677,9 @@ void nrn_setup_cleanup() {
 void nrn_setup(const char* filesdat,
                bool is_mapping_needed,
                int byte_swap,
+               double & min_delay,
+               const std::string& datapath,
+               std::string restore_path,
                bool run_setup_cleanup) {
     /// Number of local cell groups
     int ngroup = 0;
@@ -738,9 +741,6 @@ void nrn_setup(const char* filesdat,
 
     FileHandler* file_reader = new FileHandler[ngroup];
 
-    std::string datapath = nrnopt_get_str("--datpath");
-    std::string restore_path = nrnopt_get_str("--restore");
-
     // if not restoring then phase2 files will be read from dataset directory
     if (!restore_path.length()) {
         restore_path = datapath;
@@ -788,8 +788,8 @@ void nrn_setup(const char* filesdat,
     if (is_mapping_needed)
         coreneuron::phase_wrapper<(coreneuron::phase)3>();
 
-    double mindelay = set_mindelay(nrnopt_get_dbl("--mindelay"));
-    nrnopt_modify_dbl("--mindelay", mindelay);
+    // Set and adjust min_delay
+    min_delay = set_mindelay(min_delay);
 
     if (run_setup_cleanup)  // if run_setup_cleanup==false, user must call nrn_setup_cleanup() later
         nrn_setup_cleanup();

--- a/coreneuron/nrniv/nrniv_decl.h
+++ b/coreneuron/nrniv/nrniv_decl.h
@@ -60,6 +60,9 @@ extern void nrn_p_construct(void);
 extern void nrn_setup(const char* filesdat,
                       bool is_mapping_needed,
                       int byte_swap,
+                      double & mindelay,
+                      const std::string& datapath,
+                      std::string restore_path = "",
                       bool run_setup_cleanup = true);
 extern double* stdindex2ptr(int mtype, int index, NrnThread&);
 extern void delete_trajectory_requests(NrnThread&);


### PR DESCRIPTION
This is WIP for a possible auto-checkpointing system.
The idea is to from time-to-time automatically create (& overwrite) previous checkpoints, so that in case a simulation fails after a long time not all progress gets lost.

TODO: As an extension to this concept, the coreneuron main could also detect SLURM allocation variables and program a checkpoint when the allocation time is about to expire.