### PR TITLE
Allow NetSendBuffer_t to grow

### DIFF
--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -733,12 +733,7 @@ void nrn_cleanup() {
             NetSendBuffer_t* nsb = ml->_net_send_buffer;
             if (nsb) {
                 if (nsb->_size) {
-                    free_memory(nsb->_sendtype);
-                    free_memory(nsb->_vdata_index);
-                    free_memory(nsb->_pnt_index);
-                    free_memory(nsb->_weight_index);
-                    free_memory(nsb->_nsb_t);
-                    free_memory(nsb->_nsb_flag);
+                    free(nsb);
                 }
                 free_memory(nsb);
             }

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -732,10 +732,7 @@ void nrn_cleanup() {
 
             NetSendBuffer_t* nsb = ml->_net_send_buffer;
             if (nsb) {
-                if (nsb->_size) {
-                    free(nsb);
-                }
-                free_memory(nsb);
+                delete nsb;
             }
 
             if (tml->dependencies)

--- a/coreneuron/io/phase2.cpp
+++ b/coreneuron/io/phase2.cpp
@@ -465,7 +465,6 @@ void Phase2::set_net_send_buffer(Memb_list** ml_list, const std::vector<int>& pn
         Memb_list* ml = ml_list[type];
         if (ml) {  // needs a NetSendBuffer
             // begin with a size equal to twice number of instances
-            // at present there is no provision for dynamically increasing this.
             NetSendBuffer_t* nsb = new NetSendBuffer_t(ml->nodecount * 2);
             ml->_net_send_buffer = nsb;
         }

--- a/coreneuron/io/phase2.cpp
+++ b/coreneuron/io/phase2.cpp
@@ -464,23 +464,10 @@ void Phase2::set_net_send_buffer(Memb_list** ml_list, const std::vector<int>& pn
         // Does this thread have this type.
         Memb_list* ml = ml_list[type];
         if (ml) {  // needs a NetSendBuffer
-            NetSendBuffer_t* nsb = (NetSendBuffer_t*)ecalloc_align(1, sizeof(NetSendBuffer_t));
-            ml->_net_send_buffer = nsb;
-
             // begin with a size equal to twice number of instances
             // at present there is no provision for dynamically increasing this.
-            nsb->_size = ml->nodecount * 2;
-            nsb->_cnt = 0;
-
-            nsb->_sendtype = (int*)ecalloc_align(nsb->_size, sizeof(int));
-            nsb->_vdata_index = (int*)ecalloc_align(nsb->_size, sizeof(int));
-            nsb->_pnt_index = (int*)ecalloc_align(nsb->_size, sizeof(int));
-            nsb->_weight_index = (int*)ecalloc_align(nsb->_size, sizeof(int));
-            // when == 1, NetReceiveBuffer_t is newly allocated (i.e. we need to free previous copy
-            // and recopy new data
-            nsb->reallocated = 1;
-            nsb->_nsb_t = (double*)ecalloc_align(nsb->_size, sizeof(double));
-            nsb->_nsb_flag = (double*)ecalloc_align(nsb->_size, sizeof(double));
+            NetSendBuffer_t* nsb = new NetSendBuffer_t(ml->nodecount * 2);
+            ml->_net_send_buffer = nsb;
         }
     }
 }

--- a/coreneuron/mechanism/mechanism.hpp
+++ b/coreneuron/mechanism/mechanism.hpp
@@ -69,7 +69,7 @@ struct NetReceiveBuffer_t {
     int _pnt_offset;
 };
 
-struct NetSendBuffer_t {
+struct NetSendBuffer_t : MemoryManaged {
     int* _sendtype;  // net_send, net_event, net_move
     int* _vdata_index;
     int* _pnt_index;

--- a/coreneuron/mechanism/mechanism.hpp
+++ b/coreneuron/mechanism/mechanism.hpp
@@ -95,12 +95,12 @@ struct NetSendBuffer_t {
     }
 
     ~NetSendBuffer_t() {
-        free(_sendtype);
-        free(_vdata_index);
-        free(_pnt_index);
-        free(_weight_index);
-        free(_nsb_t);
-        free(_nsb_flag);
+        free_memory(_sendtype);
+        free_memory(_vdata_index);
+        free_memory(_pnt_index);
+        free_memory(_weight_index);
+        free_memory(_nsb_t);
+        free_memory(_nsb_flag);
     }
 
     void grow() {

--- a/coreneuron/mechanism/mechanism.hpp
+++ b/coreneuron/mechanism/mechanism.hpp
@@ -104,6 +104,10 @@ struct NetSendBuffer_t : MemoryManaged {
     }
 
     void grow() {
+#if defined(_OPENACC)
+        int cannot_reallocate_on_device = 0;
+        assert(cannot_reallocate_on_device);
+#else
         int new_size = _size * 2;
         grow_buf(&_sendtype, _size, new_size);
         grow_buf(&_vdata_index, _size, new_size);
@@ -111,6 +115,8 @@ struct NetSendBuffer_t : MemoryManaged {
         grow_buf(&_weight_index, _size, new_size);
         grow_buf(&_nsb_t, _size, new_size);
         grow_buf(&_nsb_flag, _size, new_size);
+        _size = new_size;
+#endif
     }
 
     private:

--- a/coreneuron/mechanism/mechanism.hpp
+++ b/coreneuron/mechanism/mechanism.hpp
@@ -27,7 +27,10 @@ THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
+#include <string.h>
+
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/utils/memory.h"
 
 namespace coreneuron {
 #if PG_ACC_BUGS
@@ -76,6 +79,50 @@ struct NetSendBuffer_t {
     int _cnt;
     int _size;       /* capacity */
     int reallocated; /* if buffer resized/reallocated, needs to be copy to cpu */
+
+    NetSendBuffer_t(int size) : _size(size) {
+        _cnt = 0;
+
+        _sendtype = (int*)ecalloc_align(_size, sizeof(int));
+        _vdata_index = (int*)ecalloc_align(_size, sizeof(int));
+        _pnt_index = (int*)ecalloc_align(_size, sizeof(int));
+        _weight_index = (int*)ecalloc_align(_size, sizeof(int));
+        // when == 1, NetReceiveBuffer_t is newly allocated (i.e. we need to free previous copy
+        // and recopy new data
+        reallocated = 1;
+        _nsb_t = (double*)ecalloc_align(_size, sizeof(double));
+        _nsb_flag = (double*)ecalloc_align(_size, sizeof(double));
+    }
+
+    ~NetSendBuffer_t() {
+        free(_sendtype);
+        free(_vdata_index);
+        free(_pnt_index);
+        free(_weight_index);
+        free(_nsb_t);
+        free(_nsb_flag);
+    }
+
+    void grow() {
+        int new_size = _size * 2;
+        grow_buf(&_sendtype, _size, new_size);
+        grow_buf(&_vdata_index, _size, new_size);
+        grow_buf(&_pnt_index, _size, new_size);
+        grow_buf(&_weight_index, _size, new_size);
+        grow_buf(&_nsb_t, _size, new_size);
+        grow_buf(&_nsb_flag, _size, new_size);
+    }
+
+    private:
+        template <typename T>
+        void grow_buf(T** buf, int size, int new_size) {
+            T* new_buf = nullptr;
+            new_buf = (T*)ecalloc_align(new_size, sizeof(T));
+            memcpy(new_buf, *buf, size * sizeof(T));
+            free(*buf);
+            *buf = new_buf;
+        }
+
 };
 
 struct Memb_list {


### PR DESCRIPTION
Until now NetSendBuffer_t was allocated at a fixed size that could not
be changed. When using buffered net_send and invoking multiple
net_send's in INITIAL blocks in NMODL it may happen that we run out of
buffer. Currently this case is not handled and causes a buffer overflow.

As a first step NetSendBuffer_t has been given a constructor and
destructor as well as a grow function that doubles all internal buffer
sizes and copies data to the new buffers.