### PR TITLE
Update voltage vector from GPU to CPU if trajectories are recorded

### DIFF
--- a/coreneuron/gpu/nrn_acc_manager.cpp
+++ b/coreneuron/gpu/nrn_acc_manager.cpp
@@ -752,6 +752,21 @@ void update_nrnthreads_on_device(NrnThread* threads, int nthreads) {
 #endif
 }
 
+/**
+ * Copy voltage vector from GPU to CPU
+ *
+ * \todo Currently we are copying all voltage vector from GPU
+ *       to CPU. We need fine-grain implementation to copy
+ *       only requested portion of the voltage vector.
+ */
+void update_voltage_from_gpu(NrnThread* nt) {
+    if (nt->compute_gpu && nt->end > 0) {
+        double* voltage = nt->_actual_v;
+        int num_voltage = nrn_soa_padded_size(nt->end, 0);
+        #pragma acc update host(voltage[0 : num_voltage])
+    }
+}
+
 void update_matrix_from_gpu(NrnThread* _nt) {
 #ifdef _OPENACC
     if (_nt->compute_gpu && (_nt->end > 0)) {

--- a/coreneuron/gpu/nrn_acc_manager.hpp
+++ b/coreneuron/gpu/nrn_acc_manager.hpp
@@ -20,6 +20,7 @@ void update_matrix_to_gpu(NrnThread* _nt);
 void update_net_receive_buffer(NrnThread* _nt);
 void realloc_net_receive_buffer(NrnThread* nt, Memb_list* ml);
 void update_net_send_buffer_on_host(NrnThread* nt, NetSendBuffer_t* nsb);
+void update_voltage_from_gpu(NrnThread* nt);
 void init_gpu();
 
 }  // namespace coreneuron

--- a/coreneuron/sim/fadvance_core.cpp
+++ b/coreneuron/sim/fadvance_core.cpp
@@ -286,6 +286,11 @@ void nrncore2nrn_send_values(NrnThread* nth) {
 
     TrajectoryRequests* tr = nth->trajec_requests;
     if (tr) {
+        // \todo Check if user has requested voltages for this NrnThread object.
+        //       Currently we are updating voltages if there is any trajectory
+        //       requested by NEURON.
+        update_voltage_from_gpu(nth); 
+
         if (tr->varrays) {  // full trajectories into Vector data
             double** va = tr->varrays;
             int vs = tr->vsize++;


### PR DESCRIPTION
  - NEURON can request various trajectories from CoreNEURON
  - In this implementation we are just updating voltage vector
    and satisfy the use case of olfactory 3d-bulb model
  - We will need more fine grain approach (for future PR)