### PR TITLE
Bug fix for PR #385 : add missing `const` for virtual method

### DIFF
--- a/coreneuron/utils/vrecitem.h
+++ b/coreneuron/utils/vrecitem.h
@@ -48,7 +48,7 @@ class PlayRecordEvent : public DiscreteEvent {
     PlayRecord* plr_;
     static unsigned long playrecord_send_;
     static unsigned long playrecord_deliver_;
-    virtual int type() {
+    virtual int type() const {
         return PlayRecordEventType;
     }
 };

--- a/coreneuron/utils/vrecitem.h
+++ b/coreneuron/utils/vrecitem.h
@@ -42,13 +42,13 @@ class PlayRecordEvent : public DiscreteEvent {
   public:
     PlayRecordEvent();
     virtual ~PlayRecordEvent();
-    virtual void deliver(double, NetCvode*, NrnThread*);
-    virtual void pr(const char*, double t, NetCvode*);
+    virtual void deliver(double, NetCvode*, NrnThread*) override;
+    virtual void pr(const char*, double t, NetCvode*) override;
     virtual NrnThread* thread();
     PlayRecord* plr_;
     static unsigned long playrecord_send_;
     static unsigned long playrecord_deliver_;
-    virtual int type() const {
+    virtual int type() const override {
         return PlayRecordEventType;
     }
 };
@@ -68,7 +68,7 @@ class PlayRecord {
         return nullptr;
     }
     virtual void pr();  // print identifying info
-    virtual int type() {
+    virtual int type() const {
         return 0;
     }
 
@@ -80,21 +80,21 @@ class VecPlayContinuous : public PlayRecord {
   public:
     VecPlayContinuous(double*, IvocVect&& yvec, IvocVect&& tvec, IvocVect* discon, int ith);
     virtual ~VecPlayContinuous();
-    virtual void play_init();
-    virtual void deliver(double tt, NetCvode*);
-    virtual PlayRecordEvent* event() {
+    virtual void play_init() override;
+    virtual void deliver(double tt, NetCvode*) override;
+    virtual PlayRecordEvent* event() override {
         return e_;
     }
-    virtual void pr();
+    virtual void pr() override;
 
-    void continuous(double tt);
+    void continuous(double tt) override;
     double interpolate(double tt);
     double interp(double th, double x0, double x1) {
         return x0 + (x1 - x0) * th;
     }
     void search(double tt);
 
-    virtual int type() {
+    virtual int type() const override {
         return VecPlayContinuousType;
     }
 


### PR DESCRIPTION
  - changing base class method prototype result into bug for
    virtual method in PlayRecordEvent

@alkino : culprit was [this commit](https://github.com/BlueBrain/CoreNeuron/pull/385/files#diff-c79cec806ef8ef3de58d9ed516974213) : 

![image](https://user-images.githubusercontent.com/666852/93755110-0f4c9500-fc03-11ea-9022-dcaf87955aa7.png)
