### PR TITLE
If a netcon_srcgid is negative, need to determine the thread.

### DIFF
--- a/coreneuron/io/nrn2core_direct.h
+++ b/coreneuron/io/nrn2core_direct.h
@@ -30,7 +30,8 @@ extern int (*nrn2core_get_dat1_)(int tid,
                                  int& n_presyn,
                                  int& n_netcon,
                                  int*& output_gid,
-                                 int*& netcon_srcgid);
+                                 int*& netcon_srcgid,
+                                 std::vector<int>& netcon_negsrcgid_tid);
 
 extern int (*nrn2core_get_dat2_1_)(int tid,
                                    int& ngid,

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -497,10 +497,10 @@ void nrn_setup(const char* filesdat,
         nrn_partrans::gap_mpi_setup(userParams.ngroup);
     }
 
+    netcon_negsrcgid_tid.resize(nrn_nthread);
     if (!corenrn_embedded) {
         coreneuron::phase_wrapper<coreneuron::phase::one>(userParams);
     } else {
-        netcon_negsrcgid_tid.resize(nrn_nthread);
         nrn_multithread_job([](NrnThread* n) {
             Phase1 p1; 
             p1.read_direct(n->id);

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -287,8 +287,8 @@ void determine_inputpresyn() {
         NrnThread& nt = nrn_threads[ith];
         // associate gid with InputPreSyn and increase PreSyn and InputPreSyn count
         nt.n_input_presyn = 0;
-        // if empty then not to be used.
-        std::vector<int>& negsrcgid_tid = netcon_negsrcgid_tid[ith];
+        std::vector<int> dummy;
+        std::vector<int>& negsrcgid_tid = corenrn_embedded ? netcon_negsrcgid_tid[ith] : dummy;
         size_t i_tid = 0;
         for (int i = 0; i < nt.n_netcon; ++i) {
             int gid = netcon_srcgid[ith][i];
@@ -384,8 +384,8 @@ void determine_inputpresyn() {
     // only used via ps.nc_index_ and ps.nc_cnt_;
     for (int ith = 0; ith < nrn_nthread; ++ith) {
         NrnThread& nt = nrn_threads[ith];
-        // if empty then not to be used.
-        std::vector<int>& negsrcgid_tid = netcon_negsrcgid_tid[ith];
+        std::vector<int> dummy;
+        std::vector<int>& negsrcgid_tid = corenrn_embedded ? netcon_negsrcgid_tid[ith] : dummy;
         size_t i_tid = 0;
         for (int i = 0; i < nt.n_netcon; ++i) {
             NetCon* nc = nt.netcons + i;
@@ -497,10 +497,10 @@ void nrn_setup(const char* filesdat,
         nrn_partrans::gap_mpi_setup(userParams.ngroup);
     }
 
-    netcon_negsrcgid_tid.resize(nrn_nthread);
     if (!corenrn_embedded) {
         coreneuron::phase_wrapper<coreneuron::phase::one>(userParams);
     } else {
+        netcon_negsrcgid_tid.resize(nrn_nthread);
         nrn_multithread_job([](NrnThread* n) {
             Phase1 p1; 
             p1.read_direct(n->id);

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -113,6 +113,14 @@ void (*nrn2core_all_weights_return_)(std::vector<double*>& weights);
 // encode the thread number into the negative gid
 // (i.e -ith - nth*(type +1000*index)) failed due to not large enough
 // integer domain size.
+// Note that for file transfer it is an error if a negative srcgid is
+// not in the same thread as the target. This is because there it may
+// not be the case that threads in a NEURON process end up on same process
+// in CoreNEURON. NEURON will raise an error if this
+// is the case. However, for direct memory transfer, it is allowed that
+// a negative srcgid may be in a different thread than the target. So
+// nrn2core_get_dat1 has a last arg netcon_negsrcgid_tid that specifies
+// for the negative gids in netcon_srcgid (in that order) the source thread.
 //
 // <firstgid>_2.dat
 // n_output n_real_output, nnode
@@ -179,6 +187,10 @@ std::vector<NetCon*> netcon_in_presyn_order_;
 
 /// Only for setup vector of netcon source gids
 std::vector<int*> netcon_srcgid;
+
+/// If a netcon_srcgid is negative, need to determine the thread when
+/// in order to use the correct neg_gid2out[tid] map
+std::vector<std::vector<int> > netcon_negsrcgid_tid;
 
 /* read files.dat file and distribute cellgroups to all mpi ranks */
 void nrn_read_filesdat(int& ngrp, int*& grp, const char* filesdat) {
@@ -275,6 +287,9 @@ void determine_inputpresyn() {
         NrnThread& nt = nrn_threads[ith];
         // associate gid with InputPreSyn and increase PreSyn and InputPreSyn count
         nt.n_input_presyn = 0;
+        // if empty then not to be used.
+        std::vector<int>& negsrcgid_tid = netcon_negsrcgid_tid[ith];
+        size_t i_tid = 0;
         for (int i = 0; i < nt.n_netcon; ++i) {
             int gid = netcon_srcgid[ith][i];
             if (gid >= 0) {
@@ -299,8 +314,12 @@ void determine_inputpresyn() {
                 inputpresyn_.push_back(psi);
                 ++nt.n_input_presyn;
             } else {
-                auto gid2out_it = neg_gid2out[nt.id].find(gid);
-                if (gid2out_it != neg_gid2out[nt.id].end()) {
+                int tid = nt.id;
+                if (!negsrcgid_tid.empty()) {
+                    tid = negsrcgid_tid[i_tid++];
+                }
+                auto gid2out_it = neg_gid2out[tid].find(gid);
+                if (gid2out_it != neg_gid2out[tid].end()) {
                     /// Increase negative PreSyn count
                     ++gid2out_it->second->nc_cnt_;
                 }
@@ -365,12 +384,19 @@ void determine_inputpresyn() {
     // only used via ps.nc_index_ and ps.nc_cnt_;
     for (int ith = 0; ith < nrn_nthread; ++ith) {
         NrnThread& nt = nrn_threads[ith];
+        // if empty then not to be used.
+        std::vector<int>& negsrcgid_tid = netcon_negsrcgid_tid[ith];
+        size_t i_tid = 0;
         for (int i = 0; i < nt.n_netcon; ++i) {
             NetCon* nc = nt.netcons + i;
             int gid = netcon_srcgid[ith][i];
+            int tid = ith;
+            if (!negsrcgid_tid.empty() && gid < -1) {
+              tid = negsrcgid_tid[i_tid++];
+            }
             PreSyn* ps;
             InputPreSyn* psi;
-            netpar_tid_gid2ps(ith, gid, &ps, &psi);
+            netpar_tid_gid2ps(tid, gid, &ps, &psi);
             if (ps) {
                 netcon_in_presyn_order_[ps->nc_index_ + ps->nc_cnt_] = nc;
                 ++ps->nc_cnt_;
@@ -394,6 +420,7 @@ void nrn_setup_cleanup() {
             delete[] netcon_srcgid[ith];
     }
     netcon_srcgid.clear();
+    netcon_negsrcgid_tid.clear();
     neg_gid2out.clear();
 }
 
@@ -473,6 +500,7 @@ void nrn_setup(const char* filesdat,
     if (!corenrn_embedded) {
         coreneuron::phase_wrapper<coreneuron::phase::one>(userParams);
     } else {
+        netcon_negsrcgid_tid.resize(nrn_nthread);
         nrn_multithread_job([](NrnThread* n) {
             Phase1 p1; 
             p1.read_direct(n->id);

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -287,8 +287,8 @@ void determine_inputpresyn() {
         NrnThread& nt = nrn_threads[ith];
         // associate gid with InputPreSyn and increase PreSyn and InputPreSyn count
         nt.n_input_presyn = 0;
-        std::vector<int> dummy;
-        std::vector<int>& negsrcgid_tid = corenrn_embedded ? nrnthreads_netcon_negsrcgid_tid[ith] : dummy;
+        // if single thread or file transfer then definitely empty.
+        std::vector<int>& negsrcgid_tid = nrnthreads_netcon_negsrcgid_tid[ith];
         size_t i_tid = 0;
         for (int i = 0; i < nt.n_netcon; ++i) {
             int gid = nrnthreads_netcon_srcgid[ith][i];
@@ -384,8 +384,8 @@ void determine_inputpresyn() {
     // only used via ps.nc_index_ and ps.nc_cnt_;
     for (int ith = 0; ith < nrn_nthread; ++ith) {
         NrnThread& nt = nrn_threads[ith];
-        std::vector<int> dummy;
-        std::vector<int>& negsrcgid_tid = corenrn_embedded ? nrnthreads_netcon_negsrcgid_tid[ith] : dummy;
+        // if single thread or file transfer then definitely empty.
+        std::vector<int>& negsrcgid_tid = nrnthreads_netcon_negsrcgid_tid[ith];
         size_t i_tid = 0;
         for (int i = 0; i < nt.n_netcon; ++i) {
             NetCon* nc = nt.netcons + i;
@@ -497,10 +497,10 @@ void nrn_setup(const char* filesdat,
         nrn_partrans::gap_mpi_setup(userParams.ngroup);
     }
 
+    nrnthreads_netcon_negsrcgid_tid.resize(nrn_nthread);
     if (!corenrn_embedded) {
         coreneuron::phase_wrapper<coreneuron::phase::one>(userParams);
     } else {
-        nrnthreads_netcon_negsrcgid_tid.resize(nrn_nthread);
         nrn_multithread_job([](NrnThread* n) {
             Phase1 p1; 
             p1.read_direct(n->id);

--- a/coreneuron/io/phase1.cpp
+++ b/coreneuron/io/phase1.cpp
@@ -27,18 +27,6 @@ void Phase1::read_file(FileHandler& F) {
     F.close();
 }
 
-static void prsrctid(int thread_id, int n, int* srcgid, std::vector<int>& srctid) {
-  if (!srctid.empty()) {
-    int i = 0;
-    for (int i_nc=0; i_nc < n; ++i_nc) {
-      if (srcgid[i_nc] < -1) {
-        printf("srcgid=%d tid=%d srctid=%d\n", srcgid[i_nc], thread_id, srctid[i]);
-        ++i;
-      }
-    }
-  }
-}
-
 void Phase1::read_direct(int thread_id) {
     int* output_gids;
     int* netcon_srcgid;
@@ -66,12 +54,12 @@ void Phase1::populate(NrnThread& nt, OMP_Mutex& mut) {
     nt.n_presyn = this->output_gids.size();
     nt.n_netcon = this->netcon_srcgids.size();
 
-    netcon_srcgid[nt.id] = new int[nt.n_netcon];
+    nrnthreads_netcon_srcgid[nt.id] = new int[nt.n_netcon];
     std::copy(this->netcon_srcgids.begin(), this->netcon_srcgids.end(),
-              netcon_srcgid[nt.id]);
+              nrnthreads_netcon_srcgid[nt.id]);
 
     if (corenrn_embedded) { // multiple threads and direct mode.
-        coreneuron::netcon_negsrcgid_tid[nt.id] = this->netcon_negsrcgid_tid;
+        coreneuron::nrnthreads_netcon_negsrcgid_tid[nt.id] = this->netcon_negsrcgid_tid;
     }
 
     nt.netcons = new NetCon[nt.n_netcon];

--- a/coreneuron/io/phase1.cpp
+++ b/coreneuron/io/phase1.cpp
@@ -46,10 +46,6 @@ void Phase1::read_direct(int thread_id) {
     delete[] netcon_srcgid;
 }
 
-extern "C" {
-extern bool corenrn_embedded;
-}
-
 void Phase1::populate(NrnThread& nt, OMP_Mutex& mut) {
     nt.n_presyn = this->output_gids.size();
     nt.n_netcon = this->netcon_srcgids.size();
@@ -58,9 +54,8 @@ void Phase1::populate(NrnThread& nt, OMP_Mutex& mut) {
     std::copy(this->netcon_srcgids.begin(), this->netcon_srcgids.end(),
               nrnthreads_netcon_srcgid[nt.id]);
 
-    if (corenrn_embedded) { // multiple threads and direct mode.
-        coreneuron::nrnthreads_netcon_negsrcgid_tid[nt.id] = this->netcon_negsrcgid_tid;
-    }
+    // netcon_negsrcgid_tid is empty if file transfer or single thread
+    coreneuron::nrnthreads_netcon_negsrcgid_tid[nt.id] = this->netcon_negsrcgid_tid;
 
     nt.netcons = new NetCon[nt.n_netcon];
     nt.presyns_helper = (PreSynHelper*)ecalloc_align(nt.n_presyn, sizeof(PreSynHelper));

--- a/coreneuron/io/phase1.cpp
+++ b/coreneuron/io/phase1.cpp
@@ -58,6 +58,10 @@ void Phase1::read_direct(int thread_id) {
     delete[] netcon_srcgid;
 }
 
+extern "C" {
+extern bool corenrn_embedded;
+}
+
 void Phase1::populate(NrnThread& nt, OMP_Mutex& mut) {
     nt.n_presyn = this->output_gids.size();
     nt.n_netcon = this->netcon_srcgids.size();
@@ -66,7 +70,7 @@ void Phase1::populate(NrnThread& nt, OMP_Mutex& mut) {
     std::copy(this->netcon_srcgids.begin(), this->netcon_srcgids.end(),
               netcon_srcgid[nt.id]);
 
-    if (!coreneuron::netcon_negsrcgid_tid.empty()) { // multiple threads and direct mode.
+    if (corenrn_embedded) { // multiple threads and direct mode.
         coreneuron::netcon_negsrcgid_tid[nt.id] = this->netcon_negsrcgid_tid;
     }
 

--- a/coreneuron/io/phase1.hpp
+++ b/coreneuron/io/phase1.hpp
@@ -18,6 +18,7 @@ class Phase1 {
     private:
     std::vector<int> output_gids;
     std::vector<int> netcon_srcgids;
+    std::vector<int> netcon_negsrcgid_tid; // entries only for negative srcgids
 };
 
 }  // namespace coreneuron

--- a/coreneuron/network/netpar.cpp
+++ b/coreneuron/network/netpar.cpp
@@ -641,10 +641,17 @@ double set_mindelay(double maxdelay) {
 
     for (int ith = 0; ith < nrn_nthread; ++ith) {
         NrnThread& nt = nrn_threads[ith];
+        // if empty then not to be used.
+        std::vector<int>& negsrcgid_tid = netcon_negsrcgid_tid[ith];
+        size_t i_tid = 0;
         for (int i = 0; i < nt.n_netcon; ++i) {
             NetCon* nc = nt.netcons + i;
             bool chk = false;  // ignore nc.delay_
             int gid = netcon_srcgid[ith][i];
+            int tid = ith;
+            if (!negsrcgid_tid.empty() && gid < -1) {
+              tid = negsrcgid_tid[i_tid++];
+            }  
             PreSyn* ps;
             InputPreSyn* psi;
             netpar_tid_gid2ps(ith, gid, &ps, &psi);

--- a/coreneuron/network/netpar.cpp
+++ b/coreneuron/network/netpar.cpp
@@ -646,12 +646,12 @@ double set_mindelay(double maxdelay) {
     for (int ith = 0; ith < nrn_nthread; ++ith) {
         NrnThread& nt = nrn_threads[ith];
         std::vector<int> dummy;
-        std::vector<int>& negsrcgid_tid = corenrn_embedded ? netcon_negsrcgid_tid[ith] : dummy;
+        std::vector<int>& negsrcgid_tid = corenrn_embedded ? nrnthreads_netcon_negsrcgid_tid[ith] : dummy;
         size_t i_tid = 0;
         for (int i = 0; i < nt.n_netcon; ++i) {
             NetCon* nc = nt.netcons + i;
             bool chk = false;  // ignore nc.delay_
-            int gid = netcon_srcgid[ith][i];
+            int gid = nrnthreads_netcon_srcgid[ith][i];
             int tid = ith;
             if (!negsrcgid_tid.empty() && gid < -1) {
               tid = negsrcgid_tid[i_tid++];

--- a/coreneuron/network/netpar.cpp
+++ b/coreneuron/network/netpar.cpp
@@ -619,6 +619,10 @@ void BBS_netpar_solve(double tstop) {
     }
 }
 
+extern "C" {
+extern bool corenrn_embedded;
+}
+
 double set_mindelay(double maxdelay) {
     double mindelay = maxdelay;
     last_maxstep_arg_ = maxdelay;
@@ -641,8 +645,8 @@ double set_mindelay(double maxdelay) {
 
     for (int ith = 0; ith < nrn_nthread; ++ith) {
         NrnThread& nt = nrn_threads[ith];
-        // if empty then not to be used.
-        std::vector<int>& negsrcgid_tid = netcon_negsrcgid_tid[ith];
+        std::vector<int> dummy;
+        std::vector<int>& negsrcgid_tid = corenrn_embedded ? netcon_negsrcgid_tid[ith] : dummy;
         size_t i_tid = 0;
         for (int i = 0; i < nt.n_netcon; ++i) {
             NetCon* nc = nt.netcons + i;

--- a/coreneuron/network/netpar.cpp
+++ b/coreneuron/network/netpar.cpp
@@ -619,10 +619,6 @@ void BBS_netpar_solve(double tstop) {
     }
 }
 
-extern "C" {
-extern bool corenrn_embedded;
-}
-
 double set_mindelay(double maxdelay) {
     double mindelay = maxdelay;
     last_maxstep_arg_ = maxdelay;
@@ -645,8 +641,8 @@ double set_mindelay(double maxdelay) {
 
     for (int ith = 0; ith < nrn_nthread; ++ith) {
         NrnThread& nt = nrn_threads[ith];
-        std::vector<int> dummy;
-        std::vector<int>& negsrcgid_tid = corenrn_embedded ? nrnthreads_netcon_negsrcgid_tid[ith] : dummy;
+        // if single thread or file transfer then definitely empty.
+        std::vector<int>& negsrcgid_tid = nrnthreads_netcon_negsrcgid_tid[ith];
         size_t i_tid = 0;
         for (int i = 0; i < nt.n_netcon; ++i) {
             NetCon* nc = nt.netcons + i;

--- a/coreneuron/nrniv/nrniv_decl.h
+++ b/coreneuron/nrniv/nrniv_decl.h
@@ -48,8 +48,11 @@ extern std::map<int, InputPreSyn*> gid2in;
 
 /// InputPreSyn.nc_index_ to + InputPreSyn.nc_cnt_ give the NetCon*
 extern std::vector<NetCon*> netcon_in_presyn_order_;
-/// Only for setup vector of netcon source gids
+/// Only for setup vector of netcon source gids and mindelay determination
 extern std::vector<int*> netcon_srcgid;
+/// Companion to netcon_srcgid when src gid is negative to allow
+/// determination of the NrnThread of the source PreSyn.
+extern std::vector<std::vector<int> > netcon_negsrcgid_tid;
 
 extern void mk_mech(const char* path);
 extern void set_globals(const char* path, bool cli_global_seed, int cli_global_seed_value);

--- a/coreneuron/nrniv/nrniv_decl.h
+++ b/coreneuron/nrniv/nrniv_decl.h
@@ -49,10 +49,10 @@ extern std::map<int, InputPreSyn*> gid2in;
 /// InputPreSyn.nc_index_ to + InputPreSyn.nc_cnt_ give the NetCon*
 extern std::vector<NetCon*> netcon_in_presyn_order_;
 /// Only for setup vector of netcon source gids and mindelay determination
-extern std::vector<int*> netcon_srcgid;
-/// Companion to netcon_srcgid when src gid is negative to allow
+extern std::vector<int*> nrnthreads_netcon_srcgid;
+/// Companion to nrnthreads_netcon_srcgid when src gid is negative to allow
 /// determination of the NrnThread of the source PreSyn.
-extern std::vector<std::vector<int> > netcon_negsrcgid_tid;
+extern std::vector<std::vector<int> > nrnthreads_netcon_negsrcgid_tid;
 
 extern void mk_mech(const char* path);
 extern void set_globals(const char* path, bool cli_global_seed, int cli_global_seed_value);


### PR DESCRIPTION
Only for direct transfer mode is it allowed that a negative srcgid is not
in the same thread as the NetCon target.

To enable thread determination an std::vector<int> involving the name
netcon_negsrcgid_tid is associated with netcon_srcgid in that when a negative
gid appears in netcon_srcgid, the tid is the value of the element in
netcon_negsrcgid_tid.

This pr is assciated with neuronsimulator/nrn#735