### PR TITLE
Bug fixes for gpu execution

### DIFF
--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -138,7 +138,6 @@ void call_prcellstate_for_prcellgid(int prcellgid, int compute_gpu, int is_init)
 void nrn_init_and_load_data(int argc,
                             char* argv[],
                             bool is_mapping_needed = false,
-                            bool nrnmpi_under_nrncontrol = true,
                             bool run_setup_cleanup = true) {
 #if defined(NRN_FEEXCEPT)
     nrn_feenableexcept();
@@ -146,11 +145,6 @@ void nrn_init_and_load_data(int argc,
 
     /// profiler like tau/vtune : do not measure from begining
     Instrumentor::stop_profile();
-
-// mpi initialisation
-#if NRNMPI
-    nrnmpi_init(nrnmpi_under_nrncontrol ? 1 : 0, &argc, &argv);
-#endif
 
     // memory footprint after mpi initialisation
     report_mem_usage("After MPI_Init");
@@ -427,30 +421,25 @@ using namespace coreneuron;
 
 
 extern "C" void mk_mech_init(int argc, char** argv) {
-#if NRNMPI
-    for(int i = 0; i < argc; ++i) {
-        if(argv[i] == "--mpi") {
-            nrnmpi_init(1, &argc, &argv);
-            break;
-        }
-    }
-#endif
-#ifdef _OPENACC
-    for(int i = 0; i < argc; ++i) {
-        if(argv[i] == "--gpu") {
-            init_gpu();
-            break;
-        }
-    }
-#endif
     // read command line parameters and parameter config files
-
     try {
         corenrn_param.parse(argc, argv);
     }
     catch (...) {
         nrn_abort(1);
     }
+
+#if NRNMPI
+    if (corenrn_param.mpi_enable) {
+        nrnmpi_init(1, &argc, &argv);
+    }
+#endif
+
+#ifdef _OPENACC
+    if (corenrn_param.gpu) {
+        init_gpu();
+    }
+#endif
 
     if (!corenrn_param.writeParametersFilepath.empty()) {
         std::ofstream out(corenrn_param.writeParametersFilepath, std::ios::trunc);

--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -428,10 +428,20 @@ using namespace coreneuron;
 
 extern "C" void mk_mech_init(int argc, char** argv) {
 #if NRNMPI
-    nrnmpi_init(1, &argc, &argv);
+    for(int i = 0; i < argc; ++i) {
+        if(argv[i] == "--mpi") {
+            nrnmpi_init(1, &argc, &argv);
+            break;
+        }
+    }
 #endif
 #ifdef _OPENACC
-    init_gpu();
+    for(int i = 0; i < argc; ++i) {
+        if(argv[i] == "--gpu") {
+            init_gpu();
+            break;
+        }
+    }
 #endif
     // read command line parameters and parameter config files
 

--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -430,6 +430,9 @@ extern "C" void mk_mech_init(int argc, char** argv) {
 #if NRNMPI
     nrnmpi_init(1, &argc, &argv);
 #endif
+#ifdef _OPENACC
+    init_gpu();
+#endif
     // read command line parameters and parameter config files
 
     try {

--- a/coreneuron/gpu/nrn_acc_manager.hpp
+++ b/coreneuron/gpu/nrn_acc_manager.hpp
@@ -20,6 +20,7 @@ void update_matrix_to_gpu(NrnThread* _nt);
 void update_net_receive_buffer(NrnThread* _nt);
 void realloc_net_receive_buffer(NrnThread* nt, Memb_list* ml);
 void update_net_send_buffer_on_host(NrnThread* nt, NetSendBuffer_t* nsb);
+void init_gpu();
 
 }  // namespace coreneuron
 #endif  // _nrn_device_manager_

--- a/coreneuron/io/nrn_setup.hpp
+++ b/coreneuron/io/nrn_setup.hpp
@@ -53,7 +53,6 @@ static void setup_ThreadData(NrnThread& nt);
 extern void nrn_init_and_load_data(int argc,
                                    char** argv,
                                    bool is_mapping_needed = false,
-                                   bool nrnmpi_under_nrncontrol = true,
                                    bool run_setup_cleanup = true);
 extern void nrn_setup_cleanup();
 

--- a/coreneuron/network/partrans_setup.cpp
+++ b/coreneuron/network/partrans_setup.cpp
@@ -256,7 +256,9 @@ void nrn_partrans::gap_thread_setup(NrnThread& nt) {
 }
 
 void nrn_partrans::gap_indices_permute(NrnThread& nt) {
-    printf("nrn_partrans::gap_indices_permute\n");
+    if (nrnmpi_myid == 0) {
+        printf("nrn_partrans::gap_indices_permute\n");
+    }
     nrn_partrans::TransferThreadData& ttd = transfer_thread_data_[nt.id];
     // sources
     if (ttd.nsrc > 0 && nt._permute) {

--- a/coreneuron/utils/randoms/nrnran123.h
+++ b/coreneuron/utils/randoms/nrnran123.h
@@ -151,6 +151,9 @@ extern DEVICE double nrnran123_negexp(nrnran123_State*); /* mean 1.0 */
 /* nrnran123_negexp min value is 2.3283064e-10, max is 22.18071 */
 
 /* missing declaration in coreneuron */
+#if !defined(DISABLE_OPENACC)
+#pragma acc routine seq
+#endif
 extern DEVICE double nrnran123_normal(nrnran123_State*);
 
 extern DEVICE double nrnran123_gauss(nrnran123_State*); /* mean 0.0, std 1.0 */


### PR DESCRIPTION
 - init_gpu should be called very early before mechanism registration
   to make sure all memory is allocated on specific gpu in case of multi-gpu
   system (e.g. bbcore_read & acc copyin)
 - nrnran123_normal should be marked as acc routine seq
 - minor debug message improvement