### PR TITLE
NMODL PYTHONPATH fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,46 +16,43 @@ matrix:
     - os: linux
       dist: xenial
       env:
-        - cmake_options=(-DCORENRN_ENABLE_MPI=ON)
+        - cmake_option="-DCORENRN_ENABLE_MPI=ON"
     - os: linux
       dist: xenial
       env:
-        - cmake_options=(-DCORENRN_ENABLE_MPI=OFF)
+        - cmake_option="-DCORENRN_ENABLE_MPI=OFF"
     - os: linux
       dist: xenial
       env:
-        - cmake_options=(-DCORENRN_ENABLE_SOA=ON)
+        - cmake_option="-DCORENRN_ENABLE_SOA=ON"
     - os: linux
       dist: xenial
       env:
-        - cmake_options=(-DCORENRN_ENABLE_SOA=OFF)
+        - cmake_option="-DCORENRN_ENABLE_SOA=OFF"
     - os: linux
       dist: xenial
       env:
-        - nmodl_flags=(sympy\ --analytic)
-        - cmake_options=(-DCORENRN_ENABLE_NMODL=ON\ -DCORENRN_NMODL_FLAGS="${nmodl_flags[@]}")
         - PYTHON_VERSION=3.6.7  # for nmodl pip3 install
         - USE_NMODL=ON
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options=(-DCORENRN_ENABLE_MPI=ON)
+        - cmake_option="-DCORENRN_ENABLE_MPI=ON"
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options=(-DCORENRN_ENABLE_MPI=OFF)
+        - cmake_option="-DCORENRN_ENABLE_MPI=OFF"
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options=(-DCORENRN_ENABLE_SOA=ON)
+        - cmake_option="-DCORENRN_ENABLE_SOA=ON"
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options=(-DCORENRN_ENABLE_SOA=OFF)
+        - cmake_option="-DCORENRN_ENABLE_SOA=OFF"
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options=(-DCORENRN_ENABLE_NMODL=ON)
         - USE_NMODL=ON
     - os: linux
       dist: xenial
@@ -149,8 +146,11 @@ script:
   - if [[ "$USE_ISPC" == "ON" ]]; then
         cmake -DCORENRN_ENABLE_ISPC=ON -DCMAKE_ISPC_COMPILER=../ispc/bin/ispc
               -DCMAKE_INSTALL_PREFIX=$HOME/CoreNeuron -DPYTHON_EXECUTABLE=$(which python3) ..;
+    elif [[ "$USE_NMODL" == "ON" ]]; then
+        cmake -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_FLAGS="sympy --analytic"
+              -DCMAKE_INSTALL_PREFIX=$HOME/CoreNeuron -DPYTHON_EXECUTABLE=$(which python3) ..;
     else
-        cmake "${cmake_options[@]}" -DCMAKE_INSTALL_PREFIX=$HOME/CoreNeuron -DPYTHON_EXECUTABLE=$(which python3) ..;
+        cmake ${cmake_option} -DCMAKE_INSTALL_PREFIX=$HOME/CoreNeuron -DPYTHON_EXECUTABLE=$(which python3) ..;
     fi
   - cmake --build .
   - ctest --output-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,46 +16,46 @@ matrix:
     - os: linux
       dist: xenial
       env:
-        - cmake_options=( -DCORENRN_ENABLE_MPI=ON )
+        - cmake_options="( -DCORENRN_ENABLE_MPI=ON )"
     - os: linux
       dist: xenial
       env:
-        - cmake_options=( -DCORENRN_ENABLE_MPI=OFF )
+        - cmake_options="( -DCORENRN_ENABLE_MPI=OFF )"
     - os: linux
       dist: xenial
       env:
-        - cmake_options=( -DCORENRN_ENABLE_SOA=ON )
+        - cmake_options="( -DCORENRN_ENABLE_SOA=ON )"
     - os: linux
       dist: xenial
       env:
-        - cmake_options=( -DCORENRN_ENABLE_SOA=OFF )
+        - cmake_options="( -DCORENRN_ENABLE_SOA=OFF )"
     - os: linux
       dist: xenial
       env:
-        - nmodl_flags=( sympy --analytic )
-        - cmake_options=( -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_FLAGS="${nmodl_flags[@]}" )
+        - nmodl_flags="( sympy --analytic )"
+        - cmake_options="( -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_FLAGS="${nmodl_flags[@]}" )"
         - PYTHON_VERSION=3.6.7  # for nmodl pip3 install
         - USE_NMODL=ON
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options=( -DCORENRN_ENABLE_MPI=ON )
+        - cmake_options="( -DCORENRN_ENABLE_MPI=ON )"
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options=( -DCORENRN_ENABLE_MPI=OFF )
+        - cmake_options="( -DCORENRN_ENABLE_MPI=OFF )
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options=( -DCORENRN_ENABLE_SOA=ON )
+        - cmake_options="( -DCORENRN_ENABLE_SOA=ON )"
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options=( -DCORENRN_ENABLE_SOA=OFF )
+        - cmake_options="( -DCORENRN_ENABLE_SOA=OFF )"
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options=( -DCORENRN_ENABLE_NMODL=ON )
+        - cmake_options="( -DCORENRN_ENABLE_NMODL=ON )"
         - USE_NMODL=ON
     - os: linux
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
     - os: linux
       dist: xenial
       env:
-        - cmake_option='-DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_FLAGS="sympy --analytic"'
+        - cmake_option="-DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_FLAGS=\"sympy --analytic\""
         - PYTHON_VERSION=3.6.7  # for nmodl pip3 install
         - USE_NMODL=ON
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,45 +16,46 @@ matrix:
     - os: linux
       dist: xenial
       env:
-        - cmake_option="-DCORENRN_ENABLE_MPI=ON"
+        - cmake_options=( -DCORENRN_ENABLE_MPI=ON )
     - os: linux
       dist: xenial
       env:
-        - cmake_option="-DCORENRN_ENABLE_MPI=OFF"
+        - cmake_options=( -DCORENRN_ENABLE_MPI=OFF )
     - os: linux
       dist: xenial
       env:
-        - cmake_option="-DCORENRN_ENABLE_SOA=ON"
+        - cmake_options=( -DCORENRN_ENABLE_SOA=ON )
     - os: linux
       dist: xenial
       env:
-        - cmake_option="-DCORENRN_ENABLE_SOA=OFF"
+        - cmake_options=( -DCORENRN_ENABLE_SOA=OFF )
     - os: linux
       dist: xenial
       env:
-        - cmake_option="-DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_FLAGS=\"sympy --analytic\""
+        - nmodl_flags=( sympy --analytic )
+        - cmake_options=( -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_FLAGS="${nmodl_flags[@]}" )
         - PYTHON_VERSION=3.6.7  # for nmodl pip3 install
         - USE_NMODL=ON
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_option="-DCORENRN_ENABLE_MPI=ON"
+        - cmake_options=( -DCORENRN_ENABLE_MPI=ON )
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_option="-DCORENRN_ENABLE_MPI=OFF"
+        - cmake_options=( -DCORENRN_ENABLE_MPI=OFF )
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_option="-DCORENRN_ENABLE_SOA=ON"
+        - cmake_options=( -DCORENRN_ENABLE_SOA=ON )
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_option="-DCORENRN_ENABLE_SOA=OFF"
+        - cmake_options=( -DCORENRN_ENABLE_SOA=OFF )
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_option="-DCORENRN_ENABLE_NMODL=ON"
+        - cmake_options=( -DCORENRN_ENABLE_NMODL=ON )
         - USE_NMODL=ON
     - os: linux
       dist: xenial
@@ -149,7 +150,7 @@ script:
         cmake -DCORENRN_ENABLE_ISPC=ON -DCMAKE_ISPC_COMPILER=../ispc/bin/ispc
               -DCMAKE_INSTALL_PREFIX=$HOME/CoreNeuron -DPYTHON_EXECUTABLE=$(which python3) ..;
     else
-        cmake ${cmake_option} -DCMAKE_INSTALL_PREFIX=$HOME/CoreNeuron -DPYTHON_EXECUTABLE=$(which python3) ..;
+        cmake "${cmake_options[@]}" -DCMAKE_INSTALL_PREFIX=$HOME/CoreNeuron -DPYTHON_EXECUTABLE=$(which python3) ..;
     fi
   - cmake --build .
   - ctest --output-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
     - os: linux
       dist: xenial
       env:
-        - cmake_option="-DCORENRN_ENABLE_NMODL=ON"
+        - cmake_option='-DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_FLAGS="sympy --analytic"'
         - PYTHON_VERSION=3.6.7  # for nmodl pip3 install
         - USE_NMODL=ON
     - os: osx
@@ -119,7 +119,7 @@ before_install:
     fi
   # install NMODL dependencies
   - if [[ "$USE_NMODL" == "ON" || "$USE_ISPC" == "ON" ]]; then
-        pip3 install jinja2 pyyaml pytest sympy;
+        pip3 install jinja2 pyyaml pytest "sympy<1.6";
     fi
   - if [ -n "$GCC_VERSION" ]; then
         export CXX="g++-${GCC_VERSION}" CC="gcc-${GCC_VERSION}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,46 +16,46 @@ matrix:
     - os: linux
       dist: xenial
       env:
-        - cmake_options="( -DCORENRN_ENABLE_MPI=ON )"
+        - cmake_options=(-DCORENRN_ENABLE_MPI=ON)
     - os: linux
       dist: xenial
       env:
-        - cmake_options="( -DCORENRN_ENABLE_MPI=OFF )"
+        - cmake_options=(-DCORENRN_ENABLE_MPI=OFF)
     - os: linux
       dist: xenial
       env:
-        - cmake_options="( -DCORENRN_ENABLE_SOA=ON )"
+        - cmake_options=(-DCORENRN_ENABLE_SOA=ON)
     - os: linux
       dist: xenial
       env:
-        - cmake_options="( -DCORENRN_ENABLE_SOA=OFF )"
+        - cmake_options=(-DCORENRN_ENABLE_SOA=OFF)
     - os: linux
       dist: xenial
       env:
-        - nmodl_flags="( sympy --analytic )"
-        - cmake_options="( -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_FLAGS="${nmodl_flags[@]}" )"
+        - nmodl_flags=(sympy\ --analytic)
+        - cmake_options=(-DCORENRN_ENABLE_NMODL=ON\ -DCORENRN_NMODL_FLAGS="${nmodl_flags[@]}")
         - PYTHON_VERSION=3.6.7  # for nmodl pip3 install
         - USE_NMODL=ON
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options="( -DCORENRN_ENABLE_MPI=ON )"
+        - cmake_options=(-DCORENRN_ENABLE_MPI=ON)
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options="( -DCORENRN_ENABLE_MPI=OFF )
+        - cmake_options=(-DCORENRN_ENABLE_MPI=OFF)
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options="( -DCORENRN_ENABLE_SOA=ON )"
+        - cmake_options=(-DCORENRN_ENABLE_SOA=ON)
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options="( -DCORENRN_ENABLE_SOA=OFF )"
+        - cmake_options=(-DCORENRN_ENABLE_SOA=OFF)
     - os: osx
       osx_image: xcode10.2
       env:
-        - cmake_options="( -DCORENRN_ENABLE_NMODL=ON )"
+        - cmake_options=(-DCORENRN_ENABLE_NMODL=ON)
         - USE_NMODL=ON
     - os: linux
       dist: xenial

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -59,7 +59,7 @@ include(NmodlHelper)
 # Command for MOD to CPP conversion
 # =============================================================================
 set(CORENRN_NMODL_COMMAND env "MODLUNIT=${NMODL_UNITS_FILE}"
-                              "PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BINARY_DIR}/lib/python"
+                              "PYTHONPATH=${CORENRN_NMODL_PYTHONPATH}"
                               ${CORENRN_NMODL_BINARY})
 
 if(${CORENRN_ENABLE_ISPC})


### PR DESCRIPTION
- Fixed NMODL PYTHONPATH in another place in CMake
- Added "sympy --analytic" flag in CoreNEURON build in CI to test if the proper PYTHONPATH of NMODL is set on CoreNEURON