### PR TITLE
Avoid using system paths for Random123

### DIFF
--- a/.github/workflows/coreneuron-ci.yml
+++ b/.github/workflows/coreneuron-ci.yml
@@ -106,8 +106,7 @@ jobs:
           fi
           
           if [[ "${{ startsWith(matrix.os, 'macOS') }}" = "true" ]]; then
-              git submodule update --init -- external/Random123
-              export PATH=${{runner.workspace}}/CoreNeuron/external/Random123:/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
+              export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
               export CXX=g++;
               export CC=gcc;
           fi

--- a/CMake/AddRandom123Submodule.cmake
+++ b/CMake/AddRandom123Submodule.cmake
@@ -10,7 +10,8 @@ find_package(FindPkgConfig QUIET)
 find_path(
   Random123_PROJ
   NAMES LICENSE
-  PATHS "${CORENEURON_PROJECT_SOURCE_DIR}/external/Random123")
+  PATHS "${CORENEURON_PROJECT_SOURCE_DIR}/external/Random123"
+  NO_SYSTEM_ENVIRONMENT_PATH)
 
 find_package_handle_standard_args(Random123 REQUIRED_VARS Random123_PROJ)
 


### PR DESCRIPTION
**Description**

`Random123` submodule needs to be in a proped `CoreNEURON` subdirectory, so we try to avoid finding from system paths.

- [x] Removed CI hacks for finding the proper Random123

**Test System**
 - OS: macos github runner
 - Version: master
