### PR TITLE
Use of DELETE_ON_ERROR for generating mod files

### DIFF
--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -241,3 +241,6 @@ install: $(SPECIAL_EXE) coremech_lib_target
 .PHONY: build_always
 
 $(VERBOSE).SILENT:
+
+# delete cpp files if mod2c error, otherwise they are not generated again
+.DELETE_ON_ERROR:


### PR DESCRIPTION
If mod2c fail, the file is generated but empty, because of that they are
not generated again and it fails later in a complicated way