### PR TITLE
No more check parameters from argc / argv but from the parser. Fix #184

### DIFF
--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -433,7 +433,7 @@ extern "C" void mk_mech_init(int argc, char** argv) {
 
 #if NRNMPI
     if (corenrn_param.mpi_enable) {
-        nrnmpi_init(1, &argc, &argv);
+        nrnmpi_init(&argc, &argv);
     }
 #endif
 

--- a/coreneuron/mpi/nrnmpi.cpp
+++ b/coreneuron/mpi/nrnmpi.cpp
@@ -44,8 +44,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
 namespace coreneuron {
 
 #if NRNMPI
-int nrnmusic;
-
 MPI_Comm nrnmpi_world_comm;
 MPI_Comm nrnmpi_comm;
 MPI_Comm nrn_bbs_comm;
@@ -56,52 +54,23 @@ extern void nrnmpi_spike_initialize();
 
 static int nrnmpi_under_nrncontrol_;
 
-void nrnmpi_init(int nrnmpi_under_nrncontrol, int* pargc, char*** pargv) {
+void nrnmpi_init(int* pargc, char*** pargv) {
     nrnmpi_use = true;
-    nrnmpi_under_nrncontrol_ = nrnmpi_under_nrncontrol;
-    if (nrnmpi_under_nrncontrol_) {
-#if !ALWAYS_CALL_MPI_INIT
-        bool b = false;
-        /* this is not good. depends on mpirun adding at least one
-           arg that starts with -p4 but that probably is dependent
-           on mpich and the use of the ch_p4 device. We are trying to
-           work around the problem that MPI_Init may change the working
-           directory and so when not invoked under mpirun we would like to
-           NOT call MPI_Init.
-        */
-        for (int i = 0; i < *pargc; ++i) {
-            if (strncmp("-p4", (*pargv)[i], 3) == 0) {
-                b = true;
-                break;
-            }
-            if (corenrn_param.mpi_enable) {
-                b = true;
-                break;
-            }
-        }
-        if (nrnmusic) {
-            b = true;
-        }
-        if (!b) {
-            nrnmpi_use = false;
-            nrnmpi_under_nrncontrol_ = 0;
-            return;
-        }
-#endif
-        int flag = 0;
-        MPI_Initialized(&flag);
+    nrnmpi_under_nrncontrol_ = 1;
 
-        if (!flag) {
+    int flag = 0;
+    MPI_Initialized(&flag);
+
+    if (!flag) {
 #if defined(_OPENMP)
-            int required = MPI_THREAD_FUNNELED;
-            int provided;
-            nrn_assert(MPI_Init_thread(pargc, pargv, required, &provided) == MPI_SUCCESS);
+        int required = MPI_THREAD_FUNNELED;
+        int provided;
+        nrn_assert(MPI_Init_thread(pargc, pargv, required, &provided) == MPI_SUCCESS);
 
-            nrn_assert(required <= provided);
+        nrn_assert(required <= provided);
 #else
-            nrn_assert(MPI_Init(pargc, pargv) == MPI_SUCCESS);
+        nrn_assert(MPI_Init(pargc, pargv) == MPI_SUCCESS);
 #endif
-        }
     }
     grp_bbs = MPI_GROUP_NULL;
     grp_net = MPI_GROUP_NULL;

--- a/coreneuron/mpi/nrnmpi.cpp
+++ b/coreneuron/mpi/nrnmpi.cpp
@@ -30,7 +30,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/time.h>
 
 #include "coreneuron/nrnconf.h"
-#include "coreneuron/apps/corenrn_parameters.hpp"
 #include "coreneuron/mpi/nrnmpi.h"
 #include "coreneuron/mpi/mpispike.hpp"
 #include "coreneuron/mpi/nrnmpi_def_cinc.h"

--- a/coreneuron/mpi/nrnmpi.cpp
+++ b/coreneuron/mpi/nrnmpi.cpp
@@ -30,6 +30,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/time.h>
 
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/apps/corenrn_parameters.hpp"
 #include "coreneuron/mpi/nrnmpi.h"
 #include "coreneuron/mpi/mpispike.hpp"
 #include "coreneuron/mpi/nrnmpi_def_cinc.h"
@@ -73,7 +74,7 @@ void nrnmpi_init(int nrnmpi_under_nrncontrol, int* pargc, char*** pargv) {
                 b = true;
                 break;
             }
-            if (strcmp("--mpi", (*pargv)[i]) == 0) {
+            if (corenrn_param.mpi_enable) {
                 b = true;
                 break;
             }

--- a/coreneuron/mpi/nrnmpidec.h
+++ b/coreneuron/mpi/nrnmpidec.h
@@ -76,7 +76,7 @@ extern int nrnmpi_bbsrecv(int source, bbsmpibuf* r);
 extern int nrnmpi_bbssendrecv(int dest, int tag, bbsmpibuf* s, bbsmpibuf* r);
 
 /* from nrnmpi.cpp */
-extern void nrnmpi_init(int nrnmpi_under_nrncontrol, int* pargc, char*** pargv);
+extern void nrnmpi_init(int* pargc, char*** pargv);
 extern int nrnmpi_wrap_mpi_init(int* flag);
 extern void nrnmpi_finalize(void);
 extern void nrnmpi_terminate();

--- a/coreneuron/mpi/nrnmpiuse.h
+++ b/coreneuron/mpi/nrnmpiuse.h
@@ -52,9 +52,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
 /* define to the dll path if you want to load automatically */
 #undef DLL_DEFAULT_FNAME
 
-/* define if needed */
-#undef ALWAYS_CALL_MPI_INIT
-
 /* Number of times to retry a failed open */
 #undef FILE_OPEN_RETRY
 


### PR DESCRIPTION
We have to decide what to do with other arguments just like `-p4` that is not valid with the new parser.

Does someone know what is `nrn_music`?