### PR TITLE
Update nmodl to latest master

### DIFF
--- a/CMake/packages/Findnmodl.cmake
+++ b/CMake/packages/Findnmodl.cmake
@@ -33,7 +33,7 @@ find_program(nmodl_BINARY NAMES nmodl${CMAKE_EXECUTABLE_SUFFIX}
         HINTS "${CORENRN_NMODL_DIR}/bin" QUIET)
 
 find_path(nmodl_INCLUDE "nmodl/fast_math.ispc" HINTS "${CORENRN_NMODL_DIR}/include")
-find_path(nmodl_PYTHONPATH "nmodl/__init__.py" HINTS "${CORENRN_NMODL_DIR}/lib/python")
+find_path(nmodl_PYTHONPATH "nmodl/__init__.py" HINTS "${CORENRN_NMODL_DIR}")
 
 # Checks 'REQUIRED', 'QUIET' and versions.
 include(FindPackageHandleStandardArgs)

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -10,7 +10,7 @@ reportinglib_dir=$(spack cd -i reportinglib%intel && pwd)
 CORENRN_TYPE="$1"
 
 if [ "${CORENRN_TYPE}" = "GPU-non-unified" ] || [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
-    module load pgi cuda hpe-mpi cmake boost
+    module load pgi/19.10 cuda hpe-mpi cmake boost
 
     mkdir build_${CORENRN_TYPE}
 else

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -10,7 +10,7 @@ reportinglib_dir=$(spack cd -i reportinglib%intel && pwd)
 CORENRN_TYPE="$1"
 
 if [ "${CORENRN_TYPE}" = "GPU-non-unified" ] || [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
-    module load pgi/19.10 cuda hpe-mpi cmake boost
+    module load pgi cuda hpe-mpi cmake boost
 
     mkdir build_${CORENRN_TYPE}
 else


### PR DESCRIPTION
- Fixes issue finding nmodl when provided with `CORENRN_NMODL_DIR` because of `nmodl_PYTHONPATH`