### PR TITLE
Update nmodl submodule to latest master and avoid recursive cloning

### DIFF
--- a/CMake/AddCLI11Submodule.cmake
+++ b/CMake/AddCLI11Submodule.cmake
@@ -17,12 +17,12 @@ find_package_handle_standard_args(CLI11 REQUIRED_VARS CLI11_PROJ)
 if(NOT CLI11_FOUND)
   find_package(Git 1.8.3 QUIET)
   if(NOT ${GIT_FOUND})
-    message(FATAL_ERROR "git not found, clone repository with --recursive")
+    message(FATAL_ERROR "git not found, clone repository with")
   endif()
-  message(STATUS "Sub-module CLI11 missing: running git submodule update --init --recursive")
+  message(STATUS "Sub-module CLI11 missing: running git submodule update --init")
   execute_process(
     COMMAND
-      ${GIT_EXECUTABLE} submodule update --init --recursive --
+      ${GIT_EXECUTABLE} submodule update --init --
       ${CORENEURON_PROJECT_SOURCE_DIR}/external/CLI11
     WORKING_DIRECTORY ${CORENEURON_PROJECT_SOURCE_DIR})
 endif()

--- a/CMake/AddCLI11Submodule.cmake
+++ b/CMake/AddCLI11Submodule.cmake
@@ -17,7 +17,7 @@ find_package_handle_standard_args(CLI11 REQUIRED_VARS CLI11_PROJ)
 if(NOT CLI11_FOUND)
   find_package(Git 1.8.3 QUIET)
   if(NOT ${GIT_FOUND})
-    message(FATAL_ERROR "git not found, clone repository with")
+    message(FATAL_ERROR "git not found, download full repository or install git")
   endif()
   message(STATUS "Sub-module CLI11 missing: running git submodule update --init")
   execute_process(

--- a/CMake/AddNmodlSubmodule.cmake
+++ b/CMake/AddNmodlSubmodule.cmake
@@ -18,10 +18,10 @@ if(NOT NMODL_FOUND)
   if(NOT ${GIT_FOUND})
     message(FATAL_ERROR "git not found, clone repository with --recursive")
   endif()
-  message(STATUS "Sub-module nmodl missing : running git submodule update --init --recursive")
+  message(STATUS "Sub-module nmodl missing : running git submodule update --init")
   execute_process(
     COMMAND
-      ${GIT_EXECUTABLE} submodule update --init --recursive --
+      ${GIT_EXECUTABLE} submodule update --init --
       ${CORENEURON_PROJECT_SOURCE_DIR}/external/nmodl
     WORKING_DIRECTORY ${CORENEURON_PROJECT_SOURCE_DIR})
 else()


### PR DESCRIPTION
  - nmodl initialize necessary submodules. so we do not need to
    do recursive initialize that adds extra submodules for no reason
  - update nmodl to latest master

Todo:

- [x] update nmodl from branch to master once PR is merged

CI_BRANCHES:NEURON_BRANCH=master,
