### PR TITLE
Abort from rank printing error message

### DIFF
--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -1230,8 +1230,8 @@ void read_phase2(FileHandler& F, int imult, NrnThread& nt) {
                 printf(
                     "Error : NEURON and CoreNEURON must use same mod files for compatibility, %d different mod file(s) found. Re-compile special and special-core!\n",
                     diff_mech_count);
+                nrn_abort(1);
             }
-            nrn_abort(1);
         }
 
         nt._nidata = F.read_int();


### PR DESCRIPTION
This is minor fix to allow rank0 to print message and then abort. Otherwise we get error stack like:

```
Model uses gap junctions
MPT ERROR: Rank 1(g:1) is aborting with error code 1.
	Process ID: 308765, Host: r2i3n6, Program: /gpfs/bbp.cscs.ch/project/proj16/kumbhar/pramod_scratch/modeldb-bulb3d-sim/sim/x86_64/special-core
	MPT Version: HPE MPT 2.21  08/29/19 00:34:00

MPT: --------stack traceback-------
srun: Job step aborted: Waiting up to 32 seconds for job step to finish.
```

With this PR:

```
Model uses gap junctions
Error: ThreshDetect is a different MOD file than used by NEURON!
Error : NEURON and CoreNEURON must use same mod files for compatibility, 1 different mod file(s) found. Re-compile special and special-core!
MPT ERROR: Rank 0(g:0) is aborting with error code 1.
	Process ID: 308585, Host: r2i3n6, Program: /gpfs/bbp.cscs.ch/project/proj16/kumbhar/pramod_scratch/modeldb-bulb3d-sim/sim/x86_64/special-core
	MPT Version: HPE MPT 2.21  08/29/19 00:34:00
```