### PR TITLE
Bugfix : Support for using CoreNEURON in embedded mode with external mechanisms

### DIFF
--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -126,25 +126,6 @@ char* prepare_args(int& argc, char**& argv, int use_mpi, const char* arg) {
     return first;
 }
 
-int corenrn_embedded_run(int nthread, int have_gaps, int use_mpi, int use_fast_imem, const char* arg) {
-    corenrn_embedded = true;
-    corenrn_embedded_nthread = nthread;
-    coreneuron::nrn_have_gaps = have_gaps != 0;
-    if (use_fast_imem != 0) {
-        coreneuron::nrn_use_fast_imem = true;
-    }
-
-    set_openmp_threads(nthread);
-    int argc = 0;
-    char** argv;
-    char* new_arg = prepare_args(argc, argv, use_mpi, arg);
-    mk_mech_init(argc, argv);
-    run_solve_core(argc, argv);
-    free(new_arg);
-    delete[] argv;
-
-    return corenrn_embedded ? 1 : 0;
-}
 }
 
 namespace coreneuron {

--- a/tests/jenkins/_env_setup.sh
+++ b/tests/jenkins/_env_setup.sh
@@ -9,7 +9,7 @@ INSTALL_HOME="${WORKSPACE}/INSTALL_HOME"
 export SPACK_ROOT="${BUILD_HOME}/spack"
 export SPACK_INSTALL_PREFIX="${SPACK_INSTALL_PREFIX:-${INSTALL_HOME}}"
 export SOFTS_DIR_PATH=$SPACK_INSTALL_PREFIX  # Deprecated, but might still be reqd
-export PATH=$SPACK_ROOT/bin:/usr/bin:$PATH
+export PATH=/usr/bin:$PATH
 
 if [ -d "$SPACK_ROOT" ]; then
     source $SPACK_ROOT/share/spack/setup-env.sh

--- a/tests/jenkins/_env_setup.sh
+++ b/tests/jenkins/_env_setup.sh
@@ -10,7 +10,7 @@ export SPACK_ROOT="${BUILD_HOME}/spack"
 export SPACK_INSTALL_PREFIX="${SPACK_INSTALL_PREFIX:-${INSTALL_HOME}}"
 export SOFTS_DIR_PATH=$SPACK_INSTALL_PREFIX  # Deprecated, but might still be reqd
 export PATH=$SPACK_ROOT/bin:/usr/bin:$PATH
-export MODULEPATH=$SPACK_INSTALL_PREFIX/modules/tcl/$(spack arch):$MODULEPATH
+source $SPACK_ROOT/share/spack/setup-env.sh
 
 # Common init
 unset $(env|awk -F= '/^(PMI|SLURM)_/ {if ($1 != "SLURM_ACCOUNT") print $1}')

--- a/tests/jenkins/_env_setup.sh
+++ b/tests/jenkins/_env_setup.sh
@@ -11,7 +11,7 @@ export SPACK_INSTALL_PREFIX="${SPACK_INSTALL_PREFIX:-${INSTALL_HOME}}"
 export SOFTS_DIR_PATH=$SPACK_INSTALL_PREFIX  # Deprecated, but might still be reqd
 export PATH=$SPACK_ROOT/bin:/usr/bin:$PATH
 
-if [ -d "$SPACK_ROOTY" ]; then
+if [ -d "$SPACK_ROOT" ]; then
     source $SPACK_ROOT/share/spack/setup-env.sh
 fi
 

--- a/tests/jenkins/_env_setup.sh
+++ b/tests/jenkins/_env_setup.sh
@@ -10,7 +10,10 @@ export SPACK_ROOT="${BUILD_HOME}/spack"
 export SPACK_INSTALL_PREFIX="${SPACK_INSTALL_PREFIX:-${INSTALL_HOME}}"
 export SOFTS_DIR_PATH=$SPACK_INSTALL_PREFIX  # Deprecated, but might still be reqd
 export PATH=$SPACK_ROOT/bin:/usr/bin:$PATH
-source $SPACK_ROOT/share/spack/setup-env.sh
+
+if [ -d "$SPACK_ROOTY" ]; then
+    source $SPACK_ROOT/share/spack/setup-env.sh
+fi
 
 # Common init
 unset $(env|awk -F= '/^(PMI|SLURM)_/ {if ($1 != "SLURM_ACCOUNT") print $1}')

--- a/tests/jenkins/install_neuron.sh
+++ b/tests/jenkins/install_neuron.sh
@@ -24,4 +24,8 @@ source ${JENKINS_DIR:-.}/_env_setup.sh
 set -x
 patch_neuron
 spack install neuron+debug@develop
+spack config get config
+spack config get modules
+module av neuron
+source $SPACK_ROOT/share/spack/setup-env.sh
 module av neuron

--- a/tests/jenkins/install_neuron.sh
+++ b/tests/jenkins/install_neuron.sh
@@ -24,5 +24,4 @@ source ${JENKINS_DIR:-.}/_env_setup.sh
 set -x
 patch_neuron
 spack install neuron+debug@develop
-ls $SPACK_INSTALL_PREFIX/modules/tcl/$(spack arch)/
 module av neuron

--- a/tests/jenkins/install_neuron.sh
+++ b/tests/jenkins/install_neuron.sh
@@ -24,4 +24,5 @@ source ${JENKINS_DIR:-.}/_env_setup.sh
 set -x
 patch_neuron
 spack install neuron+debug@develop
+ls $SPACK_INSTALL_PREFIX/modules/tcl/$(spack arch)/
 module av neuron

--- a/tests/jenkins/install_neuron.sh
+++ b/tests/jenkins/install_neuron.sh
@@ -21,11 +21,6 @@ patch_neuron() (
 set -e
 source ${JENKINS_DIR:-.}/_env_setup.sh
 
-set -x
 patch_neuron
 spack install neuron+debug@develop
-spack config get config
-spack config get modules
-module av neuron
-source $SPACK_ROOT/share/spack/setup-env.sh
 module av neuron

--- a/tests/jenkins/install_neuron.sh
+++ b/tests/jenkins/install_neuron.sh
@@ -23,4 +23,5 @@ source ${JENKINS_DIR:-.}/_env_setup.sh
 
 patch_neuron
 spack install neuron+debug@develop
+source $SPACK_ROOT/share/spack/setup-env.sh
 module av neuron

--- a/tests/jenkins/mod/CaDynamics_E2.mod
+++ b/tests/jenkins/mod/CaDynamics_E2.mod
@@ -1,0 +1,36 @@
+: Dynamics that track inside calcium concentration
+: modified from Destexhe et al. 1994
+
+NEURON	{
+	SUFFIX CaDynamics_E2
+	USEION ca READ ica WRITE cai
+	RANGE decay, gamma, minCai, depth
+}
+
+UNITS	{
+	(mV) = (millivolt)
+	(mA) = (milliamp)
+	FARADAY = (faraday) (coulombs)
+	(molar) = (1/liter)
+	(mM) = (millimolar)
+	(um)	= (micron)
+}
+
+PARAMETER	{
+	gamma = 0.05 : percent of free calcium (not buffered)
+	decay = 80 (ms) : rate of removal of calcium
+	depth = 0.1 (um) : depth of shell
+	minCai = 1e-4 (mM)
+}
+
+ASSIGNED	{ica (mA/cm2)}
+
+STATE	{
+	cai (mM)
+	}
+
+BREAKPOINT	{ SOLVE states METHOD cnexp }
+
+DERIVATIVE states	{
+	cai' = -(10000)*(ica*gamma/(2*FARADAY*depth)) - (cai - minCai)/decay
+}

--- a/tests/jenkins/neuron_direct.py
+++ b/tests/jenkins/neuron_direct.py
@@ -10,6 +10,9 @@ ic.delay = .5
 ic.dur = 0.1
 ic.amp = 0.3
 
+# for testing external mod file
+h.soma.insert("CaDynamics_E2")
+
 h.cvode.use_fast_imem(1)
 h.cvode.cache_efficient(1)
 

--- a/tests/jenkins/nrnivmodl.sh
+++ b/tests/jenkins/nrnivmodl.sh
@@ -2,7 +2,7 @@
 
 set -e
 source ${JENKINS_DIR:-.}/_env_setup.sh
-module load neuron
+module load neuron/develop
 
 set -x
 TEST_DIR="$1"

--- a/tests/jenkins/run_neuron_direct.sh
+++ b/tests/jenkins/run_neuron_direct.sh
@@ -2,7 +2,7 @@
 
 set -e
 source ${JENKINS_DIR:-.}/_env_setup.sh
-module load neuron intel
+module load neuron/develop intel
 
 set -x
 CORENRN_TYPE="$1"

--- a/tests/jenkins/run_neuron_direct.sh
+++ b/tests/jenkins/run_neuron_direct.sh
@@ -2,9 +2,24 @@
 
 set -e
 source ${JENKINS_DIR:-.}/_env_setup.sh
-module load neuron
+module load neuron intel
 
 set -x
 CORENRN_TYPE="$1"
-export CORENEURONLIB=$WORKSPACE/install_${CORENRN_TYPE}/lib/libcoreneuron.so
+export PATH=$WORKSPACE/install_${CORENRN_TYPE}/bin:$PATH
+
+# temporary build directory
+build_dir=$(mktemp -d $(pwd)/build_XXXX)
+cd $build_dir
+
+# build special and special-core
+nrnivmodl ../tests/jenkins/mod
+nrnivmodl-core ../tests/jenkins/mod
+ls -la x86_64
+
+# run test sim with external mechanism
 python $WORKSPACE/tests/jenkins/neuron_direct.py
+
+# remove build directory
+cd -
+rm -rf $build_dir

--- a/tests/jenkins/spack_setup.sh
+++ b/tests/jenkins/spack_setup.sh
@@ -23,7 +23,7 @@ install_spack() (
     # Use BBP configs
     mkdir -p $SPACK_ROOT/etc/spack/defaults/linux
     cp /gpfs/bbp.cscs.ch/apps/hpc/jenkins/config/*.yaml $SPACK_ROOT/etc/spack/
-
+    sed -i -e  's/neuron+mpi~debug%intel/neuron+mpi/g' $SPACK_ROOT/etc/spack/modules.yaml
     # Remove configs from $HOME/.spack
     rm -rf $HOME/.spack
 )


### PR DESCRIPTION
  - modl_reg was not called when corenrn_embedded_run was used
    for running simulations with in-memory mode transfer
  - move corenrn_embedded_run() into enginemech.cpp to avoid
    link error for calling coreneuron::modl_reg

fixes #274