### PR TITLE
Added hybrid MPI+OpenMP test in CI

### DIFF
--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -423,7 +423,7 @@ pipeline {
                         }
                         stage('neuron + corenrn SoA'){
                             steps{
-                                sh 'sh tests/jenkins/run_corenrn.sh SoA 4 9'
+                                sh 'sh tests/jenkins/run_nrntraub.sh SoA 4 9'
                             }
                         }
                     }

--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -135,8 +135,7 @@ pipeline {
                 stage('nrntraub'){
                     steps{
                         dir('nrntraub'){
-                            git url: 'https://github.com/iomaganaris/nrntraub.git'
-                            git branch: 'icei'
+                            git branch: 'icei', url: 'https://github.com/iomaganaris/nrntraub.git'
                         }
                     }
                 }

--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -416,12 +416,17 @@ pipeline {
                 }
                 stage('nrntraub'){
                     stages{
-                        stage('neuron + corenrn AoS'){
+                        stage('neuron'){
+                            steps{
+                                sh 'sh tests/jenkins/run_neuron.sh nrntraub nrntraub 36'
+                            }
+                        }
+                        stage('corenrn AoS'){
                             steps{
                                 sh 'sh tests/jenkins/run_nrntraub.sh AoS 4 9'
                             }
                         }
-                        stage('neuron + corenrn SoA'){
+                        stage('corenrn SoA'){
                             steps{
                                 sh 'sh tests/jenkins/run_nrntraub.sh SoA 4 9'
                             }

--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -423,7 +423,7 @@ pipeline {
                         }
                         stage('corenrn AoS'){
                             steps{
-                                sh 'sh tests/jenkins/run_nrntraub.sh AoS 4 9'
+                                sh 'sh tests/jenkins/run_nrntraub.sh AoS 36 1'
                             }
                         }
                         stage('corenrn SoA'){

--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -159,7 +159,7 @@ pipeline {
                         sh 'sh tests/jenkins/nrnivmodl.sh tqperf'
                     }
                 }
-                stage('nrnivmodl tqperf'){
+                stage('nrnivmodl nrntraub'){
                     steps{
                         sh 'sh tests/jenkins/nrnivmodl.sh nrntraub'
                     }

--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -132,6 +132,14 @@ pipeline {
                         }
                     }
                 }
+                stage('nrntraub'){
+                    steps{
+                        dir('nrntraub'){
+                            git url: 'https://github.com/iomaganaris/nrntraub.git'
+                            git branch: 'icei'
+                        }
+                    }
+                }
             }
         }
 
@@ -150,6 +158,11 @@ pipeline {
                 stage('nrnivmodl tqperf'){
                     steps{
                         sh 'sh tests/jenkins/nrnivmodl.sh tqperf'
+                    }
+                }
+                stage('nrnivmodl tqperf'){
+                    steps{
+                        sh 'sh tests/jenkins/nrnivmodl.sh nrntraub'
                     }
                 }
                 stage('nrnivmodl-core testcorenrn AoS'){
@@ -180,6 +193,16 @@ pipeline {
                 stage('nrnivmodl-core tqperf SoA'){
                     steps{
                         sh 'sh tests/jenkins/nrnivmodl-core.sh tqperf SoA'
+                    }
+                }
+                stage('nrnivmodl-core nrntraub AoS'){
+                    steps{
+                        sh 'sh tests/jenkins/nrnivmodl-core.sh nrntraub AoS'
+                    }
+                }
+                stage('nrnivmodl-core nrntraub SoA'){
+                    steps{
+                        sh 'sh tests/jenkins/nrnivmodl-core.sh nrntraub SoA'
                     }
                 }
             }
@@ -388,6 +411,20 @@ pipeline {
                         stage('corenrn SoA'){
                             steps{
                                 sh 'sh tests/jenkins/run_corenrn.sh tqperf SoA tqperf 6'
+                            }
+                        }
+                    }
+                }
+                stage('nrntraub'){
+                    stages{
+                        stage('neuron + corenrn AoS'){
+                            steps{
+                                sh 'sh tests/jenkins/run_nrntraub.sh AoS 4 9'
+                            }
+                        }
+                        stage('neuron + corenrn SoA'){
+                            steps{
+                                sh 'sh tests/jenkins/run_corenrn.sh SoA 4 9'
                             }
                         }
                     }

--- a/tests/jenkins/_test_utils.sh
+++ b/tests/jenkins/_test_utils.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+bb5_run() (
+    set +x -e
+    # default partition is interactive. during night use production
+    hour=`date +%H`
+    weekday=`date +%u`
+    if [ "$hour" -ge "19" ] || [ "$hour" -lt "8" ] || [ $weekday -gt 5 ]; then export SALLOC_PARTITION="prod"; fi
+
+    N=${N:-1}
+    if [ -n "$n" ]; then
+        SALLOC_OPTS="$SALLOC_OPTS --ntasks-per-node=$n --exclusive --mem=0"
+    else
+        SALLOC_OPTS="$SALLOC_OPTS --ntasks-per-node=36 --exclusive --mem=0"
+    fi
+
+    cmd_base="time salloc -N$N $SALLOC_OPTS -Aproj16 --hint=compute_bound -Ccpu|nvme --time 1:00:00 srun dplace "
+    echo "$cmd_base $@"
+    $cmd_base "$@"
+)

--- a/tests/jenkins/_test_utils.sh
+++ b/tests/jenkins/_test_utils.sh
@@ -9,9 +9,9 @@ bb5_run() (
 
     N=${N:-1}
     if [ -n "$n" ]; then
-        SALLOC_OPTS="$SALLOC_OPTS --ntasks-per-node=$n --exclusive --mem=0"
+        SALLOC_OPTS="$SALLOC_OPTS --ntasks-per-node=$n"
     else
-        SALLOC_OPTS="$SALLOC_OPTS --ntasks-per-node=36 --exclusive --mem=0"
+        SALLOC_OPTS="$SALLOC_OPTS --ntasks-per-node=36"
     fi
 
     cmd_base="time salloc -N$N $SALLOC_OPTS -Aproj16 --hint=compute_bound -Ccpu|nvme --time 1:00:00 srun dplace "

--- a/tests/jenkins/run_neuron.sh
+++ b/tests/jenkins/run_neuron.sh
@@ -2,6 +2,7 @@
 
 set -e
 source ${JENKINS_DIR:-.}/_env_setup.sh
+source ${JENKINS_DIR:-.}/_test_utils.sh
 
 set -x
 TEST_DIR="$1"
@@ -24,6 +25,11 @@ elif [ "${TEST_DIR}" = "tqperf" ]; then
     mkdir ${TEST}
     mpirun -n ${MPI_RANKS} ./x86_64/special -c tstop=50 run.hoc -mpi
     cat spk000.dat | sort -k 1n,1n -k 2n,2n > ${TEST}/out_nrn_${TEST}.spk
+elif [ "${TEST_DIR}" = "nrntraub" ]; then
+    # Allocate 1 node
+    N=1
+    n=${MPI_RANKS} bb5_run ./x86_64/special -mpi -c mytstop=100 -c use_coreneuron=0 init.hoc
+    sort -n -k'1,1' -k2 < out36.dat | awk 'NR==1 { print; next } { printf "%.3f\t%d\n", $1, $2 }' > out_nrn.sorted
 else
     echo "Not a valid TEST"
     exit 1

--- a/tests/jenkins/run_nrntraub.sh
+++ b/tests/jenkins/run_nrntraub.sh
@@ -17,8 +17,12 @@ N=1
 
 bb5_run ./x86_64/special -mpi -c mytstop=100 -c use_coreneuron=0 init.hoc
 
-export OMP_NUM_THREADS=${THREADS}
-n=${MPI_RANKS} bb5_run ./${CORENRN_TYPE}/special-core --mpi -d coredat
+if [ "${CORENRN_TYPE}" = "SoA" ]; then
+  export OMP_NUM_THREADS=${THREADS}
+  n=${MPI_RANKS} bb5_run ./${CORENRN_TYPE}/special-core --mpi -d coredat
+elif [ "${CORENRN_TYPE}" = "AoS" ]; then
+  bb5_run ./${CORENRN_TYPE}/special-core --mpi -d coredat
+fi
 
 sort -n -k'1,1' -k2 < out.dat | awk 'NR==1 { print; next } { printf "%.3f\t%d\n", $1, $2 }' > out_cn.sorted
 sort -n -k'1,1' -k2 < out36.dat | awk 'NR==1 { print; next } { printf "%.3f\t%d\n", $1, $2 }' > out_n.sorted

--- a/tests/jenkins/run_nrntraub.sh
+++ b/tests/jenkins/run_nrntraub.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/bash
+
+set -e
+source ${JENKINS_DIR:-.}/_env_setup.sh
+source ${JENKINS_DIR:-.}/_test_utils.sh
+
+set -x
+
+CORENRN_TYPE="$1"
+MPI_RANKS="$2"
+THREADS="$3"
+
+cd $WORKSPACE/nrntraub
+
+# Allocate 1 node
+N=1
+
+bb5_run ./x86_64/special -mpi -c mytstop=100 -c use_coreneuron=0 init.hoc
+
+export OMP_NUM_THREADS=${THREADS}
+n=${MPI_RANKS} bb5_run ./${CORENRN_TYPE}/special-core --mpi -d coredat
+
+sort -n -k'1,1' -k2 < out.dat | awk 'NR==1 { print; next } { printf "%.3f\t%d\n", $1, $2 }' > out_cn.sorted
+sort -n -k'1,1' -k2 < out36.dat | awk 'NR==1 { print; next } { printf "%.3f\t%d\n", $1, $2 }' > out_n.sorted
+
+sdiff -s out_cn.sorted out_n.sorted

--- a/tests/jenkins/run_nrntraub.sh
+++ b/tests/jenkins/run_nrntraub.sh
@@ -15,15 +15,9 @@ cd $WORKSPACE/nrntraub
 # Allocate 1 node
 N=1
 
-if [ "${CORENRN_TYPE}" = "SoA" ]; then
-  export OMP_NUM_THREADS=${THREADS}
-  n=${MPI_RANKS} bb5_run ./${CORENRN_TYPE}/special-core --mpi -d coredat --voltage=1000
-elif [ "${CORENRN_TYPE}" = "AoS" ]; then
-  bb5_run ./${CORENRN_TYPE}/special-core --mpi -d coredat --voltage=1000
-else
-    echo "Not a valid CORENRN_TYPE"
-    exit 1
-fi
+export OMP_NUM_THREADS=${THREADS}
+
+n=${MPI_RANKS} bb5_run ./${CORENRN_TYPE}/special-core --mpi -d coredat --voltage=1000
 
 sort -n -k'1,1' -k2 < out.dat | awk 'NR==1 { print; next } { printf "%.3f\t%d\n", $1, $2 }' > out_cn_${CORENRN_TYPE}.sorted
 

--- a/tests/jenkins/run_nrntraub.sh
+++ b/tests/jenkins/run_nrntraub.sh
@@ -15,16 +15,16 @@ cd $WORKSPACE/nrntraub
 # Allocate 1 node
 N=1
 
-bb5_run ./x86_64/special -mpi -c mytstop=100 -c use_coreneuron=0 init.hoc
-
 if [ "${CORENRN_TYPE}" = "SoA" ]; then
   export OMP_NUM_THREADS=${THREADS}
   n=${MPI_RANKS} bb5_run ./${CORENRN_TYPE}/special-core --mpi -d coredat --voltage=1000
 elif [ "${CORENRN_TYPE}" = "AoS" ]; then
   bb5_run ./${CORENRN_TYPE}/special-core --mpi -d coredat --voltage=1000
+else
+    echo "Not a valid CORENRN_TYPE"
+    exit 1
 fi
 
-sort -n -k'1,1' -k2 < out.dat | awk 'NR==1 { print; next } { printf "%.3f\t%d\n", $1, $2 }' > out_cn.sorted
-sort -n -k'1,1' -k2 < out36.dat | awk 'NR==1 { print; next } { printf "%.3f\t%d\n", $1, $2 }' > out_n.sorted
+sort -n -k'1,1' -k2 < out.dat | awk 'NR==1 { print; next } { printf "%.3f\t%d\n", $1, $2 }' > out_cn_${CORENRN_TYPE}.sorted
 
-sdiff -s out_cn.sorted out_n.sorted
+sdiff -s out_cn_${CORENRN_TYPE}.sorted out_nrn.sorted

--- a/tests/jenkins/run_nrntraub.sh
+++ b/tests/jenkins/run_nrntraub.sh
@@ -19,9 +19,9 @@ bb5_run ./x86_64/special -mpi -c mytstop=100 -c use_coreneuron=0 init.hoc
 
 if [ "${CORENRN_TYPE}" = "SoA" ]; then
   export OMP_NUM_THREADS=${THREADS}
-  n=${MPI_RANKS} bb5_run ./${CORENRN_TYPE}/special-core --mpi -d coredat
+  n=${MPI_RANKS} bb5_run ./${CORENRN_TYPE}/special-core --mpi -d coredat --voltage=1000
 elif [ "${CORENRN_TYPE}" = "AoS" ]; then
-  bb5_run ./${CORENRN_TYPE}/special-core --mpi -d coredat
+  bb5_run ./${CORENRN_TYPE}/special-core --mpi -d coredat --voltage=1000
 fi
 
 sort -n -k'1,1' -k2 < out.dat | awk 'NR==1 { print; next } { printf "%.3f\t%d\n", $1, $2 }' > out_cn.sorted


### PR DESCRIPTION
- Added `nrntraub` test and run it with 4 ranks and 9 threads on BB5 with the SoA `CoreNEURON` build
- Uses https://github.com/iomaganaris/nrntraub/tree/icei which creates the `coredat` by default in the `NEURON` run
- Closes https://github.com/BlueBrain/CoreNeuron/issues/292

@pramodk I didn't manage to run `NEURON` with the `threading` option still with `nrntraub`. If you think that this should be tested maybe we can have a look together at some point.
Also, let me know if I should create a PR for my fork of `nrntraub`