### PR TITLE
Replace ENGINEMECH_OBJ by the name of the file in the Makefile

### DIFF
--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -164,24 +164,23 @@ $(SPECIAL_EXE): coremech_lib_target
 	  -L$(OUTPUT_DIR) -l$(COREMECH_LIB_NAME) $(CORENRNLIB_FLAGS) $(LDFLAGS) \
 	  -Wl,-rpath,'$(LIB_RPATH)' -Wl,-rpath,$(CORENRN_LIB_DIR)
 
-coremech_lib_target: enginemech_object $(corenrnmech_lib_target)
+coremech_lib_target: $(corenrnmech_lib_target)
 	rm -rf $(OUTPUT_DIR)/.libs; \
 	mkdir -p $(OUTPUT_DIR)/.libs; \
 	ln -s ${COREMECH_LIB_PATH} $(OUTPUT_DIR)/.libs/libcorenrnmech$(LIB_SUFFIX)
 
-enginemech_object:
-	mkdir -p $(MOD_OBJS_DIR)
+$(ENGINEMECH_OBJ): | $(MOD_OBJS_DIR)
 	$(CXX_COMPILE_CMD) -c -DADDITIONAL_MECHS $(CORENRN_SHARE_CORENRN_DIR)/enginemech.cpp -o $(ENGINEMECH_OBJ)
 
 # build shared library of mechanisms
-coremech_lib_shared: $(ALL_OBJS) enginemech_object build_always
+coremech_lib_shared: $(ALL_OBJS) $(ENGINEMECH_OBJ) build_always
 	$(CXX_SHARED_LIB_CMD) $(ENGINEMECH_OBJ) -o ${COREMECH_LIB_PATH} $(ALL_OBJS) \
 	  -I$(CORENRN_INC_DIR) $(INCFLAGS) \
 	  $(LDFLAGS) $(CORENRN_LIB_DIR)/libscopmath.a \
 	  ${SONAME_OPTION} $(CORENRNLIB_FLAGS) -Wl,-rpath,$(CORENRN_LIB_DIR);
 
 # build static library of mechanisms
-coremech_lib_static: $(ALL_OBJS) enginemech_object build_always
+coremech_lib_static: $(ALL_OBJS) $(ENGINEMECH_OBJ) build_always
 	mkdir -p $(MOD_OBJS_DIR)/scopmath; \
 	cd $(MOD_OBJS_DIR)/scopmath && ar -x $(CORENRN_LIB_DIR)/libscopmath.a && cd -;\
 	rm -f ${COREMECH_LIB_PATH}; \


### PR DESCRIPTION
This is to simplify the generated Makefile.

Remove this target for a place not directly needed.

CI_BRANCHES:NEURON_BRANCH=master,
