### PR TITLE
Fix issues while NMODL is built with sympy and analytical passes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,8 @@ if(CORENRN_ENABLE_NMODL)
     include(AddNmodlSubmodule)
     set(CORENRN_NMODL_BINARY ${CMAKE_BINARY_DIR}/bin/nmodl${CMAKE_EXECUTABLE_SUFFIX})
     set(CORENRN_NMODL_INCLUDE ${CMAKE_BINARY_DIR}/include)
+    set(ENV{PYTHONPATH} "$ENV{PYTHONPATH}")
+    set(CORENRN_NMODL_PYTHONPATH $ENV{PYTHONPATH})
   endif()
   include_directories(${CORENRN_NMODL_INCLUDE})
   # set correct arguments for nmodl for cpu/gpu target

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -57,7 +57,9 @@ include(NmodlHelper)
 # =============================================================================
 # Command for MOD to CPP conversion
 # =============================================================================
-set(CORENRN_NMODL_COMMAND env "MODLUNIT=${NMODL_UNITS_FILE}" "PYTHONPATH=$ENV{PYTHONPATH}" ${CORENRN_NMODL_BINARY})
+set(CORENRN_NMODL_COMMAND env "MODLUNIT=${NMODL_UNITS_FILE}"
+                              "PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BINARY_DIR}/lib/python"
+                              ${CORENRN_NMODL_BINARY})
 
 if(${CORENRN_ENABLE_ISPC})
   set(NMODL_CODEGEN_TARGET ispc)
@@ -203,6 +205,11 @@ add_custom_command(TARGET coreneuron
                    COMMENT "Running nrnivmodl-core with halfgap.mod")
 add_dependencies(coreneuron scopmath)
 
+# make sure to have nmodl python module is built
+if(CORENRN_ENABLE_NMODL AND NOT nmodl_FOUND)
+   add_dependencies(coreneuron _nmodl)
+endif()
+
 # =============================================================================
 # create nrnivmodl-core
 # =============================================================================
@@ -297,6 +304,6 @@ endif()
 install(TARGETS nrniv-core DESTINATION bin)
 install(FILES apps/coreneuron.cpp DESTINATION share/coreneuron)
 
-# install Random123
-install(DIRECTORY ${CMAKE_BINARY_DIR}/include/Random123
+# install random123 and nmodl headers
+install(DIRECTORY ${CMAKE_BINARY_DIR}/include/
         DESTINATION include)

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -205,11 +205,6 @@ add_custom_command(TARGET coreneuron
                    COMMENT "Running nrnivmodl-core with halfgap.mod")
 add_dependencies(coreneuron scopmath)
 
-# make sure to have nmodl python module is built
-if(CORENRN_ENABLE_NMODL AND NOT nmodl_FOUND)
-   add_dependencies(coreneuron _nmodl)
-endif()
-
 # =============================================================================
 # create nrnivmodl-core
 # =============================================================================

--- a/extra/CMakeLists.txt
+++ b/extra/CMakeLists.txt
@@ -49,7 +49,7 @@ message(STATUS "CXX Compile flags from BUILD_TYPE (${_BUILD_TYPE}): ${BUILD_TYPE
 
 # nmodl options
 if(CORENRN_ENABLE_NMODL)
-  set(nmodl_arguments_c "host --c ${CORENRN_NMODL_FLAGS}")
+  set(nmodl_arguments_c "host --c passes --inline ${CORENRN_NMODL_FLAGS}")
   set(nmodl_arguments_ispc "host --ispc passes --inline ${CORENRN_NMODL_FLAGS}")
 else()
   set(nmodl_arguments_c "")

--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -51,6 +51,11 @@ ISPC = @CMAKE_ISPC_COMPILER@
 ISPC_FLAGS = @CMAKE_ISPC_FLAGS@
 ISPC_COMPILE = $(ISPC) $(ISPC_FLAGS) -I$(incdir)
 
+ifeq (@nmodl_FOUND@, TRUE)
+INCLUDES += -I@CORENRN_NMODL_INCLUDE@
+ISPC_COMPILE += -I@CORENRN_NMODL_INCLUDE@
+endif
+
 # Variables used in the "ARTIFICIAL_CELL" detection
 mod_c_srcs_path =
 mod_ispc_srcs_path =

--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -147,7 +147,7 @@ $(OBJS_DIR)/%.obj: $(MODC_DIR)/%.ispc | $(OBJS_DIR)
 # Build ispc files with mod2c/nmodl
 $(mod_ispc_files): $(MODC_DIR)/%.ispc: $(MODS_PATH)/%.mod | $(MODC_DIR)
 	@printf " -> $(C_GREEN)MOD2C$(C_RESET) $<\n"
-	PYTHONPATH=@CORENRN_NMODL_PYTHONPATH@ \
+	PYTHONPATH=@CORENRN_NMODL_PYTHONPATH@:${libdir}/python \
 	MODLUNIT=$(datadir_mod2c)/nrnunits.lib \
 	  $(nmodl_binary_path) $< -o $(MODC_DIR)/ @nmodl_arguments_ispc@
 
@@ -157,7 +157,7 @@ $(mod_ispc_c_files): $(MODC_DIR)/%.cpp: $(MODC_DIR)/%.ispc
 # Build cpp files with mod2c/nmodl
 $(mod_c_files): $(MODC_DIR)/%.cpp: $(MODS_PATH)/%.mod | $(MODC_DIR)
 	@printf " -> $(C_GREEN)MOD2C$(C_RESET) $<\n"
-	PYTHONPATH=@CORENRN_NMODL_PYTHONPATH@ \
+	PYTHONPATH=@CORENRN_NMODL_PYTHONPATH@:${libdir}/python \
 	MODLUNIT=$(datadir_mod2c)/nrnunits.lib \
 	  $(nmodl_binary_path) $< -o $(MODC_DIR)/ @nmodl_arguments_c@
 


### PR DESCRIPTION
  - set PYTHONPATH for nmodl sympy solver passes
  - make sure nmodl python module is built before compiling mod files
  - install nmodl headers to install prefix
  - enable inline pass always (--inline)
  - nrnivmodl-core inherit PYTHONPATH correctly

Fixes #278 and #279

- [x] Make sure https://github.com/BlueBrain/nmodl/pull/278 is merged
- [x] Update submodule to master of NMODL
- [x] Test if submodule under NEURON works
- [x] Test if external nmodl works under NEURON as well as CoreNEURON