### PR TITLE
Return all spikes vectors to NEURON

### DIFF
--- a/coreneuron/io/nrn2core_direct.h
+++ b/coreneuron/io/nrn2core_direct.h
@@ -108,7 +108,7 @@ extern void (*nrn2core_trajectory_values_)(int tid, int n_pr, void** vpr, double
 extern void (*nrn2core_trajectory_return_)(int tid, int n_pr, int vecsz, void** vpr, double t);
 
 /* send all spikes vectors to NEURON */  
-extern void (*nrn2core_all_spike_vectors_return_)(std::vector<double>& spikevec, std::vector<int>& gidvec);
+extern int (*nrn2core_all_spike_vectors_return_)(std::vector<double>& spikevec, std::vector<int>& gidvec);
 }
 
 #endif /* nrn2core_direct_h */

--- a/coreneuron/io/nrn2core_direct.h
+++ b/coreneuron/io/nrn2core_direct.h
@@ -106,6 +106,9 @@ extern void (*nrn2core_trajectory_values_)(int tid, int n_pr, void** vpr, double
 
 /* Filled the Vector data arrays and send back the sizes at end of run */
 extern void (*nrn2core_trajectory_return_)(int tid, int n_pr, int vecsz, void** vpr, double t);
+
+/* send all spikes vectors to NEURON */  
+extern void (*nrn2core_all_spike_vectors_return_)(std::vector<double>& spikevec, std::vector<int>& gidvec);
 }
 
 #endif /* nrn2core_direct_h */

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -146,6 +146,8 @@ void (*nrn2core_trajectory_values_)(int tid, int n_pr, void** vpr, double t);
 
 void (*nrn2core_trajectory_return_)(int tid, int n_pr, int vecsz, void** vpr, double t);
 
+void (*nrn2core_all_spike_vectors_return_)(std::vector<double>& spikevec, std::vector<int>& gidvec);
+
 // file format defined in cooperation with nrncore/src/nrniv/nrnbbcore_write.cpp
 // single integers are ascii one per line. arrays are binary int or double
 // Note that regardless of the gid contents of a group, since all gids are

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -146,7 +146,7 @@ void (*nrn2core_trajectory_values_)(int tid, int n_pr, void** vpr, double t);
 
 void (*nrn2core_trajectory_return_)(int tid, int n_pr, int vecsz, void** vpr, double t);
 
-void (*nrn2core_all_spike_vectors_return_)(std::vector<double>& spikevec, std::vector<int>& gidvec);
+int (*nrn2core_all_spike_vectors_return_)(std::vector<double>& spikevec, std::vector<int>& gidvec);
 
 // file format defined in cooperation with nrncore/src/nrniv/nrnbbcore_write.cpp
 // single integers are ascii one per line. arrays are binary int or double

--- a/coreneuron/io/output_spikes.cpp
+++ b/coreneuron/io/output_spikes.cpp
@@ -182,10 +182,6 @@ void output_spikes_parallel(const char* outpath, const std::string& population_n
                         spikevec_gid.size(), outpath);
 #endif  // ENABLE_SONATA_REPORTS
 
-    // try to transfer spikes to NRN. If successful, don't write out.dat
-    if (all_spikes_return(spikevec_time, spikevec_gid))
-        return;
-
     sort_spikes(spikevec_time, spikevec_gid);
     nrnmpi_barrier();
 
@@ -245,10 +241,6 @@ void output_spikes_parallel(const char* outpath, const std::string& population_n
 
 void output_spikes_serial(const char* outpath) {
 
-    // try to transfer spikes to. If successfull, don't write out.dat
-    if (all_spikes_return(spikevec_time, spikevec_gid))
-        return;
-
     std::stringstream ss;
     ss << outpath << "/out.dat";
     std::string fname = ss.str();
@@ -275,6 +267,9 @@ void output_spikes_serial(const char* outpath) {
 }
 
 void output_spikes(const char* outpath, const std::string& population_name) {
+    // try to transfer spikes to NEURON. If successfull, don't write out.dat
+    if (all_spikes_return(spikevec_time, spikevec_gid))
+        return;
 #if NRNMPI
     if (nrnmpi_initialized()) {
         output_spikes_parallel(outpath, population_name);


### PR DESCRIPTION
In link with: https://github.com/neuronsimulator/nrn/pull/692 

Should we add an extra parameter to the NEURON callback in order to indicate if writing `output.dat` should be skipped? Or is something we'd like to have at a global level, say a CLI option? 