### PR TITLE
Add support for inserting nmodl flags in nrnivmodl-core calls

### DIFF
--- a/extra/nrnivmodl-core.in
+++ b/extra/nrnivmodl-core.in
@@ -20,7 +20,7 @@ params_MODS_PATH="."
 params_BUILD_TYPE="@COMPILE_LIBRARY_TYPE@"
 
 # prefix for common options : make sure to rename these if options are changed.
-MAKE_OPTIONS="MECHLIB_SUFFIX NMODL_BINARY NMODL_FLAGS_RUNTIME DEST_DIR INCFLAGS LINKFLAGS MODS_PATH VERBOSE BUILD_TYPE"
+MAKE_OPTIONS="MECHLIB_SUFFIX NMODL_BINARY NMODL_RUNTIME_FLAGS DEST_DIR INCFLAGS LINKFLAGS MODS_PATH VERBOSE BUILD_TYPE"
 
 # parse CLI args
 while getopts "n:m:a:d:i:l:V:p:b:h" OPT; do
@@ -33,7 +33,7 @@ while getopts "n:m:a:d:i:l:V:p:b:h" OPT; do
         params_NMODL_BINARY="$OPTARG";;
     a)
         # additional nmodl flags to be used
-        params_NMODL_FLAGS_RUNTIME="$OPTARG";;
+        params_NMODL_RUNTIME_FLAGS="$OPTARG";;
     d)
         # destination install directory
         params_DEST_DIR="$OPTARG";;
@@ -56,8 +56,8 @@ while getopts "n:m:a:d:i:l:V:p:b:h" OPT; do
         echo "$APP_NAME [options, ...] [mods_path]"
         echo "Options:"
         echo "  -n <name>                 The model name, used as a suffix in the shared library"
-        echo "  -m <mod2c_bin>            NMODL code generation compiler path"
-        echo "  -a <nmodl_flags_runtime>  Runtime NMODL flags"
+        echo "  -m <nmodl_bin>            NMODL/mod2c code generation compiler path"
+        echo "  -a <nmodl_runtime_flags>  Runtime flags for NMODL/mod2c"
         echo "  -i <incl_flags>           Definitions passed to the compiler, typically '-I dir..'"
         echo "  -l <link_flags>           Definitions passed to the linker, typically '-Lx -lylib..'"
         echo "  -d <dest_dir>             Install to dest_dir. Default: Off."

--- a/extra/nrnivmodl-core.in
+++ b/extra/nrnivmodl-core.in
@@ -20,10 +20,10 @@ params_MODS_PATH="."
 params_BUILD_TYPE="@COMPILE_LIBRARY_TYPE@"
 
 # prefix for common options : make sure to rename these if options are changed.
-MAKE_OPTIONS="MECHLIB_SUFFIX NMODL_BINARY DEST_DIR INCFLAGS LINKFLAGS MODS_PATH VERBOSE BUILD_TYPE"
+MAKE_OPTIONS="MECHLIB_SUFFIX NMODL_BINARY NMODL_FLAGS_RUNTIME DEST_DIR INCFLAGS LINKFLAGS MODS_PATH VERBOSE BUILD_TYPE"
 
 # parse CLI args
-while getopts "n:m:v:d:i:l:p:b:hV" OPT; do
+while getopts "n:m:a:d:i:l:V:p:b:h" OPT; do
     case "$OPT" in
     n)
         # suffix for mechanism library
@@ -31,6 +31,9 @@ while getopts "n:m:v:d:i:l:p:b:hV" OPT; do
     m)
         # nmodl or mod2c binary to use
         params_NMODL_BINARY="$OPTARG";;
+    a)
+        # additional nmodl flags to be used
+        params_NMODL_FLAGS_RUNTIME="$OPTARG";;
     d)
         # destination install directory
         params_DEST_DIR="$OPTARG";;
@@ -52,14 +55,15 @@ while getopts "n:m:v:d:i:l:p:b:hV" OPT; do
     h)
         echo "$APP_NAME [options, ...] [mods_path]"
         echo "Options:"
-        echo "  -n <name>          The model name, used as a suffix in the shared library"
-        echo "  -m <mod2c_bin>     NMODL code generation compiler path"
-        echo "  -i <incl_flags>    Definitions passed to the compiler, typically '-I dir..'"
-        echo "  -l <link_flags>    Definitions passed to the linker, typically '-Lx -lylib..'"
-        echo "  -d <dest_dir>      Install to dest_dir. Default: Off."
-        echo "  -V                 Verbose: show commands executed by make"
-        echo "  -p <n_procs>       Number of parallel builds (Default: $PARALLEL_BUILDS)"
-        echo "  -b <STATIC|SHARED> libcorenrnmech library type"
+        echo "  -n <name>                 The model name, used as a suffix in the shared library"
+        echo "  -m <mod2c_bin>            NMODL code generation compiler path"
+        echo "  -a <nmodl_flags_runtime>  Runtime NMODL flags"
+        echo "  -i <incl_flags>           Definitions passed to the compiler, typically '-I dir..'"
+        echo "  -l <link_flags>           Definitions passed to the linker, typically '-Lx -lylib..'"
+        echo "  -d <dest_dir>             Install to dest_dir. Default: Off."
+        echo "  -V                        Verbose: show commands executed by make"
+        echo "  -p <n_procs>              Number of parallel builds (Default: $PARALLEL_BUILDS)"
+        echo "  -b <STATIC|SHARED>        libcorenrnmech library type"
         exit 0;;
     ?)
         exit 1;;

--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -85,8 +85,6 @@ ifeq (@nmodl_FOUND@, TRUE)
     NMODL_BINARY_PATH = $(if $(NMODL_BINARY),$(NMODL_BINARY), @CORENRN_NMODL_BINARY@)
     INCLUDES += -I@CORENRN_NMODL_INCLUDE@
     ISPC_COMPILE_CMD += -I@CORENRN_NMODL_INCLUDE@
-    nmodl_arguments_c += @NMODL_FLAGS2@
-    nmodl_arguments_ispc += @NMODL_FLAGS2@
 else
     NMODL_BINARY_PATH = $(if $(NMODL_BINARY),$(NMODL_BINARY), $(CORENRN_BIN_DIR)/@nmodl_binary_name@)
 endif
@@ -188,11 +186,11 @@ $(MOD_OBJS_DIR)/%.obj: $(MOD_TO_CPP_DIR)/%.ispc | $(MOD_OBJS_DIR)
 
 # translate MOD files to ISPC using NMODL
 $(mod_ispc_files): $(MOD_TO_CPP_DIR)/%.ispc: $(MODS_PATH)/%.mod | $(MOD_TO_CPP_DIR)
-	$(NMODL_ENV_VAR) $(NMODL_BINARY_PATH) $< -o $(MOD_TO_CPP_DIR)/ @nmodl_arguments_ispc@ $(NMODL_FLAGS_RUNTIME)
+	$(NMODL_ENV_VAR) $(NMODL_BINARY_PATH) $< -o $(MOD_TO_CPP_DIR)/ @nmodl_arguments_ispc@ $(NMODL_RUNTIME_FLAGS)
 
 # translate MOD files to CPP using mod2c/NMODL
 $(mod_cpp_files): $(MOD_TO_CPP_DIR)/%.cpp: $(MODS_PATH)/%.mod | $(MOD_TO_CPP_DIR)
-	$(NMODL_ENV_VAR) $(NMODL_BINARY_PATH) $< -o $(MOD_TO_CPP_DIR)/ @nmodl_arguments_c@ $(NMODL_FLAGS_RUNTIME)
+	$(NMODL_ENV_VAR) $(NMODL_BINARY_PATH) $< -o $(MOD_TO_CPP_DIR)/ @nmodl_arguments_c@ $(NMODL_RUNTIME_FLAGS)
 
 # static pattern to set up the dependencies for the previous recipe
 $(mod_ispc_cpp_files): $(MOD_TO_CPP_DIR)/%.cpp: $(MOD_TO_CPP_DIR)/%.ispc

--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -141,6 +141,13 @@ ALL_OBJS = $(MOD_FUNC_OBJ) $(DIMPLIC_OBJ) $(mod_cpp_objs) $(mod_ispc_objs)
 C_RESET := \033[0m
 C_GREEN := \033[32m
 
+# Default nmodl flags. Override if NMODL_RUNTIME_FLAGS is not empty
+NMODL_FLAGS_ISPC = $(if $(NMODL_RUNTIME_FLAGS),$(NMODL_RUNTIME_FLAGS),@nmodl_arguments_ispc@)
+NMODL_FLAGS_C = $(if $(NMODL_RUNTIME_FLAGS),$(NMODL_RUNTIME_FLAGS),@nmodl_arguments_c@)
+$(info Default nmodl flags: $(if (@CORENRN_ENABLE_ISPC@ == ON), @nmodl_arguments_ispc@, @nmodl_arguments_c@))
+ifneq ($(NMODL_RUNTIME_FLAGS),)
+    $(warning Runtime nmodl flags (they replace the default ones): $(NMODL_RUNTIME_FLAGS))
+endif
 
 # ======== MAIN BUILD RULES ============
 
@@ -186,11 +193,11 @@ $(MOD_OBJS_DIR)/%.obj: $(MOD_TO_CPP_DIR)/%.ispc | $(MOD_OBJS_DIR)
 
 # translate MOD files to ISPC using NMODL
 $(mod_ispc_files): $(MOD_TO_CPP_DIR)/%.ispc: $(MODS_PATH)/%.mod | $(MOD_TO_CPP_DIR)
-	$(NMODL_ENV_VAR) $(NMODL_BINARY_PATH) $< -o $(MOD_TO_CPP_DIR)/ @nmodl_arguments_ispc@ $(NMODL_RUNTIME_FLAGS)
+	$(NMODL_ENV_VAR) $(NMODL_BINARY_PATH) $< -o $(MOD_TO_CPP_DIR)/ $(NMODL_FLAGS_ISPC)
 
 # translate MOD files to CPP using mod2c/NMODL
 $(mod_cpp_files): $(MOD_TO_CPP_DIR)/%.cpp: $(MODS_PATH)/%.mod | $(MOD_TO_CPP_DIR)
-	$(NMODL_ENV_VAR) $(NMODL_BINARY_PATH) $< -o $(MOD_TO_CPP_DIR)/ @nmodl_arguments_c@ $(NMODL_RUNTIME_FLAGS)
+	$(NMODL_ENV_VAR) $(NMODL_BINARY_PATH) $< -o $(MOD_TO_CPP_DIR)/ $(NMODL_FLAGS_C)
 
 # static pattern to set up the dependencies for the previous recipe
 $(mod_ispc_cpp_files): $(MOD_TO_CPP_DIR)/%.cpp: $(MOD_TO_CPP_DIR)/%.ispc

--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -85,6 +85,8 @@ ifeq (@nmodl_FOUND@, TRUE)
     NMODL_BINARY_PATH = $(if $(NMODL_BINARY),$(NMODL_BINARY), @CORENRN_NMODL_BINARY@)
     INCLUDES += -I@CORENRN_NMODL_INCLUDE@
     ISPC_COMPILE_CMD += -I@CORENRN_NMODL_INCLUDE@
+    nmodl_arguments_c += @NMODL_FLAGS2@
+    nmodl_arguments_ispc += @NMODL_FLAGS2@
 else
     NMODL_BINARY_PATH = $(if $(NMODL_BINARY),$(NMODL_BINARY), $(CORENRN_BIN_DIR)/@nmodl_binary_name@)
 endif
@@ -186,11 +188,11 @@ $(MOD_OBJS_DIR)/%.obj: $(MOD_TO_CPP_DIR)/%.ispc | $(MOD_OBJS_DIR)
 
 # translate MOD files to ISPC using NMODL
 $(mod_ispc_files): $(MOD_TO_CPP_DIR)/%.ispc: $(MODS_PATH)/%.mod | $(MOD_TO_CPP_DIR)
-	$(NMODL_ENV_VAR) $(NMODL_BINARY_PATH) $< -o $(MOD_TO_CPP_DIR)/ @nmodl_arguments_ispc@
+	$(NMODL_ENV_VAR) $(NMODL_BINARY_PATH) $< -o $(MOD_TO_CPP_DIR)/ @nmodl_arguments_ispc@ $(NMODL_FLAGS_RUNTIME)
 
 # translate MOD files to CPP using mod2c/NMODL
 $(mod_cpp_files): $(MOD_TO_CPP_DIR)/%.cpp: $(MODS_PATH)/%.mod | $(MOD_TO_CPP_DIR)
-	$(NMODL_ENV_VAR) $(NMODL_BINARY_PATH) $< -o $(MOD_TO_CPP_DIR)/ @nmodl_arguments_c@
+	$(NMODL_ENV_VAR) $(NMODL_BINARY_PATH) $< -o $(MOD_TO_CPP_DIR)/ @nmodl_arguments_c@ $(NMODL_FLAGS_RUNTIME)
 
 # static pattern to set up the dependencies for the previous recipe
 $(mod_ispc_cpp_files): $(MOD_TO_CPP_DIR)/%.cpp: $(MOD_TO_CPP_DIR)/%.ispc


### PR DESCRIPTION
For example, this enables the call:

`nrnivmodl-core -a "sympy --analytic" mod/`

Partially addresses issue #344 