### PR TITLE
Add --verbose option Closes #338

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,6 @@ addons:
       - openmpi
       - boost
       - python@3
-    update: true
 
 #=============================================================================
 # Set up environments

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,23 +35,23 @@ matrix:
         - PYTHON_VERSION=3.6.7  # for nmodl pip3 install
         - USE_NMODL=ON
     - os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.3
       env:
         - cmake_option="-DCORENRN_ENABLE_MPI=ON"
     - os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.3
       env:
         - cmake_option="-DCORENRN_ENABLE_MPI=OFF"
     - os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.3
       env:
         - cmake_option="-DCORENRN_ENABLE_SOA=ON"
     - os: osx
-      osx_image: xcode10.2
+      osx_image: xcode12
       env:
         - cmake_option="-DCORENRN_ENABLE_SOA=OFF"
     - os: osx
-      osx_image: xcode10.2
+      osx_image: xcode12
       env:
         - USE_NMODL=ON
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,11 @@ matrix:
       env:
         - cmake_option="-DCORENRN_ENABLE_SOA=ON"
     - os: osx
-      osx_image: xcode12
+      osx_image: xcode11.3
       env:
         - cmake_option="-DCORENRN_ENABLE_SOA=OFF"
     - os: osx
-      osx_image: xcode12
+      osx_image: xcode11.3
       env:
         - USE_NMODL=ON
     - os: linux

--- a/coreneuron/apps/corenrn_parameters.cpp
+++ b/coreneuron/apps/corenrn_parameters.cpp
@@ -42,6 +42,7 @@ corenrn_parameters::corenrn_parameters(){
     app.add_option("-e, --tstop", this->tstop, "Stop Time in ms.")
         ->check(CLI::Range(0., 1e9));
     app.add_flag("--show");
+    app.add_set("--verbose", this->verbose, {verbose_level::NONE, verbose_level::ERROR, verbose_level::INFO, verbose_level::DEBUG}, "Verbose level: 0 = NONE, 1 = ERROR, 2 = INFO, 3 = DEBUG. Default is INFO");
 
     auto sub_gpu = app.add_option_group("GPU", "Commands relative to GPU.");
     sub_gpu -> add_option("-W, --nwarp", this->nwarp, "Number of warps to balance.", true)
@@ -110,6 +111,9 @@ void corenrn_parameters::parse (int argc, char** argv) {
 
     try {
         app.parse(argc, argv);
+        if(verbose == verbose_level::NONE) {
+            nrn_nobanner_ = 1;
+        }
     } catch (const CLI::ExtrasError &e) {
         std::cerr << "Single-dash arguments such as -mpi are deleted, please check ./coreneuron_exec --help for more information. \n" << std::endl;
         app.exit(e);
@@ -171,7 +175,7 @@ std::ostream& operator<<(std::ostream& os, const corenrn_parameters& corenrn_par
     return os;
 }
 
-
 corenrn_parameters corenrn_param;
+int nrn_nobanner_{0};
 
 } // namespace coreneuron

--- a/coreneuron/apps/corenrn_parameters.hpp
+++ b/coreneuron/apps/corenrn_parameters.hpp
@@ -57,6 +57,15 @@ namespace coreneuron {
 
 struct corenrn_parameters {
 
+    enum verbose_level : std::uint32_t
+    {
+      NONE = 0,
+      ERROR = 1,
+      INFO = 2,
+      DEBUG = 3,
+      DEFAULT = INFO
+    };
+
     const int report_buff_size_default=4;
 
     unsigned spikebuf=100'000;     /// Internal buffer used on every rank for spikes
@@ -77,6 +86,8 @@ struct corenrn_parameters {
     bool threading=false;          /// Enable pthread/openmp
     bool gpu=false;                /// Enable GPU computation.
     bool binqueue=false;           /// Use bin queue.
+
+    verbose_level verbose{verbose_level::DEFAULT}; /// Verbosity-level
 
     double tstop=100;              /// Stop time of simulation in msec
     double dt=-1000.0;             /// Timestep to use in msec
@@ -102,11 +113,14 @@ struct corenrn_parameters {
 
     void parse(int argc, char* argv[]); /// Runs the CLI11_PARSE macro.
 
+    inline bool is_quiet() { return verbose == verbose_level::NONE; }
+
 };
 
 std::ostream& operator<<(std::ostream& os, const corenrn_parameters& corenrn_param);    /// Printing method.
 
 extern corenrn_parameters corenrn_param;    /// Declaring global corenrn_parameters object for this instance of CoreNeuron.
+extern int nrn_nobanner_;                   /// Global no banner setting
 
 }  // namespace coreneuron
 

--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -147,7 +147,9 @@ void nrn_init_and_load_data(int argc,
     Instrumentor::stop_profile();
 
     // memory footprint after mpi initialisation
-    report_mem_usage("After MPI_Init");
+    if (!corenrn_param.is_quiet()) {
+        report_mem_usage("After MPI_Init");
+    }
 
     // initialise default coreneuron parameters
     initnrn();
@@ -216,7 +218,9 @@ void nrn_init_and_load_data(int argc,
         nrn_set_extra_thread0_vdata();
     }
 
-    report_mem_usage("Before nrn_setup");
+    if (!corenrn_param.is_quiet()) {
+        report_mem_usage("Before nrn_setup");
+    }
 
     // set if need to interleave cells
     interleave_permute_type = corenrn_param.cell_interleave_permute;
@@ -255,7 +259,9 @@ void nrn_init_and_load_data(int argc,
     int spkcompress = corenrn_param.spkcompress;
     nrnmpi_spike_compress(spkcompress, (spkcompress ? true : false), use_multisend_);
 
-    report_mem_usage("After nrn_setup ");
+    if (!corenrn_param.is_quiet()) {
+        report_mem_usage("After nrn_setup ");
+    }
 
     // Invoke PatternStim
     if (!corenrn_param.patternstim.empty()) {
@@ -266,7 +272,7 @@ void nrn_init_and_load_data(int argc,
     nrn_set_timeout(200.);
 
     // show all configuration parameters for current run
-    if (nrnmpi_myid == 0) {
+    if (nrnmpi_myid == 0 && !corenrn_param.is_quiet()) {
         std::cout << corenrn_param << std::endl;
         std::cout << " Start time (t) = " << t << std::endl << std::endl;
     }
@@ -274,7 +280,9 @@ void nrn_init_and_load_data(int argc,
     // allocate buffer for mpi communication
     mk_spikevec_buffer(corenrn_param.spikebuf);
 
-    report_mem_usage("After mk_spikevec_buffer");
+    if (!corenrn_param.is_quiet()) {
+        report_mem_usage("After mk_spikevec_buffer");
+    }
 
     if (corenrn_param.gpu) {
         setup_nrnthreads_on_device(nrn_threads, nrn_nthread);
@@ -460,7 +468,9 @@ extern "C" int run_solve_core(int argc, char** argv) {
     std::string spikes_population_name;
     bool reports_needs_finalize = false;
 
-    report_mem_usage("After mk_mech");
+    if (!corenrn_param.is_quiet()) {
+        report_mem_usage("After mk_mech");
+    }
 
     // Create outpath if it does not exist
     if (nrnmpi_myid == 0) {
@@ -534,7 +544,9 @@ extern "C" int run_solve_core(int argc, char** argv) {
             nrn_finitialize(v != 1000., v);
         }
 
-        report_mem_usage("After nrn_finitialize");
+        if (!corenrn_param.is_quiet()) {
+            report_mem_usage("After nrn_finitialize");
+        }
 
         // register all reports into reportinglib
         double min_report_dt = INT_MAX;

--- a/coreneuron/io/mk_mech.cpp
+++ b/coreneuron/io/mk_mech.cpp
@@ -43,10 +43,10 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/coreneuron.hpp"
 #include "coreneuron/mechanism//eion.hpp"
 
-static char banner[] = "Duke, Yale, and the BlueBrain Project -- Copyright 1984-2019";
+static char banner[] = "Duke, Yale, and the BlueBrain Project -- Copyright 1984-2020";
 
 namespace coreneuron {
-int nrn_nobanner_;
+extern int nrn_nobanner_;
 
 // NB: this should go away
 extern const char* nrn_version(int);

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -31,6 +31,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include <map>
 #include <cstring>
 
+#include "coreneuron/apps/corenrn_parameters.hpp"
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/sim/multicore.hpp"
@@ -215,6 +216,7 @@ void (*nrn2core_trajectory_return_)(int tid, int n_pr, int vecsz, void** vpr, do
 // files with the first containing output_gids and netcon_srcgid which are
 // stored in the nt.presyns array and nt.netcons array respectively
 namespace coreneuron {
+extern corenrn_parameters corenrn_param;
 int nrn_setup_multiple = 1; /* default */
 int nrn_setup_extracon = 0; /* default */
 static int maxgid;
@@ -803,7 +805,7 @@ void nrn_setup(const char* filesdat,
     delete[] gidgroups;
     delete[] imult;
 
-    if (nrnmpi_myid == 0) {
+    if (nrnmpi_myid == 0 && !corenrn_param.is_quiet()) {
         printf(" Setup Done   : %.2lf seconds \n", nrn_wtime() - time);
     }
 }

--- a/coreneuron/network/netpar.cpp
+++ b/coreneuron/network/netpar.cpp
@@ -32,6 +32,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include <map>
 
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/apps/corenrn_parameters.hpp"
 #include "coreneuron/sim/multicore.hpp"
 #include "coreneuron/mpi/nrnmpi.h"
 #include "coreneuron/mpi/nrnmpidec.h"
@@ -50,6 +51,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace coreneuron {
 
+extern corenrn_parameters corenrn_param;
 class PreSyn;
 class InputPreSyn;
 
@@ -728,7 +730,7 @@ void BBS_netpar_solve(double tstop) {
 #endif
     tstopunset;
 
-    if (nrnmpi_myid == 0) {
+    if (nrnmpi_myid == 0 && !corenrn_param.is_quiet()) {
         printf("\nSolver Time : %g\n", nrn_wtime() - time);
     }
 }

--- a/coreneuron/sim/fadvance_core.cpp
+++ b/coreneuron/sim/fadvance_core.cpp
@@ -30,6 +30,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "coreneuron/coreneuron.hpp"
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/apps/corenrn_parameters.hpp"
 #include "coreneuron/sim/multicore.hpp"
 #include "coreneuron/mpi/nrnmpi.h"
 #include "coreneuron/sim/fast_imem.hpp"
@@ -45,6 +46,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace coreneuron {
 
+extern corenrn_parameters corenrn_param;
 static void* nrn_fixed_step_thread(NrnThread*);
 static void* nrn_fixed_step_group_thread(NrnThread*, int, int, int&);
 
@@ -94,20 +96,20 @@ integration interval before joining
 static progressbar* progress;
 
 void initialize_progress_bar(int nstep) {
-    if (nrnmpi_myid == 0) {
+    if (nrnmpi_myid == 0 && !corenrn_param.is_quiet()) {
         printf("\n");
         progress = progressbar_new(" psolve", nstep);
     }
 }
 
 void update_progress_bar(int step, double time) {
-    if (nrnmpi_myid == 0) {
+    if (nrnmpi_myid == 0 && !corenrn_param.is_quiet()) {
         progressbar_update(progress, step, time);
     }
 }
 
 void finalize_progress_bar() {
-    if (nrnmpi_myid == 0) {
+    if (nrnmpi_myid == 0 && !corenrn_param.is_quiet()) {
         progressbar_finish(progress);
     }
 }

--- a/coreneuron/utils/nrn_stats.cpp
+++ b/coreneuron/utils/nrn_stats.cpp
@@ -211,9 +211,5 @@ void report_cell_stats(void) {
         nrnmpi_barrier();
     }
 #endif
-    if (nrnmpi_myid == 0) {
-        printf("\n\n");
-        fflush(stdout);
-    }
 }
 }  // namespace coreneuron

--- a/coreneuron/utils/nrn_stats.cpp
+++ b/coreneuron/utils/nrn_stats.cpp
@@ -36,6 +36,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdio>
 #include <climits>
 #include <vector>
+#include "coreneuron/apps/corenrn_parameters.hpp"
 #include "coreneuron/utils/nrn_stats.h"
 #include "coreneuron/mpi/nrnmpi.h"
 #include "coreneuron/sim/multicore.hpp"
@@ -44,6 +45,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/io/output_spikes.hpp"
 namespace coreneuron {
 extern NetCvode* net_cvode_instance;
+extern corenrn_parameters corenrn_param;
 
 const int NUM_STATS = 12;
 #if COLLECT_TQueue_STATISTICS
@@ -155,7 +157,7 @@ void report_cell_stats(void) {
     memcpy(gstat_array, stat_array, sizeof(stat_array));
 #endif
 
-    if (nrnmpi_myid == 0) {
+    if (nrnmpi_myid == 0 && !corenrn_param.is_quiet()) {
         printf("\n\n Simulation Statistics\n");
         printf(" Number of cells: %ld\n", gstat_array[0]);
         printf(" Number of compartments: %ld\n", gstat_array[10]);


### PR DESCRIPTION
Sample output when launched from NEURON: 
```
Starting CoreNEURON data generation
Starting CoreNEURON simulation
 Additional mechanisms from files
 Ca.mod CaDynamics_DC0.mod CaDynamics_E2.mod Ca_HVA.mod Ca_HVA2.mod Ca_LVAst.mod CoreConfig.mod Ih.mod Im.mod K_Pst.mod K_Tst.mod KdShu2007.mod NaTa_t.mod NaTg.mod NaTs2_t.mod Nap_Et2.mod ProbAMPANMDA_EMS.mod ProbGABAAB_EMS.mod ProfileHelper.mod SK_E2.mod SKv3_1.mod TTXDynamicsSwitch.mod VecStim.mod cacumm.mod cacummb.mod cagk.mod cal2.mod can2.mod cat.mod gap.mod h.mod halfgap.mod kadist.mod kaprox.mod kca.mod kd.mod kd2.mod kdb.mod kdrbca1.mod kdrca1.mod km.mod kmb.mod na3n.mod naxn.mod netstim_inhpoisson.mod new_calcium_channels.mod


 WARNING: nrn_nrn_wrote_conc support on GPU need to validate!

 psolve |========================================================| t: 50.00  ETA: 0h00m20s

Solver Time : 19.8974
```

@pramodk I would still keep the mechanisms (as they could be different ones?) and solver information.