### PR TITLE
Fix printing of max threads used by OpenMP

### DIFF
--- a/coreneuron/mpi/nrnmpi.cpp
+++ b/coreneuron/mpi/nrnmpi.cpp
@@ -125,7 +125,7 @@ void nrnmpi_init(int nrnmpi_under_nrncontrol, int* pargc, char*** pargv) {
     if (nrnmpi_myid == 0) {
 #if defined(_OPENMP)
         printf(" num_mpi=%d\n num_omp_thread=%d\n\n", nrnmpi_numprocs_world,
-               omp_get_num_threads());
+               omp_get_max_threads());
 #else
         printf(" num_mpi=%d\n\n", nrnmpi_numprocs_world);
 #endif


### PR DESCRIPTION
- Replace `omp_get_num_threads()` with `omp_get_max_threads()` to get the
  max number of threads that OpenMP can use
- From my understanding `omp_get_num_threads()` run in a "serial" region and always printed `1`
- Related to #292 