### PR TITLE
Fix passing CORENRN_NMODL_FLAGS to nrnivmodl_makefile

### DIFF
--- a/CMake/MakefileBuildOptions.cmake
+++ b/CMake/MakefileBuildOptions.cmake
@@ -12,7 +12,7 @@ set(CMAKE_ISPC_FLAGS "${CMAKE_ISPC_FLAGS} --pic")
 # note that inlining is done by default
 set(NMODL_COMMON_ARGS "passes --inline")
 
-if ("${CORENRN_NMODL_FLAGS}" STREQUAL "")
+if (NOT "${CORENRN_NMODL_FLAGS}" STREQUAL "")
   set(NMODL_COMMON_ARGS "${NMODL_COMMON_ARGS} ${CORENRN_NMODL_FLAGS}")
 endif()
 

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -12,7 +12,7 @@ CORENRN_TYPE="$1"
 if [ "${CORENRN_TYPE}" = "GPU-non-unified" ] || [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
     # PGI compiler issue in unstable :  BSD-204
     module unload unstable && module load archive/2020-12
-    module load nvhpc cuda hpe-mpi cmake boost
+    module load pgi/19.10 cuda hpe-mpi cmake boost
     mkdir build_${CORENRN_TYPE}
 else
     module load boost intel hpe-mpi cmake

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -11,8 +11,7 @@ CORENRN_TYPE="$1"
 
 if [ "${CORENRN_TYPE}" = "GPU-non-unified" ] || [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
     # PGI compiler issue in unstable :  BSD-204
-    module unload unstable && module load archive/2020-12
-    module load pgi/19.10 cuda hpe-mpi cmake boost
+    module load nvhpc cuda hpe-mpi cmake boost
     mkdir build_${CORENRN_TYPE}
 else
     module load boost intel hpe-mpi cmake

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -12,7 +12,7 @@ CORENRN_TYPE="$1"
 if [ "${CORENRN_TYPE}" = "GPU-non-unified" ] || [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
     # PGI compiler issue in unstable :  BSD-204
     module unload unstable && module load archive/2020-12
-    module load pgi/19.10 cuda hpe-mpi cmake boost
+    module load nvhpc cuda hpe-mpi cmake boost
     mkdir build_${CORENRN_TYPE}
 else
     module load boost intel hpe-mpi cmake

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -35,6 +35,7 @@ if [ "${CORENRN_TYPE}" = "GPU-non-unified" ]; then
         -DTEST_EXEC_PREFIX="srun;-n;6;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta;--gres=gpu:2;--mem;0;-t;00:05:00" \
         -DAUTO_TEST_WITH_SLURM=OFF \
         -DAUTO_TEST_WITH_MPIEXEC=OFF \
+        -DCMAKE_CXX_FLAGS="-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1" \
         $WORKSPACE/
 elif [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
     cmake \

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -35,7 +35,6 @@ if [ "${CORENRN_TYPE}" = "GPU-non-unified" ]; then
         -DTEST_EXEC_PREFIX="srun;-n;6;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta;--gres=gpu:2;--mem;0;-t;00:05:00" \
         -DAUTO_TEST_WITH_SLURM=OFF \
         -DAUTO_TEST_WITH_MPIEXEC=OFF \
-        -DCMAKE_C_FLAGS="-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1" \
         -DCMAKE_CXX_FLAGS="-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1" \
         $WORKSPACE/
 elif [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
@@ -47,6 +46,7 @@ elif [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
         -DTEST_EXEC_PREFIX="srun;-n;6;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta;--gres=gpu:2;--mem;0;-t;00:05:00" \
         -DAUTO_TEST_WITH_SLURM=OFF \
         -DAUTO_TEST_WITH_MPIEXEC=OFF \
+        -DCMAKE_CXX_FLAGS="-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1" \
         $WORKSPACE/
 elif [ "${CORENRN_TYPE}" = "AoS" ] || [ "${CORENRN_TYPE}" = "SoA" ]; then
     CORENRN_ENABLE_SOA=ON

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -35,6 +35,7 @@ if [ "${CORENRN_TYPE}" = "GPU-non-unified" ]; then
         -DTEST_EXEC_PREFIX="srun;-n;6;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta;--gres=gpu:2;--mem;0;-t;00:05:00" \
         -DAUTO_TEST_WITH_SLURM=OFF \
         -DAUTO_TEST_WITH_MPIEXEC=OFF \
+        -DCMAKE_C_FLAGS="-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1" \
         -DCMAKE_CXX_FLAGS="-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1" \
         $WORKSPACE/
 elif [ "${CORENRN_TYPE}" = "GPU-unified" ]; then


### PR DESCRIPTION
**Description**

Fixess issue with `CORENRN_NMODL_FLAGS` not being written in the `nrnivmodl_core_makefile`

**How to test this?**

```bash
cmake .. -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_FLAGS="sympy --analytic codegen --force"
make -j8
./bin/nrnivmodl-core mod
```

**Test System**
 - OS: macOS
 - Compiler: GCC
 - Version: master
 - Backend: CPU