### PR TITLE
Printing mechanism count and mech stats to log

### DIFF
--- a/coreneuron/apps/corenrn_parameters.cpp
+++ b/coreneuron/apps/corenrn_parameters.cpp
@@ -47,6 +47,7 @@ corenrn_parameters::corenrn_parameters(){
         ->check(CLI::Range(0., 1e9));
     app.add_flag("--show");
     app.add_set("--verbose", this->verbose, {verbose_level::NONE, verbose_level::ERROR, verbose_level::INFO, verbose_level::DEBUG}, "Verbose level: 0 = NONE, 1 = ERROR, 2 = INFO, 3 = DEBUG. Default is INFO");
+    app.add_flag("--count_mechs", this->count_mechs, "Print number of instances of each mechanism.");
 
     auto sub_gpu = app.add_option_group("GPU", "Commands relative to GPU.");
     sub_gpu -> add_option("-W, --nwarp", this->nwarp, "Number of warps to balance.", true)

--- a/coreneuron/apps/corenrn_parameters.hpp
+++ b/coreneuron/apps/corenrn_parameters.hpp
@@ -87,6 +87,8 @@ struct corenrn_parameters {
 
     bool show_version=false;       /// Print version and exit.
 
+    bool count_mechs=false;        /// Print mechanism counts after initialization
+
     verbose_level verbose{verbose_level::DEFAULT}; /// Verbosity-level
 
     double tstop=100;              /// Stop time of simulation in msec

--- a/coreneuron/io/mech_report.cpp
+++ b/coreneuron/io/mech_report.cpp
@@ -1,0 +1,51 @@
+#include <iostream>
+#include <vector>
+
+#include "coreneuron/coreneuron.hpp"
+#include "coreneuron/mpi/nrnmpi.h"
+#include "coreneuron/mpi/nrnmpi_impl.h"
+
+namespace coreneuron {
+
+/** display global mechanism count */
+void write_mech_report() {
+#if NRNMPI
+    /// mechanim count across all gids, local to rank
+    auto n_memb_func = corenrn.get_memb_funcs().size();
+    std::vector<unsigned long long> local_mech_count(n_memb_func, 0);
+
+    /// each gid record goes on separate row, only check non-empty threads
+    for (size_t i = 0; i < nrn_nthread; i++) {
+        const auto& nt = nrn_threads[i];
+        std::vector<int> mech_count(n_memb_func, 0);
+        for (auto* tml = nt.tml; tml; tml = tml->next) {
+            int type = tml->index;
+            const auto& ml = tml->ml;
+            local_mech_count[type] += ml->nodecount;
+        }
+    }
+
+    /// get global sum of all mechanism instances
+    std::vector<unsigned long long> total_mech_count(n_memb_func);
+    MPI_Allreduce(&local_mech_count[0],
+                  &total_mech_count[0],
+                  local_mech_count.size(),
+                  MPI_UNSIGNED_LONG_LONG,
+                  MPI_SUM,
+                  MPI_COMM_WORLD);
+
+    /// print global stats to stdout
+    if (nrnmpi_myid == 0) {
+        printf("\n================ MECHANISMS COUNT BY TYPE ==================\n");
+        printf("%4s %20s %10s\n", "Id", "Name", "Count");
+        for (int i = 0; i < total_mech_count.size(); i++) {
+            printf("%4d %20s %10lld\n", i, nrn_get_mechname(i), total_mech_count[i]);
+        }
+        printf("=============================================================\n");
+    }
+#else
+    std::cout << "Build and run with MPI to get mechanism stats \n";
+#endif
+}
+
+}  // namespace coreneuron

--- a/coreneuron/io/mech_report.cpp
+++ b/coreneuron/io/mech_report.cpp
@@ -9,22 +9,21 @@ namespace coreneuron {
 
 /** display global mechanism count */
 void write_mech_report() {
-#if NRNMPI
     /// mechanim count across all gids, local to rank
-    auto n_memb_func = corenrn.get_memb_funcs().size();
+    const auto n_memb_func = corenrn.get_memb_funcs().size();
     std::vector<unsigned long long> local_mech_count(n_memb_func, 0);
 
     /// each gid record goes on separate row, only check non-empty threads
     for (size_t i = 0; i < nrn_nthread; i++) {
         const auto& nt = nrn_threads[i];
-        std::vector<int> mech_count(n_memb_func, 0);
         for (auto* tml = nt.tml; tml; tml = tml->next) {
-            int type = tml->index;
+            const int type = tml->index;
             const auto& ml = tml->ml;
             local_mech_count[type] += ml->nodecount;
         }
     }
 
+#if NRNMPI
     /// get global sum of all mechanism instances
     std::vector<unsigned long long> total_mech_count(n_memb_func);
     MPI_Allreduce(&local_mech_count[0],
@@ -38,13 +37,18 @@ void write_mech_report() {
     if (nrnmpi_myid == 0) {
         printf("\n================ MECHANISMS COUNT BY TYPE ==================\n");
         printf("%4s %20s %10s\n", "Id", "Name", "Count");
-        for (int i = 0; i < total_mech_count.size(); i++) {
+        for (size_t i = 0; i < total_mech_count.size(); i++) {
             printf("%4d %20s %10lld\n", i, nrn_get_mechname(i), total_mech_count[i]);
         }
         printf("=============================================================\n");
     }
 #else
-    std::cout << "Build and run with MPI to get mechanism stats \n";
+    printf("\n================ MECHANISMS COUNT BY TYPE ==================\n");
+    printf("%4s %20s %10s\n", "Id", "Name", "Count");
+    for (size_t i = 0; i < local_mech_count.size(); i++) {
+        printf("%4d %20s %10lld\n", i, nrn_get_mechname(i), local_mech_count[i]);
+    }
+    printf("=============================================================\n");
 #endif
 }
 

--- a/coreneuron/io/mech_report.cpp
+++ b/coreneuron/io/mech_report.cpp
@@ -23,9 +23,10 @@ void write_mech_report() {
         }
     }
 
+    std::vector<unsigned long long> total_mech_count(n_memb_func);
+
 #if NRNMPI
     /// get global sum of all mechanism instances
-    std::vector<unsigned long long> total_mech_count(n_memb_func);
     MPI_Allreduce(&local_mech_count[0],
                   &total_mech_count[0],
                   local_mech_count.size(),
@@ -33,23 +34,18 @@ void write_mech_report() {
                   MPI_SUM,
                   MPI_COMM_WORLD);
 
+#else
+    total_mech_count = local_mech_count;
+#endif
     /// print global stats to stdout
     if (nrnmpi_myid == 0) {
         printf("\n================ MECHANISMS COUNT BY TYPE ==================\n");
         printf("%4s %20s %10s\n", "Id", "Name", "Count");
         for (size_t i = 0; i < total_mech_count.size(); i++) {
-            printf("%4d %20s %10lld\n", i, nrn_get_mechname(i), total_mech_count[i]);
+            printf("%4lu %20s %10lld\n", i, nrn_get_mechname(i), total_mech_count[i]);
         }
         printf("=============================================================\n");
     }
-#else
-    printf("\n================ MECHANISMS COUNT BY TYPE ==================\n");
-    printf("%4s %20s %10s\n", "Id", "Name", "Count");
-    for (size_t i = 0; i < local_mech_count.size(); i++) {
-        printf("%4d %20s %10lld\n", i, nrn_get_mechname(i), local_mech_count[i]);
-    }
-    printf("=============================================================\n");
-#endif
 }
 
 }  // namespace coreneuron

--- a/coreneuron/io/mech_report.h
+++ b/coreneuron/io/mech_report.h
@@ -1,0 +1,11 @@
+#ifndef NRN_MECH_REPORT_UTILS
+#define NRN_MECH_REPORT_UTILS
+
+#include <string>
+
+namespace coreneuron {
+    /// write mechanism counts to stdout
+    void write_mech_report();
+}
+
+#endif

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -51,6 +51,8 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/utils/nrnoc_aux.hpp"
 #include "coreneuron/io/phase1.hpp"
 #include "coreneuron/io/phase2.hpp"
+#include "coreneuron/io/mech_report.h"
+#include "coreneuron/apps/corenrn_parameters.hpp"
 
 // callbacks into nrn/src/nrniv/nrnbbcore_write.cpp
 #include "coreneuron/sim/fast_imem.hpp"
@@ -562,6 +564,9 @@ void nrn_setup(const char* filesdat,
 
     if (nrnmpi_myid == 0 && !corenrn_param.is_quiet()) {
         printf(" Setup Done   : %.2lf seconds \n", nrn_wtime() - time);
+    }
+    if (corenrn_param.count_mechs) {
+        write_mech_report();
     }
 }
 

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -5,6 +5,7 @@
 # =============================================================================
 
 set(COMMON_ARGS "--tstop 100. --celsius 6.3 --mpi")
+set(COUNT_MECHS_ARG "--count_mechs")
 set(RING_DATASET_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ring")
 set(RING_COMMON_ARGS "--datpath ${RING_DATASET_DIR} ${COMMON_ARGS}")
 set(RING_GAP_COMMON_ARGS "--datpath ${CMAKE_CURRENT_SOURCE_DIR}/ring_gap ${COMMON_ARGS}")
@@ -16,7 +17,7 @@ endif()
 
 # List of tests with arguments
 set(TEST_CASES_WITH_ARGS
-    "ring!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring"
+    "ring!${RING_COMMON_ARGS} ${COUNT_MECHS_ARG} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring"
     "ring_binqueue!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_binqueue --binqueue"
     "ring_multisend!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_multisend --multisend"
     "ring_spike_buffer!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_spike_buffer --spikebuf 1"


### PR DESCRIPTION
Access feature through `--count_mechs` runtime option.

**Description**

Cherry picked 055368d from @pramodk and added a runtime option to enable/disable this step.

Fixes #444

**How to test this?**


```bash
cmake ..
make -j8
nrnivmodl mod
./bin/nrnivmodl-core mod
./x86_64/special script.py
./x86_64/special-core --count_mechs --tstop=10 --datpath=coredat
```


**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
