### PR TITLE
Setup pnttype2presyn in main thread to avoid race.

### DIFF
--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -448,6 +448,16 @@ void nrn_setup(const char* filesdat,
     // Note that rank with 0 dataset/cellgroup works fine
     nrn_threads_create(userParams.ngroup <= 1 ? 2 : userParams.ngroup);
 
+    // from nrn_has_net_event create pnttype2presyn for use in phase2.
+    auto& memb_func = corenrn.get_memb_funcs();
+    auto& pnttype2presyn = corenrn.get_pnttype2presyn();
+    auto& nrn_has_net_event_ = corenrn.get_has_net_event();
+    pnttype2presyn.clear();
+    pnttype2presyn.resize(memb_func.size(), -1);
+    for (size_t i = 0; i < nrn_has_net_event_.size(); ++i) {
+        pnttype2presyn[nrn_has_net_event_[i]] = i;
+    }
+
     nrnthread_chkpnt = new NrnThreadChkpnt[nrn_nthread];
 
     if (nrn_nthread > 1) {

--- a/coreneuron/io/phase2.cpp
+++ b/coreneuron/io/phase2.cpp
@@ -1082,13 +1082,6 @@ void Phase2::populate(NrnThread& nt, const UserParams& userParams) {
     }
     auto& pnttype2presyn = corenrn.get_pnttype2presyn();
     auto& nrn_has_net_event_ = corenrn.get_has_net_event();
-    // from nrn_has_net_event create pnttype2presyn.
-    if (pnttype2presyn.empty()) {
-        pnttype2presyn.resize(memb_func.size(), -1);
-    }
-    for (size_t i = 0; i < nrn_has_net_event_.size(); ++i) {
-        pnttype2presyn[nrn_has_net_event_[i]] = i;
-    }
     // create the nt.pnt2presyn_ix array of arrays.
     nt.pnt2presyn_ix = (int**)ecalloc(nrn_has_net_event_.size(), sizeof(int*));
     for (size_t i = 0; i < nrn_has_net_event_.size(); ++i) {


### PR DESCRIPTION
**Phase2 setup of pnttype2presyn causes race.**

Move the setup to main thread prior to phase2.

Fixes neuronsimulator/nrn#884

**How to test this?**

See test-mpithread.py at neuronsimulator/nrn#884 and follow build instructions. Without this change the error reliability is high with:
```
mpiexec -n 4 nrniv -mpi -python test-mpithread.py
```

CI_BRANCHES:NEURON_BRANCH=master,