### PR TITLE
Fix undefined reference to `solve_core' race condition

### DIFF
--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -174,14 +174,14 @@ enginemech_object:
 	$(CXX_COMPILE_CMD) -c -DADDITIONAL_MECHS $(CORENRN_SHARE_CORENRN_DIR)/enginemech.cpp -o $(ENGINEMECH_OBJ)
 
 # build shared library of mechanisms
-coremech_lib_shared: $(ALL_OBJS) build_always
+coremech_lib_shared: $(ALL_OBJS) enginemech_object build_always
 	$(CXX_SHARED_LIB_CMD) $(ENGINEMECH_OBJ) -o ${COREMECH_LIB_PATH} $(ALL_OBJS) \
 	  -I$(CORENRN_INC_DIR) $(INCFLAGS) \
 	  $(LDFLAGS) $(CORENRN_LIB_DIR)/libscopmath.a \
 	  ${SONAME_OPTION} $(CORENRNLIB_FLAGS) -Wl,-rpath,$(CORENRN_LIB_DIR);
 
 # build static library of mechanisms
-coremech_lib_static: $(ALL_OBJS) build_always
+coremech_lib_static: $(ALL_OBJS) enginemech_object build_always
 	mkdir -p $(MOD_OBJS_DIR)/scopmath; \
 	cd $(MOD_OBJS_DIR)/scopmath && ar -x $(CORENRN_LIB_DIR)/libscopmath.a && cd -;\
 	rm -f ${COREMECH_LIB_PATH}; \


### PR DESCRIPTION
related error:
```
/home/runner/work/nrn/nrn/build/bin
 => Binary creating x86_64/special-core
/tmp/cc9fs5kJ.o: In function `main':
/home/runner/work/nrn/nrn/build/share/coreneuron/coreneuron.cpp:34: undefined reference to `solve_core'
collect2: error: ld returned 1 exit status
make[3]: *** [x86_64/special-core] Error 1
/home/runner/work/nrn/nrn/build/share/coreneuron/nrnivmodl_core_makefile:161: recipe for target 'x86_64/special-core' failed
make[2]: *** [external/coreneuron/coreneuron/CMakeFiles/nrniv-core] Error 2
external/coreneuron/coreneuron/CMakeFiles/nrniv-core.dir/build.make:74: recipe for target 'external/coreneuron/coreneuron/CMakeFiles/nrniv-core' failed
CMakeFiles/Makefile2:1276: recipe for target 'external/coreneuron/coreneuron/CMakeFiles/nrniv-core.dir/all' failed
make[1]: *** [external/coreneuron/coreneuron/CMakeFiles/nrniv-core.dir/all] Error 2
make: *** [all] Error 2
Makefile:179: recipe for target 'all' failed
Error: Process completed with exit code 2.
```

CI_BRANCHES:NEURON_BRANCH=master