### PR TITLE
Bugfix : add missing link to libscopmath

### DIFF
--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -135,7 +135,8 @@ $(coremech_lib): $(mod_func_o) $(dimplic_o) $(mod_c_objs) $(mod_ispc_objs) build
 		$(CXX_LINK_SHARED) $(INCFLAGS) -I $(incdir) enginemech.o -o ${coremech_lib} ${_SONAME} \
 			$(mod_func_o) $(dimplic_o) $(mod_c_objs) $(mod_ispc_objs) $(libdir)/libscopmath.a $(CORENRNLIB_FLAGS) -Wl,-rpath,$(libdir) $(LDFLAGS);\
 	else\
-		ar cq ${coremech_lib} enginemech.o $(mod_func_o) $(dimplic_o) $(mod_c_objs) $(mod_ispc_objs);\
+		mkdir -p $(OBJS_DIR)/scopmath_obj && cd $(OBJS_DIR)/scopmath_obj && ar -x $(libdir)/libscopmath.a && cd -;\
+		ar cq ${coremech_lib} enginemech.o $(mod_func_o) $(dimplic_o) $(OBJS_DIR)/scopmath_obj/*.o $(mod_c_objs) $(mod_ispc_objs);\
 	fi
 	(rm -f $(OUTPUT)/.libs/libcorenrnmech$(library_suffix) ; mkdir -p $(OUTPUT)/.libs ; ln -s ../../${coremech_lib} $(OUTPUT)/.libs/libcorenrnmech$(library_suffix))
 


### PR DESCRIPTION
  - libscopmath.a was linked to libcorenrnmech with shared library
    but was missing in case of static library
  - ar doesnt provide way to link two static libraries together.
    Hence extrat objects and then combined those together.

fixes #303 #306