### PR TITLE
CMake build options refactoring for Makefile

### DIFF
--- a/CMake/MakefileBuildOptions.cmake
+++ b/CMake/MakefileBuildOptions.cmake
@@ -1,0 +1,73 @@
+# =============================================================================
+# Common CXX and ISPC flags
+# =============================================================================
+
+# ISPC should compile with --pic by default
+set(CMAKE_ISPC_FLAGS "${CMAKE_ISPC_FLAGS} --pic")
+
+# =============================================================================
+# NMODL CLI options : common and backend specific
+# =============================================================================
+# if user pass arguments then use those as common arguments
+if ("${CORENRN_NMODL_FLAGS}" STREQUAL "")
+  set(NMODL_COMMON_ARGS "passes --inline")
+else()
+  set(NMODL_COMMON_ARGS ${CORENRN_NMODL_FLAGS})
+endif()
+
+set(NMODL_CPU_BACKEND_ARGS "host --c")
+set(NMODL_ISPC_BACKEND_ARGS "host --ispc")
+set(NMODL_ACC_BACKEND_ARGS "host --c acc --oacc")
+
+# =============================================================================
+# Extract Compile definitions : common to all backend
+# =============================================================================
+get_directory_property(COMPILE_DEFS COMPILE_DEFINITIONS)
+if(COMPILE_DEFS)
+    set(CORENRN_COMMON_COMPILE_DEFS "")
+    foreach(flag ${COMPILE_DEFS})
+        set(CORENRN_COMMON_COMPILE_DEFS "${CORENRN_COMMON_COMPILE_DEFS} -D${flag}")
+    endforeach()
+endif()
+
+# =============================================================================
+# link flags : common to all backend
+# =============================================================================
+# ~~~
+# find_cuda uses FindThreads that adds below imported target we
+# shouldn't add imported target to link line
+# ~~~
+list(REMOVE_ITEM CORENRN_LINK_LIBS "Threads::Threads")
+
+# replicate CMake magic to transform system libs to -l<libname>
+foreach(link_lib ${CORENRN_LINK_LIBS})
+    if(${link_lib} MATCHES "\-l.*")
+        string(APPEND CORENRN_COMMON_LDFLAGS " ${link_lib}")
+        continue()
+    endif()
+    get_filename_component(path ${link_lib} DIRECTORY)
+    if(NOT path)
+        string(APPEND CORENRN_COMMON_LDFLAGS " -l${link_lib}")
+    elseif("${path}" MATCHES "^(/lib|/lib64|/usr/lib|/usr/lib64)$")
+        get_filename_component(libname ${link_lib} NAME_WE)
+        string(REGEX REPLACE "^lib" "" libname ${libname})
+        string(APPEND CORENRN_COMMON_LDFLAGS " -l${libname}")
+    else()
+        string(APPEND CORENRN_COMMON_LDFLAGS " ${link_lib}")
+    endif()
+endforeach()
+
+# =============================================================================
+# compile flags : common to all backend
+# =============================================================================
+# PGI compiler adds --c++14;-A option for C++14, remove ";"
+string(REPLACE ";" " " CXX14_STD_FLAGS "${CMAKE_CXX14_STANDARD_COMPILE_OPTION}")
+string(TOUPPER "${CMAKE_BUILD_TYPE}" _BUILD_TYPE)
+set(CORENRN_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${_BUILD_TYPE}} ${CXX14_STD_FLAGS}")
+
+# =============================================================================
+# nmodl/mod2c related options : TODO
+# =============================================================================
+# name of nmodl/mod2c binary
+get_filename_component(nmodl_name ${CORENRN_MOD2CPP_BINARY} NAME)
+set(nmodl_binary_name ${nmodl_name})

--- a/CMake/OpenAccHelper.cmake
+++ b/CMake/OpenAccHelper.cmake
@@ -4,10 +4,14 @@
 # See top-level LICENSE file for details.
 # =============================================================================
 
+# =============================================================================
+# Prepare compiler flags for GPU target
+# =============================================================================
 if(CORENRN_ENABLE_GPU)
+
   # cuda unified memory support
   if(CORENRN_ENABLE_CUDA_UNIFIED_MEMORY)
-    add_definitions(-DUNIFIED_MEMORY)
+    set(UNIFIED_MEMORY_DEF -DUNIFIED_MEMORY)
   endif()
 
   # if user don't specify host compiler, use gcc from $PATH
@@ -20,31 +24,23 @@ if(CORENRN_ENABLE_GPU)
 
   # various flags for PGI compiler with GPU build
   if(${CMAKE_C_COMPILER_ID} STREQUAL "PGI")
+
     # workaround for old PGI version
-    add_definitions(-DPG_ACC_BUGS)
-    set(ACC_FLAGS "-acc")
+    set(PGI_ACC_BUG_DEFS -DPG_ACC_BUGS)
+    set(PGI_ACC_FLAGS "-acc")
     # disable very verbose diagnosis messages and obvious warnings for mod2c
     set(PGI_DIAG_FLAGS "--diag_suppress 161,177,550")
-    # some of the mod files can have too many functions, increase inline level
+    # inlining of large functions for OpenACC
     set(PGI_INLINE_FLAGS "-Minline=size:200,levels:10")
-    # C/C++ compiler flags
-    set(CMAKE_C_FLAGS "${ACC_FLAGS} ${CMAKE_C_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${ACC_FLAGS} ${CMAKE_CXX_FLAGS} ${PGI_DIAG_FLAGS}")
+
     # avoid PGI adding standard compliant "-A" flags
     set(CMAKE_CXX11_STANDARD_COMPILE_OPTION --c++11)
     set(CMAKE_CXX14_STANDARD_COMPILE_OPTION --c++14)
+
   else()
     message(FATAL_ERROR "GPU support is available via OpenACC using PGI/NVIDIA compilers."
                         " Use NVIDIA HPC SDK with -DCMAKE_C_COMPILER=nvc -DCMAKE_CXX_COMPILER=nvc++")
   endif()
-
-  # set property for neuron to link with coreneuron libraries
-  set_property(
-    GLOBAL
-    PROPERTY
-      CORENEURON_LIB_LINK_FLAGS
-      "-acc -rdynamic -lrt -Wl,--whole-archive -L${CMAKE_HOST_SYSTEM_PROCESSOR} -lcorenrnmech -L${CMAKE_INSTALL_PREFIX}/lib -lcoreneuron -lcudacoreneuron -Wl,--no-whole-archive ${CUDA_cudart_static_LIBRARY}"
-  )
 
   # find_cuda produce verbose messages : use new behavior to use _ROOT variables
   if(POLICY CMP0074)
@@ -53,11 +49,26 @@ if(CORENRN_ENABLE_GPU)
   find_package(CUDA 9.0 REQUIRED)
   set(CUDA_SEPARABLE_COMPILATION ON)
   set(CUDA_PROPAGATE_HOST_FLAGS OFF)
-  add_definitions(-DCUDA_PROFILING)
-else(CORENRN_ENABLE_GPU)
-  # OpenACC pragmas are not guarded, disable all unknown pragm warnings
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${IGNORE_UNKNOWN_PRAGMA_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNORE_UNKNOWN_PRAGMA_FLAGS}")
+  set(CUDA_PROFILING_DEF -DCUDA_PROFILING)
+
+  set(CORENRN_ACC_GPU_DEFS "${UNIFIED_MEMORY_DEF} ${CUDA_PROFILING_DEF} ${PGI_ACC_BUG_DEFS}")
+  set(CORENRN_ACC_GPU_FLAGS "${PGI_ACC_FLAGS} ${PGI_DIAG_FLAGS} ${PGI_INLINE_FLAGS}")
+
+  add_definitions(${CORENRN_ACC_GPU_DEFS})
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CORENRN_ACC_GPU_FLAGS}")
+endif()
+
+# =============================================================================
+# Set global property that will be used by NEURON to link with CoreNEURON
+# =============================================================================
+if(CORENRN_ENABLE_GPU)
+  set_property(
+    GLOBAL
+    PROPERTY
+      CORENEURON_LIB_LINK_FLAGS
+      "${PGI_ACC_FLAGS} -rdynamic -lrt -Wl,--whole-archive -L${CMAKE_HOST_SYSTEM_PROCESSOR} -lcorenrnmech -L${CMAKE_INSTALL_PREFIX}/lib -lcoreneuron -lcudacoreneuron -Wl,--no-whole-archive ${CUDA_cudart_static_LIBRARY}"
+  )
+else()
   set_property(GLOBAL PROPERTY CORENEURON_LIB_LINK_FLAGS
                                "-L${CMAKE_HOST_SYSTEM_PROCESSOR} -lcorenrnmech")
 endif(CORENRN_ENABLE_GPU)

--- a/CMake/OpenAccHelper.cmake
+++ b/CMake/OpenAccHelper.cmake
@@ -26,7 +26,6 @@ if(CORENRN_ENABLE_GPU)
   if(${CMAKE_C_COMPILER_ID} STREQUAL "PGI")
 
     # workaround for old PGI version
-    set(PGI_ACC_BUG_DEFS -DPG_ACC_BUGS)
     set(PGI_ACC_FLAGS "-acc")
     # disable very verbose diagnosis messages and obvious warnings for mod2c
     set(PGI_DIAG_FLAGS "--diag_suppress 161,177,550")
@@ -51,7 +50,7 @@ if(CORENRN_ENABLE_GPU)
   set(CUDA_PROPAGATE_HOST_FLAGS OFF)
   set(CUDA_PROFILING_DEF -DCUDA_PROFILING)
 
-  set(CORENRN_ACC_GPU_DEFS "${UNIFIED_MEMORY_DEF} ${CUDA_PROFILING_DEF} ${PGI_ACC_BUG_DEFS}")
+  set(CORENRN_ACC_GPU_DEFS "${UNIFIED_MEMORY_DEF} ${CUDA_PROFILING_DEF}")
   set(CORENRN_ACC_GPU_FLAGS "${PGI_ACC_FLAGS} ${PGI_DIAG_FLAGS} ${PGI_INLINE_FLAGS}")
 
   add_definitions(${CORENRN_ACC_GPU_DEFS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,13 +95,6 @@ set(LIKWID_DIR
     ""
     CACHE PATH "Path to likwid performance analysis suite")
 
-set(CORENRN_FRONTEND_C_COMPILER
-    gcc
-    CACHE FILEPATH "C compiler for building mod2c [frontend]")
-set(CORENRN_FRONTEND_CXX_COMPILER
-    g++
-    CACHE FILEPATH "C++ compiler for building mod2c [frontend]")
-
 if(CORENEURON_AS_SUBPROJECT)
   set(CORENRN_ENABLE_UNIT_TESTS OFF)
 endif()
@@ -127,11 +120,6 @@ find_package(PythonInterp REQUIRED)
 find_package(Perl REQUIRED)
 
 # =============================================================================
-# ISPC should compile with --pic by default
-# =============================================================================
-set(CMAKE_ISPC_FLAGS "--pic ${CMAKE_ISPC_FLAGS}")
-
-# =============================================================================
 # Common build options
 # =============================================================================
 # build mod files for coreneuron
@@ -147,7 +135,6 @@ endif()
 # Build option specific compiler flags
 # =============================================================================
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "PGI")
-  add_definitions(-DSWAP_ENDIAN_DISABLE_ASM)
   # PGI with llvm code generation doesn't have necessary assembly intrinsic headers
   add_definitions(-DEIGEN_DONT_VECTORIZE=1)
 endif()
@@ -168,7 +155,6 @@ endif()
 
 if(CORENRN_ENABLE_ISPC)
   enable_language(ISPC)
-  add_definitions("-DISPC_INTEROP=1")
   set(CORENRN_ENABLE_NMODL ON)
 endif()
 
@@ -283,7 +269,6 @@ if(CORENRN_ENABLE_NMODL)
   if(CORENRN_ENABLE_GPU)
     string(APPEND CORENRN_NMODL_FLAGS " acc --oacc")
   endif()
-  separate_arguments(NMODL_EXTRA_FLAGS_LIST UNIX_COMMAND "${CORENRN_NMODL_FLAGS}")
 else()
   include(AddMod2cSubmodule)
   set(CORENRN_MOD2CPP_BINARY ${CMAKE_BINARY_DIR}/bin/mod2c_core${CMAKE_EXECUTABLE_SUFFIX})
@@ -310,9 +295,16 @@ if(CORENRN_ENABLE_LIKWID_PROFILING)
 endif()
 
 # =============================================================================
+# Common CXX flags : ignore unknown pragma warnings
+# =============================================================================
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNORE_UNKNOWN_PRAGMA_FLAGS}")
+
+# =============================================================================
 # Add main directories
 # =============================================================================
 add_subdirectory(coreneuron)
+
+include(MakefileBuildOptions)
 add_subdirectory(extra)
 
 if(CORENRN_ENABLE_UNIT_TESTS)
@@ -324,14 +316,6 @@ endif()
 # =============================================================================
 install(FILES CMake/coreneuron-config.cmake DESTINATION share/cmake)
 install(EXPORT coreneuron DESTINATION share/cmake)
-
-# just for printing the compiler flags in the build status
-string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
-if(BUILD_TYPE_UPPER MATCHES "CUSTOM")
-  set(COMPILER_FLAGS "${CMAKE_CXX_FLAGS}")
-else()
-  set(COMPILER_FLAGS "${CMAKE_CXX_FLAGS_${BUILD_TYPE_UPPER}}")
-endif()
 
 if(NOT CORENEURON_AS_SUBPROJECT)
   # =============================================================================
@@ -402,7 +386,7 @@ if(cmake_generator_tolower MATCHES "makefile")
 
   message(STATUS "C COMPILER          | ${CMAKE_C_COMPILER}")
   message(STATUS "CXX COMPILER        | ${CMAKE_CXX_COMPILER}")
-  message(STATUS "COMPILE FLAGS       | ${COMPILER_FLAGS} ${CMAKE_CXX_FLAGS}")
+  message(STATUS "COMPILE FLAGS       | ${CORENRN_CXX_FLAGS}")
   message(STATUS "Build Type          | ${COMPILE_LIBRARY_TYPE}")
   message(STATUS "MPI                 | ${CORENRN_ENABLE_MPI}")
   if(CORENRN_ENABLE_MPI)

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -56,11 +56,6 @@ set(NMODL_UNITS_FILE "${CMAKE_BINARY_DIR}/share/mod2c/nrnunits.lib")
 file(COPY ${CORENEURON_PROJECT_SOURCE_DIR}/coreneuron/mechanism/mech/modfile
      DESTINATION ${CMAKE_BINARY_DIR}/share)
 
-# eion.cpp depends on CORENRN_USE_LEGACY_UNITS
-set(LegacyFR_FILES mechanism/eion.cpp apps/main1.cpp io/global_vars.cpp)
-set_source_files_properties(${LegacyFR_FILES} PROPERTIES COMPILE_FLAGS
-                              "-DCORENRN_USE_LEGACY_UNITS=${CORENRN_USE_LEGACY_UNITS}")
-
 # =============================================================================
 # coreneuron GPU library
 # =============================================================================
@@ -84,12 +79,6 @@ if(CORENRN_ENABLE_GPU)
 
   set_source_files_properties(${OPENACC_EXCLUDED_FILES} PROPERTIES COMPILE_FLAGS
                               "-DDISABLE_OPENACC")
-
-  # TODO : only older PGI versions?
-  if(${CMAKE_C_COMPILER_ID} STREQUAL "PGI")
-    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/scopmath_core/sparse_thread.c
-                                PROPERTIES COMPILE_FLAGS "-ta=tesla:nollvm")
-  endif()
 
   # compile cuda files for multiple architecture
   cuda_add_library(

--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -77,10 +77,8 @@ bool corenrn_units_use_legacy() {
 
 void (*nrn2core_part2_clean_)();
 
-#ifdef ISPC_INTEROP
 // cf. utils/ispc_globals.c
 extern double ispc_celsius;
-#endif
 
 /**
  * If "export OMP_NUM_THREADS=n" is not set then omp by default sets
@@ -213,9 +211,9 @@ void nrn_init_and_load_data(int argc,
 
     corenrn_param.celsius = celsius;
 
-#ifdef ISPC_INTEROP
+    // for ispc backend
     ispc_celsius = celsius;
-#endif
+
     // create net_cvode instance
     mk_netcvode();
 

--- a/coreneuron/gpu/nrn_acc_manager.cpp
+++ b/coreneuron/gpu/nrn_acc_manager.cpp
@@ -969,8 +969,7 @@ void nrn_ion_global_map_copyto_device() {
             (double**)acc_copyin(nrn_ion_global_map, sizeof(double*) * nrn_ion_global_map_size);
         for (int j = 0; j < nrn_ion_global_map_size; j++) {
             if (nrn_ion_global_map[j]) {
-                /* @todo: fix this constant size 3 :( */
-                double* d_mechmap = (double*)acc_copyin(nrn_ion_global_map[j], 3 * sizeof(double));
+                double* d_mechmap = (double*)acc_copyin(nrn_ion_global_map[j], ion_global_map_member_size * sizeof(double));
                 acc_memcpy_to_device(&(d_data[j]), &d_mechmap, sizeof(double*));
             }
         }

--- a/coreneuron/mechanism/eion.cpp
+++ b/coreneuron/mechanism/eion.cpp
@@ -48,21 +48,12 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #if defined(_OPENACC)
-#if defined(PG_ACC_BUGS)
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ \
     _Pragma(                       \
-        "acc parallel loop present(pd[0:_cntml_padded*5], ppd[0:1], nrn_ion_global_map[0:nrn_ion_global_map_size][0:3]) if(nt->compute_gpu)")
+        "acc parallel loop present(pd[0:_cntml_padded*5], ppd[0:1], nrn_ion_global_map[0:nrn_ion_global_map_size][0:ion_global_map_member_size]) if(nt->compute_gpu)")
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ \
     _Pragma(                      \
-        "acc parallel loop present(pd[0:_cntml_padded*5], nrn_ion_global_map[0:nrn_ion_global_map_size][0:3]) if(nt->compute_gpu) async(stream_id)")
-#else
-#define _PRAGMA_FOR_INIT_ACC_LOOP_ \
-    _Pragma(                       \
-        "acc parallel loop present(pd[0:_cntml_padded*5], ppd[0:1], nrn_ion_global_map[0:nrn_ion_global_map_size]) if(nt->compute_gpu)")
-#define _PRAGMA_FOR_CUR_ACC_LOOP_ \
-    _Pragma(                      \
-        "acc parallel loop present(pd[0:_cntml_padded*5], nrn_ion_global_map[0:nrn_ion_global_map_size]) if(nt->compute_gpu) async(stream_id)")
-#endif
+        "acc parallel loop present(pd[0:_cntml_padded*5], nrn_ion_global_map[0:nrn_ion_global_map_size][0:ion_global_map_member_size]) if(nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_SEC_ORDER_CUR_ACC_LOOP_ \
     _Pragma(                                \
         "acc parallel loop present(pd[0:_cntml_padded*5], ni[0:_cntml_actual], _vec_rhs[0:_nt->end]) if(_nt->compute_gpu) async(stream_id)")
@@ -73,6 +64,10 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 namespace coreneuron {
+
+// for each ion it refers to internal concentration, external concentration, and charge,
+const int ion_global_map_member_size = 3;
+
 
 #define nparm 5
 static const char* mechanism[] = {/*just a template*/
@@ -130,7 +125,7 @@ void ion_reg(const char* name, double valence) {
             }
             nrn_ion_global_map_size = mechtype + 1;
         }
-        nrn_ion_global_map[mechtype] = (double*)emalloc(3 * sizeof(double));
+        nrn_ion_global_map[mechtype] = (double*)emalloc(ion_global_map_member_size * sizeof(double));
 
         register_mech((const char**)mechanism, nrn_alloc_ion, nrn_cur_ion, (mod_f_t)0, (mod_f_t)0,
                       (mod_f_t)nrn_init_ion, -1, 1);

--- a/coreneuron/mechanism/mechanism.hpp
+++ b/coreneuron/mechanism/mechanism.hpp
@@ -33,7 +33,9 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "coreneuron/utils/memory.h"
 
 namespace coreneuron {
-#if PG_ACC_BUGS
+// OpenACC with PGI compiler has issue when union is used and hence use struct
+// \todo check if newer PGI versions has resolved this issue
+#if defined(_OPENACC)
 struct ThreadDatum {
     int i;
     double* pval;

--- a/coreneuron/mechanism/membfunc.hpp
+++ b/coreneuron/mechanism/membfunc.hpp
@@ -86,6 +86,7 @@ struct BAMech {
 
 extern int nrn_ion_global_map_size;
 extern double** nrn_ion_global_map;
+extern const int ion_global_map_member_size;
 
 #define NRNPOINTER                                                            \
     4 /* added on to list of mechanism variables.These are                    \
@@ -93,6 +94,7 @@ pointers which connect variables  from other mechanisms via the _ppval array. \
 */
 
 #define _AMBIGUOUS 5
+
 
 extern int nrn_get_mechtype(const char*);
 extern const char* nrn_get_mechname(int);  // slow. use memb_func[i].sym if posible

--- a/coreneuron/mechanism/register_mech.cpp
+++ b/coreneuron/mechanism/register_mech.cpp
@@ -40,12 +40,9 @@ THE POSSIBILITY OF SUCH DAMAGE.
 namespace coreneuron {
 int secondorder = 0;
 double t, dt, celsius;
-#if defined(PG_ACC_BUGS)
-// clang-format off
-    #pragma acc declare copyin(secondorder)
-    #pragma acc declare copyin(celsius)
-// clang-format on
-#endif
+// declare copyin required for correct initialization
+#pragma acc declare copyin(secondorder)
+#pragma acc declare copyin(celsius)
 int rev_dt;
 
 using Pfrv = void (*)();

--- a/extra/CMakeLists.txt
+++ b/extra/CMakeLists.txt
@@ -5,71 +5,15 @@
 # =============================================================================
 
 # =============================================================================
-# Prepare nrnivmodl-core script with correct compiler flags
+# Copy first into build directory as it will be used for special-core
 # =============================================================================
-
-# extract the COMPILE_DEFINITIONS property from the directory.
-get_directory_property(CORENRN_COMPILE_FLAGS COMPILE_DEFINITIONS)
-if(CORENRN_COMPILE_FLAGS)
-  set(CORENRN_COMPILE_DEFS "")
-  foreach(flag ${CORENRN_COMPILE_FLAGS})
-    set(CORENRN_COMPILE_DEFS "${CORENRN_COMPILE_DEFS} -D${flag}")
-  endforeach()
-endif()
-
-# ~~~
-# find_cuda uses FindThreads that adds below imported target we shouldn't add
-# imported target to link line
-# ~~~
-list(REMOVE_ITEM CORENRN_LINK_LIBS "Threads::Threads")
-# replicate CMake magic to transform system libs to -l<libname>
-foreach(link_lib ${CORENRN_LINK_LIBS})
-  if(${link_lib} MATCHES "\-l.*")
-      string(APPEND CORENRN_LINK_DEFS " ${link_lib}")
-      continue()
-  endif()
-  get_filename_component(path ${link_lib} DIRECTORY)
-  if(NOT path)
-    string(APPEND CORENRN_LINK_DEFS " -l${link_lib}")
-  elseif("${path}" MATCHES "^(/lib|/lib64|/usr/lib|/usr/lib64)$")
-    get_filename_component(libname ${link_lib} NAME_WE)
-    string(REGEX REPLACE "^lib" "" libname ${libname})
-    string(APPEND CORENRN_LINK_DEFS " -l${libname}")
-  else()
-    string(APPEND CORENRN_LINK_DEFS " ${link_lib}")
-  endif()
-endforeach()
-
-# PGI compiler add --c++14;-A option for c++14 flag
-string(REPLACE ";" " " CXX14_STANDARD_COMPILE_OPTION "${CMAKE_CXX14_STANDARD_COMPILE_OPTION}")
-
-# compiler flags depending on BUILD_TYPE (configured as BUILD_TYPE_<LANG>_FLAGS)
-string(TOUPPER "${CMAKE_BUILD_TYPE}" _BUILD_TYPE)
-set(BUILD_TYPE_C_FLAGS "${CMAKE_C_FLAGS_${_BUILD_TYPE}}")
-set(BUILD_TYPE_CXX_FLAGS "${CMAKE_CXX_FLAGS_${_BUILD_TYPE}}")
-message(STATUS "CXX Compile flags from BUILD_TYPE (${_BUILD_TYPE}): ${BUILD_TYPE_CXX_FLAGS}")
-
-# nmodl options
-if(CORENRN_ENABLE_NMODL)
-  set(nmodl_arguments_c "host --c passes --inline ${CORENRN_NMODL_FLAGS}")
-  set(nmodl_arguments_ispc "host --ispc passes --inline ${CORENRN_NMODL_FLAGS}")
-else()
-  set(nmodl_arguments_c "")
-  set(nmodl_arguments_ispc "")
-endif()
-
-# name of nmodl/mod2c binary
-get_filename_component(nmodl_name ${CORENRN_MOD2CPP_BINARY} NAME)
-set(nmodl_binary_name ${nmodl_name})
-
-# =============================================================================
-# Install first into build directory and then to install prefix
-# =============================================================================
-
 configure_file(nrnivmodl_core_makefile.in
                ${CMAKE_BINARY_DIR}/share/coreneuron/nrnivmodl_core_makefile @ONLY)
 configure_file(nrnivmodl-core.in ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core @ONLY)
 
+# =============================================================================
+# Install for end users
+# =============================================================================
 install(FILES ${CMAKE_BINARY_DIR}/share/coreneuron/nrnivmodl_core_makefile
         DESTINATION share/coreneuron)
 install(PROGRAMS ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core DESTINATION bin)

--- a/extra/nrnivmodl-core.in
+++ b/extra/nrnivmodl-core.in
@@ -100,7 +100,7 @@ else
 fi
 
 # temporary directory where mod files will be copied
-temp_mod_dir=@CMAKE_HOST_SYSTEM_PROCESSOR@/core/mods
+temp_mod_dir=@CMAKE_HOST_SYSTEM_PROCESSOR@/corenrn/mod2c
 mkdir -p $temp_mod_dir
 
 # copy mod files with include files. note that ${ROOT_DIR}/share
@@ -109,7 +109,7 @@ set +e
 for mod_dir in ${ROOT_DIR}/share/modfile $params_MODS_PATH;
 do
     # copy mod files and include files
-    files=`ls $mod_dir/*.mod $mod_dir/*.inc 2>/dev/null`
+    files=`ls $mod_dir/*.mod $mod_dir/*.inc $mod_dir/*.h* 2>/dev/null`
     for f in $files;
     do
         # copy mod files only if it's changed (to avoid rebuild)

--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -15,6 +15,12 @@ OUTPUT_DIR = @CMAKE_HOST_SYSTEM_PROCESSOR@
 DESTDIR =
 TARGET_LIB_TYPE = $(BUILD_TYPE)
 
+# required for OSX to execute nrnivmodl-core
+OSX_SYSROOT=@CMAKE_OSX_SYSROOT@
+ifneq ($(OSX_SYSROOT),)
+  export SDKROOT := $(OSX_SYSROOT)
+endif
+
 # CoreNEURON installation directories
 CORENRN_BIN_DIR := $(ROOT)/bin
 CORENRN_LIB_DIR := $(ROOT)/lib
@@ -64,11 +70,11 @@ MOD2CPP_ENV_VAR = PYTHONPATH=@CORENRN_NMODL_PYTHONPATH@:${CORENRN_LIB_DIR}/pytho
 # nmodl options
 ifeq (@CORENRN_ENABLE_NMODL@, ON)
     ifeq (@CORENRN_ENABLE_GPU@, ON)
-        nmodl_arguments_c="@NMODL_ACC_BACKEND_ARGS@ @NMODL_COMMON_ARGS@"
+        nmodl_arguments_c=@NMODL_ACC_BACKEND_ARGS@ @NMODL_COMMON_ARGS@
     else
-        nmodl_arguments_c="@NMODL_CPU_BACKEND_ARGS@ @NMODL_COMMON_ARGS@"
+        nmodl_arguments_c=@NMODL_CPU_BACKEND_ARGS@ @NMODL_COMMON_ARGS@
     endif
-    nmodl_arguments_ispc="@NMODL_ISPC_BACKEND_ARGS@ @NMODL_COMMON_ARGS@"
+    nmodl_arguments_ispc=@NMODL_ISPC_BACKEND_ARGS@ @NMODL_COMMON_ARGS@
 endif
 
 # name of the mechanism library with suffix if provided
@@ -155,8 +161,8 @@ C_GREEN := \033[32m
 
 # Default nmodl flags. Override if MOD2CPP_RUNTIME_FLAGS is not empty
 ifeq (@CORENRN_ENABLE_NMODL@, ON)
-    MOD2CPP_FLAGS_ISPC = $(if $(MOD2CPP_RUNTIME_FLAGS),$(MOD2CPP_RUNTIME_FLAGS),@nmodl_arguments_ispc@)
-    MOD2CPP_FLAGS_C = $(if $(MOD2CPP_RUNTIME_FLAGS),$(MOD2CPP_RUNTIME_FLAGS),@nmodl_arguments_c@)
+    MOD2CPP_FLAGS_ISPC = $(if $(MOD2CPP_RUNTIME_FLAGS),$(MOD2CPP_RUNTIME_FLAGS),$(nmodl_arguments_ispc))
+    MOD2CPP_FLAGS_C = $(if $(MOD2CPP_RUNTIME_FLAGS),$(MOD2CPP_RUNTIME_FLAGS),$(nmodl_arguments_c))
 endif
 
 ifeq (@CORENRN_ENABLE_ISPC@, ON)

--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -35,7 +35,7 @@ MOD_TO_CPP_DIR = $(OUTPUT_DIR)/corenrn/mod2c
 MOD_OBJS_DIR = $(OUTPUT_DIR)/corenrn/build
 
 # Linked libraries gathered by CMake
-LDFLAGS = $(LINKFLAGS) @CORENRN_LINK_DEFS@
+LDFLAGS = $(LINKFLAGS) @CORENRN_COMMON_LDFLAGS@
 CORENRNLIB_FLAGS = -L$(CORENRN_LIB_DIR) -lcoreneuron
 CORENRNLIB_FLAGS += $(if @reportinglib_LIB_DIR@, -W$(subst ;, -W,l,-rpath,@reportinglib_LIB_DIR@),)
 CORENRNLIB_FLAGS += $(if @sonatareport_LIB_DIR@, -W$(subst ;, -W,l,-rpath,@sonatareport_LIB_DIR@),)
@@ -49,8 +49,8 @@ INCLUDES += $(if @reportinglib_INCLUDE_DIR@, -I$(subst ;, -I,@reportinglib_INCLU
 
 # C++ compilation and link commands
 CXX = @CMAKE_CXX_COMPILER@
-CXXFLAGS = @BUILD_TYPE_CXX_FLAGS@ @CMAKE_CXX_FLAGS@ @CXX14_STANDARD_COMPILE_OPTION@ @PGI_INLINE_FLAGS@
-CXX_COMPILE_CMD = $(CXX) $(CXXFLAGS) @CMAKE_CXX_COMPILE_OPTIONS_PIC@ @CORENRN_COMPILE_DEFS@ $(INCLUDES)
+CXXFLAGS = @CORENRN_CXX_FLAGS@
+CXX_COMPILE_CMD = $(CXX) $(CXXFLAGS) @CMAKE_CXX_COMPILE_OPTIONS_PIC@ @CORENRN_COMMON_COMPILE_DEFS@ $(INCLUDES)
 CXX_LINK_EXE_CMD = $(CXX) $(CXXFLAGS) @CMAKE_EXE_LINKER_FLAGS@
 CXX_SHARED_LIB_CMD = $(CXX) $(CXXFLAGS) @CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS@ @CMAKE_SHARED_LIBRARY_CXX_FLAGS@ @CMAKE_SHARED_LINKER_FLAGS@
 
@@ -60,6 +60,16 @@ ISPC_COMPILE_CMD = $(ISPC) @CMAKE_ISPC_FLAGS@ -I$(CORENRN_INC_DIR)
 
 # env variables required for mod2c or nmodl
 MOD2CPP_ENV_VAR = PYTHONPATH=@CORENRN_NMODL_PYTHONPATH@:${CORENRN_LIB_DIR}/python MODLUNIT=$(CORENRN_SHARE_MOD2CPP_DIR)/nrnunits.lib
+
+# nmodl options
+ifeq (@CORENRN_ENABLE_NMODL@, ON)
+    ifeq (@CORENRN_ENABLE_GPU@, ON)
+        nmodl_arguments_c="@NMODL_ACC_BACKEND_ARGS@ @NMODL_COMMON_ARGS@"
+    else
+        nmodl_arguments_c="@NMODL_CPU_BACKEND_ARGS@ @NMODL_COMMON_ARGS@"
+    endif
+    nmodl_arguments_ispc="@NMODL_ISPC_BACKEND_ARGS@ @NMODL_COMMON_ARGS@"
+endif
 
 # name of the mechanism library with suffix if provided
 COREMECH_LIB_NAME = corenrnmech$(if $(MECHLIB_SUFFIX),_$(MECHLIB_SUFFIX),)
@@ -144,13 +154,17 @@ C_RESET := \033[0m
 C_GREEN := \033[32m
 
 # Default nmodl flags. Override if MOD2CPP_RUNTIME_FLAGS is not empty
-NMODL_FLAGS_ISPC = $(if $(MOD2CPP_RUNTIME_FLAGS),$(MOD2CPP_RUNTIME_FLAGS),@nmodl_arguments_ispc@)
-MOD2CPP_FLAGS_C = $(if $(MOD2CPP_RUNTIME_FLAGS),$(MOD2CPP_RUNTIME_FLAGS),@nmodl_arguments_c@)
-ifeq (@CORENRN_ENABLE_ISPC@, ON)
-    $(info Default nmodl flags: @nmodl_arguments_ispc@)
-else
-    $(info Default nmodl flags: @nmodl_arguments_c@)
+ifeq (@CORENRN_ENABLE_NMODL@, ON)
+    MOD2CPP_FLAGS_ISPC = $(if $(MOD2CPP_RUNTIME_FLAGS),$(MOD2CPP_RUNTIME_FLAGS),@nmodl_arguments_ispc@)
+    MOD2CPP_FLAGS_C = $(if $(MOD2CPP_RUNTIME_FLAGS),$(MOD2CPP_RUNTIME_FLAGS),@nmodl_arguments_c@)
 endif
+
+ifeq (@CORENRN_ENABLE_ISPC@, ON)
+    $(info Default NMODL flags: @nmodl_arguments_ispc@)
+else
+    $(info Default NMODL flags: @nmodl_arguments_c@)
+endif
+
 ifneq ($(MOD2CPP_RUNTIME_FLAGS),)
     $(warning Runtime nmodl flags (they replace the default ones): $(MOD2CPP_RUNTIME_FLAGS))
 endif
@@ -198,7 +212,7 @@ $(MOD_OBJS_DIR)/%.obj: $(MOD_TO_CPP_DIR)/%.ispc | $(MOD_OBJS_DIR)
 
 # translate MOD files to ISPC using NMODL
 $(mod_ispc_files): $(MOD_TO_CPP_DIR)/%.ispc: $(MODS_PATH)/%.mod | $(MOD_TO_CPP_DIR)
-	$(MOD2CPP_ENV_VAR) $(MOD2CPP_BINARY_PATH) $< -o $(MOD_TO_CPP_DIR)/ $(NMODL_FLAGS_ISPC)
+	$(MOD2CPP_ENV_VAR) $(MOD2CPP_BINARY_PATH) $< -o $(MOD_TO_CPP_DIR)/ $(MOD2CPP_FLAGS_ISPC)
 
 # translate MOD files to CPP using mod2c/NMODL
 $(mod_cpp_files): $(MOD_TO_CPP_DIR)/%.cpp: $(MODS_PATH)/%.mod | $(MOD_TO_CPP_DIR)

--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -1,6 +1,9 @@
 pipeline {
     agent {
-        label 'bb5 && !bb5-07'
+        node {
+            label 'bb5 && !bb5-07'
+            customWorkspace "/gpfs/bbp.cscs.ch/project/proj16/kumbhar/pramod_scratch/jenkins/${BUILD_TAG}"
+        }
     }
     parameters {
         string(name: 'sha1', defaultValue: 'master',
@@ -402,9 +405,10 @@ pipeline {
             }
         }*/
     }
+    /*
     post {
         always {
             cleanWs()
         }
-    }
+    }*/
 }

--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
 
     stages {
 
+        /*
         stage('install Spack'){
             steps {
                 sh 'source $WORKSPACE/tests/jenkins/spack_setup.sh'
@@ -29,9 +30,11 @@ pipeline {
                 sh 'sh tests/jenkins/install_neuron_reportinglib.sh'
             }
         }
+        */
 
         stage('build CoreNeuron'){
             parallel{
+                /*
                 stage('AoS'){
                     stages{
                         stage('build'){
@@ -61,6 +64,7 @@ pipeline {
                         }
                     }
                 }
+                */
 
                 stage('GPU-non-unified'){
                     stages{
@@ -94,6 +98,7 @@ pipeline {
             }
         }
 
+        /*
         stage('neuron_direct'){
             parallel{
                 stage('AoS'){
@@ -107,8 +112,9 @@ pipeline {
                     }
                 }
             }
-        }
+        }*/
 
+        /*
         stage('checkout tests'){
             parallel{
                 stage('testcorenrn'){
@@ -133,8 +139,9 @@ pipeline {
                     }
                 }
             }
-        }
+        }*/
 
+        /*
         stage('nrnivmodl'){
             parallel{
                 stage('nrnivmodl testcorenrn'){
@@ -183,8 +190,8 @@ pipeline {
                     }
                 }
             }
-        }
-
+        }*/
+        /*
         stage('testcorenrn'){
             parallel{
                 stage('deriv'){
@@ -393,7 +400,7 @@ pipeline {
                     }
                 }
             }
-        }
+        }*/
     }
     post {
         always {

--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     parameters {
         string(name: 'sha1', defaultValue: 'master',
                description: 'What branch of CoreNeuron to test.')
-        string(name: 'SPACK_BRANCH', defaultValue: 'develop',
+        string(name: 'SPACK_BRANCH', defaultValue: '',
                description: 'Which branch of spack to use.')
         string(name: 'NEURON_BRANCH', defaultValue: '',
                description: 'Which branch of neuron to use. For master branch (neuron@develop) leave this parameter blank.')

--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -2,7 +2,6 @@ pipeline {
     agent {
         node {
             label 'bb5 && !bb5-07'
-            customWorkspace "/gpfs/bbp.cscs.ch/project/proj16/kumbhar/pramod_scratch/jenkins/${BUILD_TAG}"
         }
     }
     parameters {
@@ -21,7 +20,6 @@ pipeline {
 
     stages {
 
-        /*
         stage('install Spack'){
             steps {
                 sh 'source $WORKSPACE/tests/jenkins/spack_setup.sh'
@@ -33,11 +31,9 @@ pipeline {
                 sh 'sh tests/jenkins/install_neuron_reportinglib.sh'
             }
         }
-        */
 
         stage('build CoreNeuron'){
             parallel{
-                /*
                 stage('AoS'){
                     stages{
                         stage('build'){
@@ -67,7 +63,6 @@ pipeline {
                         }
                     }
                 }
-                */
 
                 stage('GPU-non-unified'){
                     stages{
@@ -101,7 +96,6 @@ pipeline {
             }
         }
 
-        /*
         stage('neuron_direct'){
             parallel{
                 stage('AoS'){
@@ -115,9 +109,8 @@ pipeline {
                     }
                 }
             }
-        }*/
+        }
 
-        /*
         stage('checkout tests'){
             parallel{
                 stage('testcorenrn'){
@@ -142,9 +135,8 @@ pipeline {
                     }
                 }
             }
-        }*/
+        }
 
-        /*
         stage('nrnivmodl'){
             parallel{
                 stage('nrnivmodl testcorenrn'){
@@ -193,8 +185,8 @@ pipeline {
                     }
                 }
             }
-        }*/
-        /*
+        }
+
         stage('testcorenrn'){
             parallel{
                 stage('deriv'){
@@ -403,12 +395,12 @@ pipeline {
                     }
                 }
             }
-        }*/
+        }
     }
-    /*
+
     post {
         always {
             cleanWs()
         }
-    }*/
+    }
 }

--- a/tests/jenkins/_env_setup.sh
+++ b/tests/jenkins/_env_setup.sh
@@ -1,7 +1,7 @@
 # Upstream modules
 unset MODULEPATH
 source /gpfs/bbp.cscs.ch/apps/hpc/jenkins/config/modules.sh
-module load archive/2020-12
+module load unstable
 
 # Local spack
 BUILD_HOME="${WORKSPACE}/BUILD_HOME"

--- a/tests/jenkins/_env_setup.sh
+++ b/tests/jenkins/_env_setup.sh
@@ -1,7 +1,7 @@
 # Upstream modules
 unset MODULEPATH
 source /gpfs/bbp.cscs.ch/apps/hpc/jenkins/config/modules.sh
-module load unstable
+module load archive/2020-12
 
 # Local spack
 BUILD_HOME="${WORKSPACE}/BUILD_HOME"

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -10,7 +10,7 @@ reportinglib_dir=$(spack location --install-dir --latest reportinglib%intel)
 CORENRN_TYPE="$1"
 
 if [ "${CORENRN_TYPE}" = "GPU-non-unified" ] || [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
-    module load nvhpc/20.9 cuda/10.1.243 hpe-mpi cmake boost
+    module load pgi/19.10 cuda hpe-mpi cmake boost
 
     mkdir build_${CORENRN_TYPE}
 else

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -10,7 +10,7 @@ source ${JENKINS_DIR:-.}/_env_setup.sh
 CORENRN_TYPE="$1"
 
 if [ "${CORENRN_TYPE}" = "GPU-non-unified" ] || [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
-    module load pgi/19.10 cuda hpe-mpi cmake boost
+    module load nvhpc/20.9 cuda/10.1.243 hpe-mpi cmake boost
 
     mkdir build_${CORENRN_TYPE}
 else

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -10,7 +10,7 @@ reportinglib_dir=$(spack location --install-dir --latest reportinglib%intel)
 CORENRN_TYPE="$1"
 
 if [ "${CORENRN_TYPE}" = "GPU-non-unified" ] || [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
-    module load pgi/19.10 cuda hpe-mpi cmake boost
+    module load nvhpc/20.11 cuda/11.1.0 hpe-mpi cmake boost
 
     mkdir build_${CORENRN_TYPE}
 else

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -10,7 +10,7 @@ reportinglib_dir=$(spack location --install-dir --latest reportinglib%intel)
 CORENRN_TYPE="$1"
 
 if [ "${CORENRN_TYPE}" = "GPU-non-unified" ] || [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
-    module load nvhpc/20.11 cuda/11.1.0 hpe-mpi cmake boost
+    module load nvhpc/20.9 cuda/10.1.243 hpe-mpi cmake boost
 
     mkdir build_${CORENRN_TYPE}
 else

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -38,8 +38,8 @@ if [ "${CORENRN_TYPE}" = "GPU-non-unified" ]; then
         -DCORENRN_ENABLE_GPU=ON \
         -DCORENRN_ENABLE_CUDA_UNIFIED_MEMORY=OFF \
         -DCMAKE_INSTALL_PREFIX=$WORKSPACE/install_${CORENRN_TYPE}/ \
-        -DTEST_MPI_EXEC_BIN="srun;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta;--gres=gpu:2;--mem;0;-t;00:05:00" \
-        -DTEST_EXEC_PREFIX="srun;-n;6;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta;--gres=gpu:2;--mem;0;-t;00:05:00" \
+        -DTEST_MPI_EXEC_BIN="srun;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta,skl;--gres=gpu:2;--mem;0;-t;00:05:00" \
+        -DTEST_EXEC_PREFIX="srun;-n;6;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta,skl;--gres=gpu:2;--mem;0;-t;00:05:00" \
         -DAUTO_TEST_WITH_SLURM=OFF \
         -DAUTO_TEST_WITH_MPIEXEC=OFF \
         $WORKSPACE/
@@ -48,8 +48,8 @@ elif [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
         -DCORENRN_ENABLE_GPU=ON \
         -DCORENRN_ENABLE_CUDA_UNIFIED_MEMORY=ON \
         -DCMAKE_INSTALL_PREFIX=$WORKSPACE/install_${CORENRN_TYPE}/ \
-        -DTEST_MPI_EXEC_BIN="srun;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta;--gres=gpu:2;--mem;0;-t;00:05:00" \
-        -DTEST_EXEC_PREFIX="srun;-n;6;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta;--gres=gpu:2;--mem;0;-t;00:05:00" \
+        -DTEST_MPI_EXEC_BIN="srun;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta,skl;--gres=gpu:2;--mem;0;-t;00:05:00" \
+        -DTEST_EXEC_PREFIX="srun;-n;6;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta,skl;--gres=gpu:2;--mem;0;-t;00:05:00" \
         -DAUTO_TEST_WITH_SLURM=OFF \
         -DAUTO_TEST_WITH_MPIEXEC=OFF \
         $WORKSPACE/

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -10,7 +10,7 @@ reportinglib_dir=$(spack location --install-dir --latest reportinglib%intel)
 CORENRN_TYPE="$1"
 
 if [ "${CORENRN_TYPE}" = "GPU-non-unified" ] || [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
-    module load pgi/19.10 cuda hpe-mpi cmake boost
+    module load nvhpc/20.9 cuda/10.1.243 hpe-mpi cmake boost
 
     mkdir build_${CORENRN_TYPE}
 else

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -10,8 +10,7 @@ source ${JENKINS_DIR:-.}/_env_setup.sh
 CORENRN_TYPE="$1"
 
 if [ "${CORENRN_TYPE}" = "GPU-non-unified" ] || [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
-    module load nvhpc/20.9 cuda/10.1.243 hpe-mpi cmake boost
-
+    module load pgi/19.10 cuda hpe-mpi cmake boost
     mkdir build_${CORENRN_TYPE}
 else
     module load boost intel hpe-mpi cmake

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -10,7 +10,9 @@ reportinglib_dir=$(spack location --install-dir --latest reportinglib%intel)
 CORENRN_TYPE="$1"
 
 if [ "${CORENRN_TYPE}" = "GPU-non-unified" ] || [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
-    module load nvhpc/20.9 cuda/11.1.0 hpe-mpi cmake boost
+    # PGI compiler issue in unstable :  BSD-204
+    module unload unstable && module load archive/2020-12
+    module load pgi/19.10 cuda hpe-mpi cmake boost
     mkdir build_${CORENRN_TYPE}
 else
     module load boost intel hpe-mpi cmake

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -5,12 +5,12 @@ set -x
 
 source ${JENKINS_DIR:-.}/_env_setup.sh
 
-#reportinglib_dir=$(spack location --install-dir --latest reportinglib%intel)
+reportinglib_dir=$(spack location --install-dir --latest reportinglib%intel)
 
 CORENRN_TYPE="$1"
 
 if [ "${CORENRN_TYPE}" = "GPU-non-unified" ] || [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
-    module load pgi/19.10 cuda hpe-mpi cmake boost
+    module load nvhpc/20.9 cuda/11.1.0 hpe-mpi cmake boost
     mkdir build_${CORENRN_TYPE}
 else
     module load boost intel hpe-mpi cmake
@@ -65,7 +65,7 @@ elif [ "${CORENRN_TYPE}" = "AoS" ] || [ "${CORENRN_TYPE}" = "SoA" ]; then
       -DCMAKE_BUILD_TYPE=Debug  \
       -DCORENRN_ENABLE_SOA=$CORENRN_ENABLE_SOA \
       -DCORENRN_ENABLE_OPENMP=$ENABLE_OPENMP \
-      -DCORENRN_ENABLE_BIN_REPORTS=OFF \
+      -DCORENRN_ENABLE_BIN_REPORTS=ON \
       -DCMAKE_PREFIX_PATH=$reportinglib_dir \
       -DTEST_MPI_EXEC_BIN="mpirun" \
       -DTEST_EXEC_PREFIX="mpirun;-n;2" \

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -5,7 +5,7 @@ set -x
 
 source ${JENKINS_DIR:-.}/_env_setup.sh
 
-reportinglib_dir=$(spack location --install-dir --latest reportinglib%intel)
+#reportinglib_dir=$(spack location --install-dir --latest reportinglib%intel)
 
 CORENRN_TYPE="$1"
 
@@ -66,7 +66,7 @@ elif [ "${CORENRN_TYPE}" = "AoS" ] || [ "${CORENRN_TYPE}" = "SoA" ]; then
       -DCMAKE_BUILD_TYPE=Debug  \
       -DCORENRN_ENABLE_SOA=$CORENRN_ENABLE_SOA \
       -DCORENRN_ENABLE_OPENMP=$ENABLE_OPENMP \
-      -DCORENRN_ENABLE_BIN_REPORTS=ON \
+      -DCORENRN_ENABLE_BIN_REPORTS=OFF \
       -DCMAKE_PREFIX_PATH=$reportinglib_dir \
       -DTEST_MPI_EXEC_BIN="mpirun" \
       -DTEST_EXEC_PREFIX="mpirun;-n;2" \

--- a/tests/jenkins/spack_setup.sh
+++ b/tests/jenkins/spack_setup.sh
@@ -16,10 +16,16 @@ install_spack() (
     mkdir -p $BASEDIR && cd $BASEDIR
     rm -rf .spack   # CLEANUP SPACK CONFIGS
     SPACK_REPO=https://github.com/BlueBrain/spack.git
-    SPACK_BRANCH=${SPACK_BRANCH:-"develop"}
 
-    echo "Installing SPACK. Cloning $SPACK_REPO $SPACK_ROOT --depth 1 -b $SPACK_BRANCH"
-    git clone $SPACK_REPO $SPACK_ROOT --depth 1 -b $SPACK_BRANCH
+    # cloning branch option
+    BRANCH_OPT=""
+    if [ -n "$SPACK_BRANCH" ]; then
+        BRANCH_OPT="-b ${SPACK_BRANCH}"
+    fi
+
+    echo "Installing SPACK. Cloning $SPACK_REPO $SPACK_ROOT --depth 1 $BRANCH_OPT"
+    git clone $SPACK_REPO $SPACK_ROOT --depth 1 $BRANCH_OPT
+
     # Use BBP configs
     mkdir -p $SPACK_ROOT/etc/spack/defaults/linux
     cp /gpfs/bbp.cscs.ch/apps/hpc/jenkins/config/*.yaml $SPACK_ROOT/etc/spack/


### PR DESCRIPTION
In order to simplify makefile generation with multiple targets (#442)
this PR refactor some of the CMake flags handling:

* move all makefile related options into single file MakefileBuildOptions.cmake
* remove all option processing from extra/CMakeLists.txt
* minor simplifications in makefile; removing ISPC_INTEROP definition

**How to test this?**

Usual CMake build options; no changes in CMake

CI_BRANCHES:NEURON_BRANCH=master,SPACK_BRANCH=bbpv-2021-01