### PR TITLE
Fix caliper link lines for nrnivmodl-core

### DIFF
--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -144,14 +144,14 @@ add_library(scopmath STATIC ${CORENEURON_HEADER_FILES} ${SCOPMATH_CODE_FILES})
 
 target_link_libraries(
   coreneuron
-  ${MPI_C_LIBRARIES}
   ${reportinglib_LIBRARY}
   ${sonatareport_LIBRARY}
   ${link_cudacoreneuron}
   ${CUDA_LIBRARIES}
   ${CALIPER_LIB}
   ${CALIPER_MPI_LIB}
-  ${likwid_LIBRARIES})
+  ${likwid_LIBRARIES}
+  ${MPI_C_LIBRARIES})
 target_include_directories(coreneuron SYSTEM
                            PRIVATE ${CORENEURON_PROJECT_SOURCE_DIR}/external/Random123/include)
 target_include_directories(coreneuron SYSTEM

--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -39,6 +39,8 @@ LDFLAGS = $(LINKFLAGS) @CORENRN_LINK_DEFS@
 CORENRNLIB_FLAGS = -L$(CORENRN_LIB_DIR) -lcoreneuron
 CORENRNLIB_FLAGS += $(if @reportinglib_LIB_DIR@, -W$(subst ;, -W,l,-rpath,@reportinglib_LIB_DIR@),)
 CORENRNLIB_FLAGS += $(if @sonatareport_LIB_DIR@, -W$(subst ;, -W,l,-rpath,@sonatareport_LIB_DIR@),)
+CORENRNLIB_FLAGS += $(if @caliper_LIB_DIR@, -W$(subst ;, -W,l,-rpath,@caliper_LIB_DIR@),)
+CORENRNLIB_FLAGS += $(if @caliper_LIB_DIR@,-L@caliper_LIB_DIR@,)
 
 # Includes paths gathered by CMake
 INCLUDES = $(INCFLAGS) -I$(CORENRN_INC_DIR) -I$(CORENRN_INC_DIR)/coreneuron/utils/randoms


### PR DESCRIPTION
  - CoreNEURON supports caliper instrumentation with -DCORENRN_ENABLE_CALIPER_PROFILING=ON
  - If caliper profiling is enabled then nrnivmodl-core should add path to lib directory of caliper
  - Change order of mpi and caliper libraries due to issue LLNL/Caliper/issues/176

Related to #449

**How to test this?**

```bash
cmake .. -DCORENRN_ENABLE_CALIPER_PROFILING=TRUE -Dcaliper_DIR=/gpfs/.../gcc-8.3.0/caliper-2.0.1/share/cmake/caliper
make -j
```

and run test as:

```
$ CALI_CONFIG_PROFILE=mpi-runtime-report srun -n 3 bin/x86_64/special-core -e 10 -d ../tests/integration/ring --mpi
== CALIPER: (0): default: Registered aggregation service
== CALIPER: (0): default: Registered event trigger service
== CALIPER: (0): default: Registered timestamp service
== CALIPER: (0): default: Registered MPI service
== CALIPER: (0): default: Registered mpireport service
== CALIPER: (0): Creating channel default
== CALIPER: (0): Initialized
 num_mpi=3
 num_omp_thread=1


 Duke, Yale, and the BlueBrain Project -- Copyright 1984-2020
 Version : 0.21.0 785af34 (2020-12-30 15:30:57 +0100)

 Additional mechanisms from files
 exp2syn.mod expsyn.mod halfgap.mod hh.mod netstim.mod passive.mod pattern.mod stim.mod svclmp.mod

 Memory (MBs) :             After mk_mech : Max 8.4844, Min 8.3477, Avg 8.3945
 Memory (MBs) :            After MPI_Init : Max 8.4844, Min 8.3477, Avg 8.3945
 Memory (MBs) :          Before nrn_setup : Max 8.7422, Min 8.5859, Avg 8.6471
Info : The number of input datasets are less than ranks, some ranks will be idle!
 Setup Done   : 0.00 seconds
 Memory (MBs) :          After nrn_setup  : Max 8.7812, Min 8.6250, Avg 8.6862
GENERAL PARAMETERS
--mpi=true
--gpu=false
--dt=0.025
--tstop=10

GPU
--nwarp=0
--cell-permute=0

INPUT PARAMETERS
--voltage=-65
--seed=-1
--datpath=../tests/integration/ring
--filesdat=files.dat
--pattern=
--report-conf=
--restore=

PARALLEL COMPUTATION PARAMETERS
--threading=false
--skip_mpi_finalize=false

SPIKE EXCHANGE
--ms_phases=2
--ms_subintervals=2
--multisend=false
--spk_compress=0
--binqueue=false

CONFIGURATION
--spikebuf=100000
--prcellgid=-1
--forwardskip=0
--celsius=6.3
--mindelay=1
--report-buffer-size=4

OUTPUT PARAMETERS
--dt_io=0.1
--outpath=.
--checkpoint=

 Start time (t) = 0

 Memory (MBs) :  After mk_spikevec_buffer : Max 8.7812, Min 8.6250, Avg 8.6862
 Memory (MBs) :     After nrn_finitialize : Max 8.7812, Min 8.6250, Avg 8.6862

 psolve |========================================================| t: 10.00  ETA: 0h00m00s

Solver Time : 0.0173045


 Simulation Statistics
 Number of cells: 20
 Number of compartments: 804
 Number of presyns: 21
 Number of input presyns: 20
 Number of synapses: 21
 Number of point processes: 41
 Number of transfer (gap) targets: 0
 Number of spikes: 3
 Number of spikes with non negative gid-s: 3
== CALIPER: (0): default: Flushing Caliper data
== CALIPER: (0): default: Aggregate: flushed 61 snapshots.
Path                           Min time/rank Max time/rank Avg time/rank Time % (total)
main                               95.000000    133.000000    109.000000       0.528109
  MPI_Finalize                      1.000000      2.000000      1.333333       0.006460
  MPI_Comm_free                     4.000000     13.000000      9.000000       0.043605
  MPI_Initialized                   1.000000      2.000000      1.333333       0.006460
  checkpoint                        4.000000      5.000000      4.666667       0.022610
  output-spike                     46.000000    176.000000     89.666667       0.434439
    MPI_File_close                 45.000000     78.000000     62.333333       0.302007
    MPI_File_write_at_all         118.000000    145.000000    129.666667       0.628240
    MPI_File_open                 352.000000    354.000000    353.333333       1.711914
      MPI_Type_create_struct        2.000000      3.000000      2.666667       0.012920
    MPI_Exscan                     13.000000     17.000000     14.333333       0.069446
    MPI_Barrier                     1.000000      2.000000      1.666667       0.008075
    MPI_Alltoallv                  30.000000     32.000000     31.000000       0.150196
    MPI_Alltoall                   30.000000     30.000000     30.000000       0.145351
    MPI_Allreduce                   6.000000    150.000000    100.666667       0.487734
    MPI_Initialized                 1.000000      4.000000      2.000000       0.009690
  simulation                      626.000000    772.000000    681.333333       3.301087
    MPI_Barrier                     1.000000      2.000000      1.666667       0.008075
    spike-exchange                 29.000000     34.000000     30.666667       0.148581
      communication                26.000000     29.000000     27.333333       0.132431
        MPI_Allgatherv             19.000000     21.000000     20.000000       0.096901
        MPI_Allgather              24.000000     26.000000     25.333333       0.122741
      imbalance                    18.000000     22.000000     20.000000       0.096901
        MPI_Barrier               131.000000  13015.000000   4440.666667      21.515205
    timestep                     1980.000000   3623.000000   3074.333333      14.895266
      state-update               1517.000000   1563.000000   1540.000000       4.974241
        state-hh                 1179.000000   1182.000000   1180.500000       3.813046
        state-ExpSyn              577.000000    605.000000    591.000000       1.908946
        state-pas                 400.000000    407.000000    403.500000       1.303316
      update                      554.000000    583.000000    568.500000       1.836270
      second_order_cur            408.000000    415.000000    411.500000       1.329156
      matrix-solver              1020.000000   1022.000000   1021.000000       3.297857
      setup_tree_matrix          2904.000000   2906.000000   2905.000000       9.383226
        cur-hh                    489.000000    497.000000    493.000000       1.592403
        cur-ExpSyn                445.000000    470.000000    457.500000       1.477737
        cur-k_ion                 396.000000    412.000000    404.000000       1.304931
        cur-na_ion                416.000000    425.000000    420.500000       1.358226
        cur-pas                   630.000000    651.000000    640.500000       2.068832
      deliver_events             1559.000000   1665.000000   1627.666667       7.886109
  finitialize                      18.000000     64.000000     43.333333       0.209952
    spike-exchange                  3.000000      3.000000      3.000000       0.014535
      communication                 3.000000      4.000000      3.666667       0.017765
        MPI_Allgather              12.000000     13.000000     12.333333       0.059755
      imbalance                     2.000000      3.000000      2.333333       0.011305
        MPI_Barrier                 1.000000     55.000000     25.000000       0.121126
    cur-hh                          1.000000      2.000000      1.500000       0.004845
    cur-ExpSyn                      1.000000      4.000000      2.500000       0.008075
    cur-k_ion                       1.000000      1.000000      1.000000       0.003230
    cur-na_ion                      1.000000      1.000000      1.000000       0.003230
    cur-pas                         2.000000      2.000000      2.000000       0.006460
  MPI_Barrier                      11.000000     17.000000     14.666667       0.071061
  load-model                      389.000000    755.000000    587.666667       2.847268
    MPI_Allreduce                  46.000000    418.000000    217.000000       1.051374
  MPI_Allreduce                    52.000000    102.000000     82.333333       0.398908
MPI_Op_create                       3.000000      4.000000      3.666667       0.017765
MPI_Type_commit                     2.000000      2.000000      2.000000       0.009690
MPI_Type_create_struct              4.000000      5.000000      4.666667       0.022610
MPI_Get_address                     5.000000      6.000000      5.333333       0.025840
MPI_Comm_dup                       33.000000     35.000000     34.000000       0.164731
MPI_Init_thread                    81.000000    224.000000    166.666667       0.807507
== CALIPER: (0): Finishing ...
== CALIPER: (0): default: Flushing Caliper data
== CALIPER: (0): Finished
```

CI_BRANCHES:NEURON_BRANCH=master,
