### PR TITLE
Remove queue statistics related (dead) code

### DIFF
--- a/coreneuron/network/netcvode.cpp
+++ b/coreneuron/network/netcvode.cpp
@@ -171,10 +171,6 @@ void NetCvodeThreadData::enqueue(NetCvode* nc, NrnThread* nt) {
     for (size_t i = 0; i < inter_thread_events_.size(); ++i) {
         InterThreadEvent ite = inter_thread_events_[i];
         nc->bin_event(ite.t_, ite.de_, nt);
-#if COLLECT_TQueue_STATISTICS
-        /// TQueue::qtype::ite = 2
-        tqe_->record_stat_event(2, ite.t_);
-#endif
     }
     inter_thread_events_.clear();
     MUTUNLOCK
@@ -525,11 +521,6 @@ void InputPreSyn::send(double tt, NetCvode* ns, NrnThread* nt) {
         if (d->active_ && d->target_) {
             NrnThread* n = PP2NT(d->target_);
 
-#if COLLECT_TQueue_STATISTICS
-            /// TQueue::qtype::spike = 1
-            ns->p[nt->id].tqe_->record_stat_event(1, tt);
-#endif
-
             if (nt == n)
                 ns->bin_event(tt + d->delay_, d, n);
             else
@@ -767,11 +758,6 @@ tryagain:
             if (print_event_) {
                 db->pr("binq deliver", nrn_threads->_t, this);
             }
-#endif
-
-#if COLLECT_TQueue_STATISTICS
-            /// TQueue::qtype::deq = 3
-            p[tid].tqe_->record_stat_event(3, q->t_);
 #endif
 
             delete q;

--- a/coreneuron/network/tqueue.cpp
+++ b/coreneuron/network/tqueue.cpp
@@ -34,11 +34,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/sim/multicore.hpp"
 #include "coreneuron/network/tqueue.hpp"
 
-#if COLLECT_TQueue_STATISTICS
-#define STAT(arg) ++arg;
-#else
-#define STAT(arg) /**/
-#endif
 namespace coreneuron {
 // splay tree + bin queue limited to fixed step method
 // for event-sets or priority queues
@@ -65,9 +60,6 @@ BinQ::BinQ() {
     }
     qpt_ = 0;
     tt_ = 0.;
-#if COLLECT_TQueue_STATISTICS
-    nfenq = nfdeq = 0;
-#endif
 }
 
 BinQ::~BinQ() {
@@ -115,17 +107,11 @@ void BinQ::enqueue(double td, TQItem* q) {
     q->cnt_ = idt;  // only for iteration
     q->left_ = bins_[idt];
     bins_[idt] = q;
-#if COLLECT_TQueue_STATISTICS
-    ++nfenq;
-#endif
 }
 TQItem* BinQ::dequeue() {
     TQItem* q = bins_[qpt_];
     if (q) {
         bins_[qpt_] = q->left_;
-#if COLLECT_TQueue_STATISTICS
-        ++nfdeq;
-#endif
     }
     return q;
 }

--- a/coreneuron/network/tqueue.hpp
+++ b/coreneuron/network/tqueue.hpp
@@ -56,7 +56,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/utils/nrnmutdec.h"
 
 namespace coreneuron {
-#define COLLECT_TQueue_STATISTICS 0
 #define STRCMP(a, b) (a - b)
 
 class TQItem;
@@ -134,10 +133,6 @@ class BinQ {
     TQItem* next(TQItem*);
     void remove(TQItem*);
     void resize(int);
-#if COLLECT_TQueue_STATISTICS
-  public:
-    int nfenq, nfdeq;
-#endif
   private:
     double tt_;  // time at beginning of qpt_ interval
     int nbin_, qpt_;
@@ -172,10 +167,6 @@ class TQueue {
     inline TQItem* atomic_dq(double til);
     inline void remove(TQItem*);
     inline void move(TQItem*, double tnew);
-#if COLLECT_TQueue_STATISTICS
-    inline void statistics();
-    inline void record_stat_event(int type, double time);
-#endif
     int nshift_;
 
     /// Priority queue of vectors for queuing the events. enqueuing for move() and
@@ -183,10 +174,6 @@ class TQueue {
     std::priority_queue<TQPair, std::vector<TQPair>, less_time> pq_que_;
     /// Types of queuing statistics
     enum qtype { enq = 0, spike, ite, deq };
-#if COLLECT_TQueue_STATISTICS
-    /// Map for queuing statistics
-    std::map<double, long> time_map_events[4];
-#endif
 
   private:
     double least_t_nolock() {
@@ -208,10 +195,6 @@ class TQueue {
         return TQPair(p->t_, p);
     }
     MUTDEC
-#if COLLECT_TQueue_STATISTICS
-    unsigned long ninsert, nrem, nleast, nbal, ncmplxrem;
-    unsigned long ncompare, nleastsrch, nfind, nfindsrch, nmove, nfastmove;
-#endif
 };
 }  // namespace coreneuron
 #include "coreneuron/network/tqueue.ipp"

--- a/coreneuron/utils/nrn_stats.cpp
+++ b/coreneuron/utils/nrn_stats.cpp
@@ -44,13 +44,9 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/network/partrans.hpp"
 #include "coreneuron/io/output_spikes.hpp"
 namespace coreneuron {
-extern NetCvode* net_cvode_instance;
 extern corenrn_parameters corenrn_param;
 
 const int NUM_STATS = 12;
-#if COLLECT_TQueue_STATISTICS
-const int NUM_EVENT_TYPES = 3;
-#endif
 enum event_type { enq = 0, spike, ite };
 
 void report_cell_stats(void) {
@@ -79,77 +75,6 @@ void report_cell_stats(void) {
 
     stat_array[6] = (long)spikevec_positive_gid_size;  // number of non-negative gid spikes
 
-/// Event queuing statistics
-#if COLLECT_TQueue_STATISTICS
-    //    long que_stat[3] = {0, 0, 0}, gmax_que_stat[3];
-    /// Number of events for each thread, enqueued and spike enqueued
-    std::vector<long>
-        thread_vec_events[NUM_EVENT_TYPES];  // Number of events throughout the simulation
-    std::vector<std::pair<double, long> >
-        thread_vec_max_num_events[NUM_EVENT_TYPES];  // Time and the maximum number of events
-    std::vector<long> thread_vec_event_times[NUM_EVENT_TYPES];  // Number of time intervals for
-                                                                // events in the simulation
-    for (int type = 0; type < NUM_EVENT_TYPES; ++type) {
-        thread_vec_events[type].resize(nrn_nthread);
-        thread_vec_max_num_events[type].resize(nrn_nthread);
-        thread_vec_event_times[type].resize(nrn_nthread);
-    }
-
-    /// Get the total number of enqueued events and enqueued with spike events
-    /// time_map_events - maps from TQueue class in sptbinq.h, - a collector of events statistics
-    for (int ith = 0; ith < nrn_nthread; ++ith) {
-        for (int type = 0; type < NUM_EVENT_TYPES; ++type) {
-            thread_vec_event_times[type][ith] +=
-                (long)net_cvode_instance->p[ith].tqe_->time_map_events[type].size();
-            thread_vec_max_num_events[type][ith].second = 0;
-            auto mapit = net_cvode_instance->p[ith].tqe_->time_map_events[type].begin();
-            for (; mapit != net_cvode_instance->p[ith].tqe_->time_map_events[type].end(); ++mapit) {
-                thread_vec_events[type][ith] += mapit->second;
-                if (mapit->second > thread_vec_max_num_events[type][ith].second) {
-                    thread_vec_max_num_events[type][ith].second = mapit->second;
-                    thread_vec_max_num_events[type][ith].first = mapit->first;
-                }
-            }
-            stat_array[7 + type] +=
-                thread_vec_events[type][ith];  // number of enqueued events and number of spike
-                                               // triggered events (enqueued after spike exchange)
-        }
-    }
-
-    /// Maximum number of events and correspondent time
-    long max_num_events[NUM_EVENT_TYPES] = {0, 0, 0}, gmax_num_events[NUM_EVENT_TYPES];
-    /// Get the maximum number of events one between threads first
-    for (int type = 0; type < NUM_EVENT_TYPES; ++type) {
-        for (int ith = 0; ith < nrn_nthread; ++ith) {
-            if (thread_vec_max_num_events[type][ith].second > max_num_events[type]) {
-                max_num_events[type] = thread_vec_max_num_events[type][ith].second;
-            }
-        }
-    }
-    nrnmpi_long_allreduce_vec(max_num_events, gmax_num_events, NUM_EVENT_TYPES, 2);
-
-    long qmin[NUM_EVENT_TYPES] = {LONG_MAX, LONG_MAX, LONG_MAX}, qmax[NUM_EVENT_TYPES] = {0, 0, 0},
-         qsum[NUM_EVENT_TYPES] = {0, 0, 0}, qdiff[NUM_EVENT_TYPES];
-    long gqmax[NUM_EVENT_TYPES], gqmin[NUM_EVENT_TYPES], gqsum[NUM_EVENT_TYPES],
-        gqdiff_max[NUM_EVENT_TYPES], gqdiff_min[NUM_EVENT_TYPES];
-    /// Max and min number of time intervals for the events and difference between threads
-    for (int type = 0; type < NUM_EVENT_TYPES; ++type) {
-        for (int ith = 0; ith < nrn_nthread; ++ith) {
-            qsum[type] += thread_vec_event_times[type][ith];
-            if (thread_vec_event_times[type][ith] > qmax[type])
-                qmax[type] = thread_vec_event_times[type][ith];
-            if (thread_vec_event_times[type][ith] < qmin[type])
-                qmin[type] = thread_vec_event_times[type][ith];
-        }
-        qdiff[type] = qmax[type] - qmin[type];
-    }
-    nrnmpi_long_allreduce_vec(qsum, gqsum, NUM_EVENT_TYPES, 1);
-    nrnmpi_long_allreduce_vec(qmax, gqmax, NUM_EVENT_TYPES, 2);
-    nrnmpi_long_allreduce_vec(qmin, gqmin, NUM_EVENT_TYPES, 0);
-    nrnmpi_long_allreduce_vec(qdiff, gqdiff_max, NUM_EVENT_TYPES, 2);
-    nrnmpi_long_allreduce_vec(qdiff, gqdiff_min, NUM_EVENT_TYPES, 0);
-#endif
-
 #if NRNMPI
     nrnmpi_long_allreduce_vec(stat_array, gstat_array, NUM_STATS, 1);
 #else
@@ -168,48 +93,6 @@ void report_cell_stats(void) {
         printf(" Number of transfer (gap) targets: %ld\n", gstat_array[11]);
         printf(" Number of spikes: %ld\n", gstat_array[5]);
         printf(" Number of spikes with non negative gid-s: %ld\n", gstat_array[6]);
-#if COLLECT_TQueue_STATISTICS
-        printf(" Number of enqueued events: %ld\n", gstat_array[7]);
-        printf(" Maximum number of time intervals for the events: %ld\n", gqmax[enq]);
-        printf(" Number of after-spike enqueued events: %ld\n", gstat_array[8]);
-        printf(" Number of inter-thread enqueued events: %ld\n", gstat_array[9]);
-        //        printf(" Maximum difference of time interval enqueued events between threads on a
-        //        single MPI: %ld\n", gqdiff_max[enq]);
-        //        printf(" Maximum difference of time interval spike enqueued events between threads
-        //        on a single MPI: %ld\n", gqdiff_max[spike]);
-        //        printf(" Minimum difference of time interval enqueued events between threads on a
-        //        single MPI: %ld\n", gqdiff_min[enq]);
-        //        printf(" Minimum difference of time interval spike enqueued events between threads
-        //        on a single MPI: %ld\n", gqdiff_min[spike]);
-        printf(" Maximum number of enqueued events during specific time by one thread: %ld\n",
-               gmax_num_events[enq]);
-        printf(" Maximum number of spike enqueued events during specific time by one thread: %ld\n",
-               gmax_num_events[spike]);
-#endif
     }
-
-#if COLLECT_TQueue_STATISTICS
-    int q_detailed_stats = 0;
-    if (q_detailed_stats) {
-        nrnmpi_barrier();
-        if (nrnmpi_myid == 0)
-            printf("\n Times for maximum number of enqueued events: ");
-        nrnmpi_barrier();
-        for (int ith = 0; ith < nrn_nthread; ++ith) {
-            if (thread_vec_max_num_events[enq][ith].second == gmax_num_events[enq])
-                printf("%lf\n", thread_vec_max_num_events[enq][ith].first);
-        }
-        nrnmpi_barrier();
-
-        if (nrnmpi_myid == 0)
-            printf("\n\n Times for maximum number of spike enqueued events: ");
-        nrnmpi_barrier();
-        for (int ith = 0; ith < nrn_nthread; ++ith) {
-            if (thread_vec_max_num_events[spike][ith].second == gmax_num_events[spike])
-                printf("%lf\n", thread_vec_max_num_events[spike][ith].first);
-        }
-        nrnmpi_barrier();
-    }
-#endif
 }
 }  // namespace coreneuron


### PR DESCRIPTION
 - histotically queue stats related code was added
   to get an idea of number of events in the particular
   simulation
 - we haven't used this for years and I haven't found
   this anything useful anyway.