### PR TITLE
clang-format for missing header files

### DIFF
--- a/.github/workflows/clang_cmake_format_check.yaml
+++ b/.github/workflows/clang_cmake_format_check.yaml
@@ -23,7 +23,7 @@ jobs:
         - name: Run clang-format
           shell: bash
           working-directory: ${{runner.workspace}}/CoreNeuron/BUILD
-          run: make check-clang-format
+          run: make check-clang-format VERBOSE=1
         - name: Run cmake-format
           shell: bash
           working-directory: ${{runner.workspace}}/CoreNeuron/BUILD

--- a/.github/workflows/clang_cmake_format_check.yaml
+++ b/.github/workflows/clang_cmake_format_check.yaml
@@ -10,7 +10,9 @@ jobs:
         - name: Fetch repository
           uses: actions/checkout@v2
         - name: Install clang-format 11
-          run:  sudo apt-get install clang-format-11 python3-pip
+          run:  |
+              sudo apt-get update
+              sudo apt-get install clang-format-11 python3-pip
         - name: Install cmake-format 0.6.13
           run:  python3 -m pip install cmake-format==0.6.13
         - name: Configure

--- a/.github/workflows/clang_cmake_format_check.yaml
+++ b/.github/workflows/clang_cmake_format_check.yaml
@@ -10,9 +10,7 @@ jobs:
         - name: Fetch repository
           uses: actions/checkout@v2
         - name: Install clang-format 11
-          run:  |
-              sudo apt-get update
-              sudo apt-get install clang-format-11 python3-pip
+          run:  sudo apt-get install clang-format-11 python3-pip libboost-all-dev libopenmpi-dev openmpi-bin
         - name: Install cmake-format 0.6.13
           run:  python3 -m pip install cmake-format==0.6.13
         - name: Configure
@@ -21,7 +19,7 @@ jobs:
           run: |
               export PATH=/home/runner/.local/bin:$PATH
               mkdir BUILD && cd BUILD
-              cmake -DCORENRN_CLANG_FORMAT=ON -DCORENRN_CMAKE_FORMAT=ON -DCORENRN_ENABLE_MPI=OFF -DCORENRN_ENABLE_OPENMP=OFF -DClangFormat_EXECUTABLE=$(which clang-format-11) -DCMakeFormat_EXECUTABLE=$(which cmake-format) ..
+              cmake -DCORENRN_CLANG_FORMAT=ON -DCORENRN_CMAKE_FORMAT=ON -DCORENRN_ENABLE_MPI=ON -DCORENRN_ENABLE_OPENMP=OFF -DClangFormat_EXECUTABLE=$(which clang-format-11) -DCMakeFormat_EXECUTABLE=$(which cmake-format) ..
         - name: Run clang-format
           shell: bash
           working-directory: ${{runner.workspace}}/CoreNeuron/BUILD

--- a/.github/workflows/clang_cmake_format_check.yaml
+++ b/.github/workflows/clang_cmake_format_check.yaml
@@ -10,7 +10,9 @@ jobs:
         - name: Fetch repository
           uses: actions/checkout@v2
         - name: Install clang-format 11
-          run:  sudo apt-get install clang-format-11 python3-pip libboost-all-dev libopenmpi-dev openmpi-bin
+          run: |
+              sudo apt-get update
+              sudo apt-get install clang-format-11 python3-pip libboost-all-dev libopenmpi-dev openmpi-bin
         - name: Install cmake-format 0.6.13
           run:  python3 -m pip install cmake-format==0.6.13
         - name: Configure

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -5,8 +5,9 @@
 # =============================================================================
 
 # commonly included directories
-include_directories(utils/randoms ${MPI_INCLUDE_PATH} ${PROJECT_BINARY_DIR}/coreneuron
-                    ${CMAKE_BINARY_DIR}/coreneuron ${CMAKE_BINARY_DIR}/include)
+include_directories(
+  utils/randoms ${MPI_INCLUDE_PATH} ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR}/coreneuron
+  ${CMAKE_BINARY_DIR}/coreneuron ${CMAKE_BINARY_DIR}/include)
 
 # put libraries (e.g. dll) in bin directory
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/coreneuron/apps/corenrn_parameters.hpp
+++ b/coreneuron/apps/corenrn_parameters.hpp
@@ -36,74 +36,71 @@
 namespace coreneuron {
 
 struct corenrn_parameters {
+    enum verbose_level : std::uint32_t { NONE = 0, ERROR = 1, INFO = 2, DEBUG = 3, DEFAULT = INFO };
 
-    enum verbose_level : std::uint32_t
-    {
-      NONE = 0,
-      ERROR = 1,
-      INFO = 2,
-      DEBUG = 3,
-      DEFAULT = INFO
-    };
+    const int report_buff_size_default = 4;
 
-    const int report_buff_size_default=4;
+    unsigned spikebuf = 100'000;           /// Internal buffer used on every rank for spikes
+    int prcellgid = -1;                    /// Gid of cell for prcellstate
+    unsigned ms_phases = 2;                /// Number of multisend phases, 1 or 2
+    unsigned ms_subint = 2;                /// Number of multisend interval. 1 or 2
+    unsigned spkcompress = 0;              /// Spike Compression
+    unsigned cell_interleave_permute = 0;  /// Cell interleaving permutation
+    unsigned nwarp = 0;  /// Number of warps to balance for cell_interleave_permute == 2
+    unsigned report_buff_size = report_buff_size_default;  /// Size in MB of the report buffer.
+    int seed = -1;  /// Initialization seed for random number generator (int)
 
-    unsigned spikebuf=100'000;     /// Internal buffer used on every rank for spikes
-    int prcellgid=-1;              /// Gid of cell for prcellstate
-    unsigned ms_phases=2;     /// Number of multisend phases, 1 or 2
-    unsigned ms_subint=2;     /// Number of multisend interval. 1 or 2
-    unsigned spkcompress=0;        /// Spike Compression
-    unsigned cell_interleave_permute=0; /// Cell interleaving permutation
-    unsigned nwarp=0;              /// Number of warps to balance for cell_interleave_permute == 2
-    unsigned report_buff_size=report_buff_size_default; ///Size in MB of the report buffer.
-    int seed=-1;                   /// Initialization seed for random number generator (int)
+    bool mpi_enable = false;         /// Enable MPI flag.
+    bool skip_mpi_finalize = false;  /// Skip MPI finalization
+    bool multisend = false;          /// Use Multisend spike exchange instead of Allgather.
+    bool threading = false;          /// Enable pthread/openmp
+    bool gpu = false;                /// Enable GPU computation.
+    bool binqueue = false;           /// Use bin queue.
 
-    bool mpi_enable=false;         /// Enable MPI flag.
-    bool skip_mpi_finalize=false;  /// Skip MPI finalization
-    bool multisend=false;          /// Use Multisend spike exchange instead of Allgather.
-    bool threading=false;          /// Enable pthread/openmp
-    bool gpu=false;                /// Enable GPU computation.
-    bool binqueue=false;           /// Use bin queue.
+    bool show_version = false;  /// Print version and exit.
 
-    bool show_version=false;       /// Print version and exit.
+    bool count_mechs = false;  /// Print mechanism counts after initialization
 
-    bool count_mechs=false;        /// Print mechanism counts after initialization
+    verbose_level verbose{verbose_level::DEFAULT};  /// Verbosity-level
 
-    verbose_level verbose{verbose_level::DEFAULT}; /// Verbosity-level
+    double tstop = 100;        /// Stop time of simulation in msec
+    double dt = -1000.0;       /// Timestep to use in msec
+    double dt_io = 0.1;        /// I/O timestep to use in msec
+    double dt_report;          /// I/O timestep to use in msec for reports
+    double celsius = -1000.0;  /// Temperature in degC.
+    double voltage = -65.0;    /// Initial voltage used for nrn_finitialize(1, v_init).
+    double forwardskip = 0.;   /// Forward skip to TIME.
+    double mindelay = 10.;     /// Maximum integration interval (likely reduced by minimum NetCon
+                               /// delay).
 
-    double tstop=100;              /// Stop time of simulation in msec
-    double dt=-1000.0;             /// Timestep to use in msec
-    double dt_io=0.1;              /// I/O timestep to use in msec
-    double dt_report;              /// I/O timestep to use in msec for reports
-    double celsius=-1000.0;        /// Temperature in degC.
-    double voltage=-65.0;          /// Initial voltage used for nrn_finitialize(1, v_init).
-    double forwardskip=0.;         /// Forward skip to TIME.
-    double mindelay=10.;           /// Maximum integration interval (likely reduced by minimum NetCon delay).
+    std::string patternstim;             /// Apply patternstim using the specified spike file.
+    std::string datpath = ".";           /// Directory path where .dat files
+    std::string outpath = ".";           /// Directory where spikes will be written
+    std::string filesdat = "files.dat";  /// Name of file containing list of gids dat files read in
+    std::string restorepath;             /// Restore simulation from provided checkpoint directory.
+    std::string reportfilepath;          /// Reports configuration file.
+    std::string checkpointpath;  /// Enable checkpoint and specify directory to store related files.
+    std::string writeParametersFilepath;  /// Write parameters to this file
 
-    std::string patternstim;          /// Apply patternstim using the specified spike file.
-    std::string datpath=".";          /// Directory path where .dat files
-    std::string outpath=".";          /// Directory where spikes will be written
-    std::string filesdat="files.dat"; /// Name of file containing list of gids dat files read in
-    std::string restorepath;          /// Restore simulation from provided checkpoint directory.
-    std::string reportfilepath;       /// Reports configuration file.
-    std::string checkpointpath;       /// Enable checkpoint and specify directory to store related files.
-    std::string writeParametersFilepath; /// Write parameters to this file
+    CLI::App app{"CoreNeuron - Optimised Simulator Engine for NEURON."};  /// CLI app that performs
+                                                                          /// CLI parsing
 
-    CLI::App app{"CoreNeuron - Optimised Simulator Engine for NEURON."}; ///CLI app that performs CLI parsing
+    corenrn_parameters();  /// Constructor that initializes the CLI11 app.
 
-    corenrn_parameters();          ///Constructor that initializes the CLI11 app.
+    void parse(int argc, char* argv[]);  /// Runs the CLI11_PARSE macro.
 
-    void parse(int argc, char* argv[]); /// Runs the CLI11_PARSE macro.
-
-    inline bool is_quiet() { return verbose == verbose_level::NONE; }
-
+    inline bool is_quiet() {
+        return verbose == verbose_level::NONE;
+    }
 };
 
-std::ostream& operator<<(std::ostream& os, const corenrn_parameters& corenrn_param);    /// Printing method.
+std::ostream& operator<<(std::ostream& os,
+                         const corenrn_parameters& corenrn_param);  /// Printing method.
 
-extern corenrn_parameters corenrn_param;    /// Declaring global corenrn_parameters object for this instance of CoreNeuron.
-extern int nrn_nobanner_;                   /// Global no banner setting
+extern corenrn_parameters corenrn_param;  /// Declaring global corenrn_parameters object for this
+                                          /// instance of CoreNeuron.
+extern int nrn_nobanner_;                 /// Global no banner setting
 
 }  // namespace coreneuron
 
-#endif //CN_PARAMETERS_H
+#endif  // CN_PARAMETERS_H

--- a/coreneuron/coreneuron.hpp
+++ b/coreneuron/coreneuron.hpp
@@ -21,10 +21,10 @@
 #include <vector>
 #include <array>
 
-#include "coreneuron/utils/randoms/nrnran123.h"      //Random Number Generator
+#include "coreneuron/utils/randoms/nrnran123.h"     //Random Number Generator
 #include "coreneuron/sim/scopmath/newton_struct.h"  //Newton Struct
-#include "coreneuron/membrane_definitions.h"                //static definitions
-#include "coreneuron/mechanism/mechanism.hpp"               //Memb_list and mechs info
+#include "coreneuron/membrane_definitions.h"        //static definitions
+#include "coreneuron/mechanism/mechanism.hpp"       //Memb_list and mechs info
 
 #include "coreneuron/utils/memory.h"  //Memory alignments and padding
 #include "coreneuron/nrnconf.h"
@@ -54,7 +54,6 @@ using DependencyTable = std::vector<std::vector<int>>;
  * this class.
  */
 class CoreNeuron {
-
     /**
      * map if mech is a point process
      * In the future only a field of Mechanism class
@@ -128,7 +127,6 @@ class CoreNeuron {
     std::vector<bbcore_write_t> nrn_bbcore_write;
 
   public:
-
     auto& get_memb_funcs() {
         return memb_funcs;
     }
@@ -212,7 +210,6 @@ class CoreNeuron {
     auto& get_bbcore_write() {
         return nrn_bbcore_write;
     }
-
 };
 
 extern CoreNeuron corenrn;

--- a/coreneuron/io/core2nrn_data_return.hpp
+++ b/coreneuron/io/core2nrn_data_return.hpp
@@ -16,5 +16,4 @@ namespace coreneuron {
 extern void core2nrn_data_return();
 
 }  // namespace coreneuron
-#endif // _H_CORENRNDATARETURN_
-
+#endif  // _H_CORENRNDATARETURN_

--- a/coreneuron/io/mech_report.h
+++ b/coreneuron/io/mech_report.h
@@ -12,8 +12,8 @@
 #include <string>
 
 namespace coreneuron {
-    /// write mechanism counts to stdout
-    void write_mech_report();
-}
+/// write mechanism counts to stdout
+void write_mech_report();
+}  // namespace coreneuron
 
 #endif

--- a/coreneuron/io/nrn2core_direct.h
+++ b/coreneuron/io/nrn2core_direct.h
@@ -107,15 +107,15 @@ extern void (*nrn2core_trajectory_values_)(int tid, int n_pr, void** vpr, double
 /* Filled the Vector data arrays and send back the sizes at end of run */
 extern void (*nrn2core_trajectory_return_)(int tid, int n_pr, int vecsz, void** vpr, double t);
 
-/* send all spikes vectors to NEURON */  
-extern int (*nrn2core_all_spike_vectors_return_)(std::vector<double>& spikevec, std::vector<int>& gidvec);
+/* send all spikes vectors to NEURON */
+extern int (*nrn2core_all_spike_vectors_return_)(std::vector<double>& spikevec,
+                                                 std::vector<int>& gidvec);
 
 /* send all weights to NEURON */
 extern void (*nrn2core_all_weights_return_)(std::vector<double*>& weights);
 
 /* get data array pointer from NEURON to copy into. */
-extern size_t (*nrn2core_type_return_)(int type, int tid, double*& data,
-                                       double**& mdata);
-} // extern "C"
+extern size_t (*nrn2core_type_return_)(int type, int tid, double*& data, double**& mdata);
+}  // extern "C"
 
 #endif /* nrn2core_direct_h */

--- a/coreneuron/io/nrn_checkpoint.hpp
+++ b/coreneuron/io/nrn_checkpoint.hpp
@@ -17,9 +17,7 @@ class FileHandler;
 
 extern bool nrn_checkpoint_arg_exists;
 
-void write_checkpoint(NrnThread* nt,
-                      int nb_threads,
-                      const char* dir);
+void write_checkpoint(NrnThread* nt, int nb_threads, const char* dir);
 
 void checkpoint_restore_tqueue(NrnThread&, const Phase2& p2);
 
@@ -88,7 +86,6 @@ struct NrnThreadChkpnt {
     int* mtype;
     int* vecplay_ix;
 #endif  // CHKPNTDEBUG
-
 };
 
 extern NrnThreadChkpnt* nrnthread_chkpnt;

--- a/coreneuron/io/nrn_filehandler.hpp
+++ b/coreneuron/io/nrn_filehandler.hpp
@@ -48,8 +48,9 @@ class FileHandler {
     FileHandler& operator=(const FileHandler&);
 
   public:
-    FileHandler() : chkpnt(0), stored_chkpnt(0) {
-    }
+    FileHandler()
+        : chkpnt(0)
+        , stored_chkpnt(0) {}
 
     explicit FileHandler(const std::string& filename);
 
@@ -166,7 +167,7 @@ class FileHandler {
                 F.seekg(count * sizeof(T), std::ios_base::cur);
                 break;
             case read:
-                F.read((char*)p, count * sizeof(T));
+                F.read((char*) p, count * sizeof(T));
                 break;
         }
 
@@ -204,7 +205,7 @@ class FileHandler {
         nrn_assert(F.is_open());
         nrn_assert(current_mode & std::ios::out);
         write_checkpoint();
-        F.write((const char*)p, nb_elements * (sizeof(T)));
+        F.write((const char*) p, nb_elements * (sizeof(T)));
         nrn_assert(!F.fail());
     }
 
@@ -232,7 +233,7 @@ class FileHandler {
         }
         // AoS never use padding, SoA is translated above, so one write
         // operation is enought in both cases
-        F.write((const char*)temp_cpy, nb_elements * sizeof(T) * nb_lines);
+        F.write((const char*) temp_cpy, nb_elements * sizeof(T) * nb_lines);
         nrn_assert(!F.fail());
         delete[] temp_cpy;
     }

--- a/coreneuron/io/nrn_setup.hpp
+++ b/coreneuron/io/nrn_setup.hpp
@@ -99,7 +99,9 @@ inline void* phase_wrapper_w(NrnThread* nt, UserParams& userParams, bool in_memo
                 data_dir = userParams.restore_path;
             }
 
-            std::string fname = std::string(data_dir) + "/" + std::to_string(userParams.gidgroups[i]) + "_" + getPhaseName<P>() + ".dat";
+            std::string fname = std::string(data_dir) + "/" +
+                                std::to_string(userParams.gidgroups[i]) + "_" + getPhaseName<P>() +
+                                ".dat";
 
             // Avoid trying to open the gid_gap.dat file if it doesn't exist when there are no
             // gap junctions in this gid

--- a/coreneuron/io/nrnsection_mapping.hpp
+++ b/coreneuron/io/nrnsection_mapping.hpp
@@ -40,8 +40,8 @@ struct SecMapping {
 
     SecMapping() = default;
 
-    explicit SecMapping(std::string s) : name(std::move(s)) {
-    }
+    explicit SecMapping(std::string s)
+        : name(std::move(s)) {}
 
     /** @brief return total number of sections in section list */
     size_t num_sections() const noexcept {
@@ -50,8 +50,9 @@ struct SecMapping {
 
     /** @brief return number of segments in section list */
     size_t num_segments() const {
-        return std::accumulate(secmap.begin(), secmap.end(), 0,
-            [](int psum, const auto& item) { return psum + item.second.size(); });
+        return std::accumulate(secmap.begin(), secmap.end(), 0, [](int psum, const auto& item) {
+            return psum + item.second.size();
+        });
     }
 
     /** @brief add section to associated segment */
@@ -73,19 +74,27 @@ struct CellMapping {
     /** list of section lists (like soma, axon, apic) */
     std::vector<SecMapping*> secmapvec;
 
-    CellMapping(int g) : gid(g) {
-    }
+    CellMapping(int g)
+        : gid(g) {}
 
     /** @brief total number of sections in a cell */
     int num_sections() const {
-        return std::accumulate(secmapvec.begin(), secmapvec.end(), 0,
-            [](int psum, const auto& secmap) { return psum + secmap->num_sections(); });
+        return std::accumulate(secmapvec.begin(),
+                               secmapvec.end(),
+                               0,
+                               [](int psum, const auto& secmap) {
+                                   return psum + secmap->num_sections();
+                               });
     }
 
     /** @brief return number of segments in a cell */
     int num_segments() const {
-        return std::accumulate(secmapvec.begin(), secmapvec.end(), 0,
-                               [](int psum, const auto& secmap) { return psum + secmap->num_segments(); });
+        return std::accumulate(secmapvec.begin(),
+                               secmapvec.end(),
+                               0,
+                               [](int psum, const auto& secmap) {
+                                   return psum + secmap->num_segments();
+                               });
     }
 
     /** @brief number of section lists */
@@ -100,7 +109,7 @@ struct CellMapping {
 
     /** @brief return section list mapping with given name */
     SecMapping* get_seclist_mapping(const std::string& name) const {
-        for (auto& secmap : secmapvec) {
+        for (auto& secmap: secmapvec) {
             if (name == secmap->name) {
                 return secmap;
             }
@@ -161,7 +170,7 @@ struct NrnThreadMappingInfo {
      *	if exist otherwise return nullptr.
      */
     CellMapping* get_cell_mapping(int gid) const {
-        for (const auto& mapping  : mappingvec) {
+        for (const auto& mapping: mappingvec) {
             if (mapping->gid == gid) {
                 return mapping;
             }
@@ -174,6 +183,6 @@ struct NrnThreadMappingInfo {
         mappingvec.push_back(c);
     }
 };
-}
+}  // namespace coreneuron
 
 #endif  // NRN_SECTION_MAPPING

--- a/coreneuron/io/output_spikes.hpp
+++ b/coreneuron/io/output_spikes.hpp
@@ -20,7 +20,7 @@ extern std::vector<double> spikevec_time;
 extern std::vector<int> spikevec_gid;
 
 void clear_spike_vectors();
-void validation(std::vector<std::pair<double, int> >& res);
+void validation(std::vector<std::pair<double, int>>& res);
 
 void spikevec_lock();
 void spikevec_unlock();

--- a/coreneuron/io/phase1.hpp
+++ b/coreneuron/io/phase1.hpp
@@ -18,15 +18,15 @@ namespace coreneuron {
 struct NrnThread;
 
 class Phase1 {
-    public:
+  public:
     void read_file(FileHandler& F);
     void read_direct(int thread_id);
     void populate(NrnThread& nt, OMP_Mutex& mut);
 
-    private:
+  private:
     std::vector<int> output_gids;
     std::vector<int> netcon_srcgids;
-    std::vector<int> netcon_negsrcgid_tid; // entries only for negative srcgids
+    std::vector<int> netcon_negsrcgid_tid;  // entries only for negative srcgids
 };
 
 }  // namespace coreneuron

--- a/coreneuron/io/phase2.hpp
+++ b/coreneuron/io/phase2.hpp
@@ -21,7 +21,7 @@ struct Memb_func;
 struct Memb_list;
 
 class Phase2 {
-    public:
+  public:
     void read_file(FileHandler& F, const NrnThread& nt);
     void read_direct(int thread_id, const NrnThread& nt);
     void populate(NrnThread& nt, const UserParams& userParams);
@@ -46,8 +46,7 @@ class Phase2 {
     struct PreSynType_: public EventTypeBase {
         int presyn_index;
     };
-    struct NetParEvent_: public EventTypeBase {
-    };
+    struct NetParEvent_: public EventTypeBase {};
     struct PlayRecordEventType_: public EventTypeBase {
         int play_record_type;
         int vecplay_index;
@@ -69,10 +68,16 @@ class Phase2 {
 
     std::vector<std::pair<int, std::shared_ptr<EventTypeBase>>> events;
 
-    private:
+  private:
     void check_mechanism();
     NrnThreadMembList* create_tml(int mech_id, Memb_func& memb_func, int& shadow_rhs_cnt);
-    void transform_int_data(int elem0, int nodecount, int* pdata, int i, int dparam_size, int layout, int n_node_);
+    void transform_int_data(int elem0,
+                            int nodecount,
+                            int* pdata,
+                            int i,
+                            int dparam_size,
+                            int layout,
+                            int n_node_);
     void set_net_send_buffer(Memb_list** ml_list, const std::vector<int>& pnt_offset);
     void restore_events(FileHandler& F);
     void fill_before_after_lists(NrnThread& nt, const std::vector<Memb_func>& memb_func);

--- a/coreneuron/io/prcellstate.hpp
+++ b/coreneuron/io/prcellstate.hpp
@@ -12,4 +12,4 @@ namespace coreneuron {
 
 extern int prcellstate(int gid, const char* suffix);
 
-} // namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/io/setup_fornetcon.hpp
+++ b/coreneuron/io/setup_fornetcon.hpp
@@ -20,4 +20,4 @@ namespace coreneuron {
 void setup_fornetcon_info(NrnThread& nt);
 
 }  // namespace coreneuron
-#endif //_H_SETUP_FORNETCON_
+#endif  //_H_SETUP_FORNETCON_

--- a/coreneuron/io/user_params.hpp
+++ b/coreneuron/io/user_params.hpp
@@ -14,14 +14,12 @@ namespace coreneuron {
 /// Before it was globals variables, group them to give them as a single argument.
 /// They have for the most part, nothing related to each other.
 struct UserParams {
-    UserParams(int ngroup_, int* gidgroups_,
-        const char* path_, const char* restore_path_)
-    : ngroup(ngroup_)
-    , gidgroups(gidgroups_)
-    , path(path_)
-    , restore_path(restore_path_)
-    , file_reader(ngroup_)
-    {}
+    UserParams(int ngroup_, int* gidgroups_, const char* path_, const char* restore_path_)
+        : ngroup(ngroup_)
+        , gidgroups(gidgroups_)
+        , path(path_)
+        , restore_path(restore_path_)
+        , file_reader(ngroup_) {}
 
     /// direct memory mode with neuron, do not open files
     /// Number of local cell groups

--- a/coreneuron/mechanism/eion.hpp
+++ b/coreneuron/mechanism/eion.hpp
@@ -15,4 +15,4 @@ namespace coreneuron {
 extern int nrn_is_ion(int);
 extern void ion_reg(const char*, double);
 
-} // namespace coreneuron
+}  // namespace coreneuron

--- a/coreneuron/mechanism/mech/cfile/cabvars.h
+++ b/coreneuron/mechanism/mech/cfile/cabvars.h
@@ -12,14 +12,22 @@ extern void capacitance_reg(void), _passive_reg(void),
 #if EXTRACELLULAR
     extracell_reg_(void),
 #endif
-    _stim_reg(void), _hh_reg(void), _netstim_reg(void), _expsyn_reg(void), _exp2syn_reg(void), _svclmp_reg(void);
+    _stim_reg(void), _hh_reg(void), _netstim_reg(void), _expsyn_reg(void), _exp2syn_reg(void),
+    _svclmp_reg(void);
 
 static void (*mechanism[])(void) = {/* type will start at 3 */
-                                    capacitance_reg, _passive_reg,
+                                    capacitance_reg,
+                                    _passive_reg,
 #if EXTRACELLULAR
                                     /* extracellular requires special handling and must be type 5 */
                                     extracell_reg_,
 #endif
-                                    _stim_reg, _hh_reg, _expsyn_reg, _netstim_reg, _exp2syn_reg, _svclmp_reg, 0};
+                                    _stim_reg,
+                                    _hh_reg,
+                                    _expsyn_reg,
+                                    _netstim_reg,
+                                    _exp2syn_reg,
+                                    _svclmp_reg,
+                                    0};
 
 }  // namespace coreneuron

--- a/coreneuron/mechanism/mech/mod2c_core_thread.hpp
+++ b/coreneuron/mechanism/mech/mod2c_core_thread.hpp
@@ -62,7 +62,7 @@ struct Elm {
     struct Elm* c_left;  /* Link to left element in same row */
     struct Elm* c_right; /*       in solution order (see getelm) */
 };
-#define ELM0 (Elm*)0
+#define ELM0 (Elm*) 0
 
 struct Item {
     Elm* elm;
@@ -70,11 +70,11 @@ struct Item {
     struct Item* next;
     struct Item* prev;
 };
-#define ITEM0 (Item*)0
+#define ITEM0 (Item*) 0
 
 using List = Item; /* list of mixed items */
 
-struct SparseObj {  /* all the state information */
+struct SparseObj {          /* all the state information */
     Elm** rowst;            /* link to first element in row (solution order)*/
     Elm** diag;             /* link to pivot element in row (solution order)*/
     void* elmpool;          /* no interthread cache line sharing for elements */

--- a/coreneuron/mechanism/mechanism.hpp
+++ b/coreneuron/mechanism/mechanism.hpp
@@ -52,7 +52,7 @@ struct NetReceiveBuffer_t {
     int _pnt_offset;
 };
 
-struct NetSendBuffer_t : MemoryManaged {
+struct NetSendBuffer_t: MemoryManaged {
     int* _sendtype;  // net_send, net_event, net_move
     int* _vdata_index;
     int* _pnt_index;
@@ -63,18 +63,19 @@ struct NetSendBuffer_t : MemoryManaged {
     int _size;       /* capacity */
     int reallocated; /* if buffer resized/reallocated, needs to be copy to cpu */
 
-    NetSendBuffer_t(int size) : _size(size) {
+    NetSendBuffer_t(int size)
+        : _size(size) {
         _cnt = 0;
 
-        _sendtype = (int*)ecalloc_align(_size, sizeof(int));
-        _vdata_index = (int*)ecalloc_align(_size, sizeof(int));
-        _pnt_index = (int*)ecalloc_align(_size, sizeof(int));
-        _weight_index = (int*)ecalloc_align(_size, sizeof(int));
+        _sendtype = (int*) ecalloc_align(_size, sizeof(int));
+        _vdata_index = (int*) ecalloc_align(_size, sizeof(int));
+        _pnt_index = (int*) ecalloc_align(_size, sizeof(int));
+        _weight_index = (int*) ecalloc_align(_size, sizeof(int));
         // when == 1, NetReceiveBuffer_t is newly allocated (i.e. we need to free previous copy
         // and recopy new data
         reallocated = 1;
-        _nsb_t = (double*)ecalloc_align(_size, sizeof(double));
-        _nsb_flag = (double*)ecalloc_align(_size, sizeof(double));
+        _nsb_t = (double*) ecalloc_align(_size, sizeof(double));
+        _nsb_flag = (double*) ecalloc_align(_size, sizeof(double));
     }
 
     ~NetSendBuffer_t() {
@@ -102,16 +103,15 @@ struct NetSendBuffer_t : MemoryManaged {
 #endif
     }
 
-    private:
-        template <typename T>
-        void grow_buf(T** buf, int size, int new_size) {
-            T* new_buf = nullptr;
-            new_buf = (T*)ecalloc_align(new_size, sizeof(T));
-            memcpy(new_buf, *buf, size * sizeof(T));
-            free(*buf);
-            *buf = new_buf;
-        }
-
+  private:
+    template <typename T>
+    void grow_buf(T** buf, int size, int new_size) {
+        T* new_buf = nullptr;
+        new_buf = (T*) ecalloc_align(new_size, sizeof(T));
+        memcpy(new_buf, *buf, size * sizeof(T));
+        free(*buf);
+        *buf = new_buf;
+    }
 };
 
 struct Memb_list {

--- a/coreneuron/mechanism/membfunc.hpp
+++ b/coreneuron/mechanism/membfunc.hpp
@@ -13,12 +13,12 @@
 #include "coreneuron/mechanism/mechanism.hpp"
 namespace coreneuron {
 
-using Pfrpdat = Datum* (*)(void);
+using Pfrpdat = Datum* (*) (void);
 
 struct NrnThread;
 
 using mod_alloc_t = void (*)(double*, Datum*, int);
-using mod_f_t =  void (*)(NrnThread*, Memb_list*, int);
+using mod_f_t = void (*)(NrnThread*, Memb_list*, int);
 using pnt_receive_t = void (*)(Point_process*, int, double);
 
 /*
@@ -42,21 +42,21 @@ struct Memb_func {
     int* dparam_semantics; /* for nrncore writing. */
 };
 
-#define VINDEX -1
+#define VINDEX       -1
 #define CABLESECTION 1
-#define MORPHOLOGY 2
-#define CAP 3
-#define EXTRACELL 5
+#define MORPHOLOGY   2
+#define CAP          3
+#define EXTRACELL    5
 
 #define nrnocCONST 1
-#define DEP 2
-#define STATE 3 /*See init.c and cabvars.h for order of nrnocCONST, DEP, and STATE */
+#define DEP        2
+#define STATE      3 /*See init.c and cabvars.h for order of nrnocCONST, DEP, and STATE */
 
-#define BEFORE_INITIAL 0
-#define AFTER_INITIAL 1
+#define BEFORE_INITIAL    0
+#define AFTER_INITIAL     1
 #define BEFORE_BREAKPOINT 2
-#define AFTER_SOLVE 3
-#define BEFORE_STEP 4
+#define AFTER_SOLVE       3
+#define BEFORE_STEP       4
 #define BEFORE_AFTER_SIZE 5 /* 1 more than the previous */
 struct BAMech {
     mod_f_t f;

--- a/coreneuron/membrane_definitions.h
+++ b/coreneuron/membrane_definitions.h
@@ -9,16 +9,16 @@
 /* /local/src/master/nrn/src/nrnoc/membdef.h,v 1.2 1995/02/13 20:20:42 hines Exp */
 
 /* numerical parameters */
-#define DEF_nseg 1             /* default number of segments per section*/
-#define DEF_dt .025            /* ms */
+#define DEF_nseg   1           /* default number of segments per section*/
+#define DEF_dt     .025        /* ms */
 #define DEF_rev_dt 1. / DEF_dt /* 1/ms */
 #define DEF_secondorder                           \
     0 /* >0 means crank-nicolson. 2 means current \
       adjusted to t+dt/2 */
 
 /*global parameters */
-#define DEF_Ra 35.4 /* ohm-cm */ /*changed from 34.5 on 1/6/95*/
-#define DEF_celsius 6.3          /* deg-C */
+#define DEF_Ra      35.4 /* ohm-cm */ /*changed from 34.5 on 1/6/95*/
+#define DEF_celsius 6.3               /* deg-C */
 
 #define DEF_vrest -65. /* mV */
 
@@ -28,7 +28,7 @@
 
 /* Parameters that are used in mechanism _alloc() procedures */
 /* cable */
-#define DEF_L 100. /* microns */
+#define DEF_L          100. /* microns */
 #define DEF_rallbranch 1.
 
 /* morphology */

--- a/coreneuron/mpi/mpispike.hpp
+++ b/coreneuron/mpi/mpispike.hpp
@@ -26,24 +26,24 @@ struct NRNMPI_Spikebuf {
 #endif
 
 #define icapacity_ nrnmpi_i_capacity_
-#define spikeout_ nrnmpi_spikeout_
-#define spikein_ nrnmpi_spikein_
-#define nout_ nrnmpi_nout_
-#define nin_ nrnmpi_nin_
+#define spikeout_  nrnmpi_spikeout_
+#define spikein_   nrnmpi_spikein_
+#define nout_      nrnmpi_nout_
+#define nin_       nrnmpi_nin_
 extern int nout_;
 extern int* nin_;
 extern int icapacity_;
 extern NRNMPI_Spike* spikeout_;
 extern NRNMPI_Spike* spikein_;
 
-#define spfixout_ nrnmpi_spikeout_fixed_
-#define spfixin_ nrnmpi_spikein_fixed_
-#define spfixin_ovfl_ nrnmpi_spikein_fixed_ovfl_
-#define localgid_size_ nrnmpi_localgid_size_
-#define ag_send_size_ nrnmpi_ag_send_size_
+#define spfixout_       nrnmpi_spikeout_fixed_
+#define spfixin_        nrnmpi_spikein_fixed_
+#define spfixin_ovfl_   nrnmpi_spikein_fixed_ovfl_
+#define localgid_size_  nrnmpi_localgid_size_
+#define ag_send_size_   nrnmpi_ag_send_size_
 #define ag_send_nspike_ nrnmpi_send_nspike_
-#define ovfl_capacity_ nrnmpi_ovfl_capacity_
-#define ovfl_ nrnmpi_ovfl_
+#define ovfl_capacity_  nrnmpi_ovfl_capacity_
+#define ovfl_           nrnmpi_ovfl_
 extern int localgid_size_;  /* bytes */
 extern int ag_send_size_;   /* bytes */
 extern int ag_send_nspike_; /* spikes */
@@ -55,7 +55,7 @@ extern unsigned char* spfixin_ovfl_;
 
 #if nrn_spikebuf_size > 0
 #define spbufout_ nrnmpi_spbufout_
-#define spbufin_ nrnmpi_spbufin_
+#define spbufin_  nrnmpi_spbufin_
 extern NRNMPI_Spikebuf* spbufout_;
 extern NRNMPI_Spikebuf* spbufin_;
 #endif

--- a/coreneuron/mpi/nrnmpidec.h
+++ b/coreneuron/mpi/nrnmpidec.h
@@ -74,7 +74,12 @@ extern void nrnmpi_int_gatherv(int* s, int scnt, int* r, int* rcnt, int* rdispl,
 extern void nrnmpi_int_allgather(int* s, int* r, int n);
 extern void nrnmpi_int_allgatherv(int* s, int* r, int* n, int* dspl);
 extern void nrnmpi_int_alltoall(int* s, int* r, int n);
-extern void nrnmpi_int_alltoallv(const int* s, const int* scnt, const int* sdispl, int* r, int* rcnt, int* rdispl);
+extern void nrnmpi_int_alltoallv(const int* s,
+                                 const int* scnt,
+                                 const int* sdispl,
+                                 int* r,
+                                 int* rcnt,
+                                 int* rdispl);
 extern void nrnmpi_dbl_allgatherv(double* s, double* r, int* n, int* dspl);
 extern void nrnmpi_dbl_alltoallv(double* s,
                                  int* scnt,

--- a/coreneuron/network/have2want.h
+++ b/coreneuron/network/have2want.h
@@ -146,8 +146,15 @@ static void have_to_want(HAVEWANT_t* have,
     // 1) Send have and want to the rendezvous ranks.
     HAVEWANT_t *have_s_data, *have_r_data;
     int *have_s_cnt, *have_s_displ, *have_r_cnt, *have_r_displ;
-    rendezvous_rank_get(have, have_size, have_s_data, have_s_cnt, have_s_displ, have_r_data,
-                        have_r_cnt, have_r_displ, rendezvous_rank);
+    rendezvous_rank_get(have,
+                        have_size,
+                        have_s_data,
+                        have_s_cnt,
+                        have_s_displ,
+                        have_r_data,
+                        have_r_cnt,
+                        have_r_displ,
+                        rendezvous_rank);
     // assume it is an error if two ranks have the same key so create
     // hash table of key2rank. Will also need it for matching have and want
     HAVEWANT2Int havekey2rank = HAVEWANT2Int();
@@ -156,7 +163,7 @@ static void have_to_want(HAVEWANT_t* have,
             HAVEWANT_t key = have_r_data[have_r_displ[r] + i];
             if (havekey2rank.find(key) != havekey2rank.end()) {
                 char buf[200];
-                sprintf(buf, "key %lld owned by multiple ranks\n", (long long)key);
+                sprintf(buf, "key %lld owned by multiple ranks\n", (long long) key);
                 hoc_execerror(buf, 0);
             }
             havekey2rank[key] = r;
@@ -171,8 +178,15 @@ static void have_to_want(HAVEWANT_t* have,
 
     HAVEWANT_t *want_s_data, *want_r_data;
     int *want_s_cnt, *want_s_displ, *want_r_cnt, *want_r_displ;
-    rendezvous_rank_get(want, want_size, want_s_data, want_s_cnt, want_s_displ, want_r_data,
-                        want_r_cnt, want_r_displ, rendezvous_rank);
+    rendezvous_rank_get(want,
+                        want_size,
+                        want_s_data,
+                        want_s_cnt,
+                        want_s_displ,
+                        want_r_data,
+                        want_r_cnt,
+                        want_r_displ,
+                        rendezvous_rank);
 
     // 2) Rendezvous rank matches have and want.
     //    we already have made the havekey2rank map.
@@ -186,7 +200,7 @@ static void have_to_want(HAVEWANT_t* have,
             HAVEWANT_t key = want_r_data[ix];
             if (havekey2rank.find(key) == havekey2rank.end()) {
                 char buf[200];
-                sprintf(buf, "key = %lld is wanted but does not exist\n", (long long)key);
+                sprintf(buf, "key = %lld is wanted but does not exist\n", (long long) key);
                 hoc_execerror(buf, 0);
             }
             want_r_ownerranks[ix] = havekey2rank[key];
@@ -202,8 +216,12 @@ static void have_to_want(HAVEWANT_t* have,
     int* want_s_ownerranks = new int[want_s_displ[nhost]];
 #if NRNMPI
     if (nhost > 1) {
-        nrnmpi_int_alltoallv(want_r_ownerranks, want_r_cnt, want_r_displ, want_s_ownerranks,
-                             want_s_cnt, want_s_displ);
+        nrnmpi_int_alltoallv(want_r_ownerranks,
+                             want_r_cnt,
+                             want_r_displ,
+                             want_s_ownerranks,
+                             want_s_cnt,
+                             want_s_displ);
     } else
 #endif
     {
@@ -251,8 +269,8 @@ static void have_to_want(HAVEWANT_t* have,
     want_r_data = new HAVEWANT_t[want_r_displ[nhost]];
 #if NRNMPI
     if (nhost > 1) {
-        HAVEWANT_alltoallv(want_s_data, want_s_cnt, want_s_displ, want_r_data, want_r_cnt,
-                           want_r_displ);
+        HAVEWANT_alltoallv(
+            want_s_data, want_s_cnt, want_s_displ, want_r_data, want_r_cnt, want_r_displ);
     } else
 #endif
     {

--- a/coreneuron/network/netcon.hpp
+++ b/coreneuron/network/netcon.hpp
@@ -24,12 +24,12 @@ struct Point_process;
 class NetCvode;
 
 #define DiscreteEventType 0
-#define TstopEventType 1
-#define NetConType 2
-#define SelfEventType 3
-#define PreSynType 4
-#define NetParEventType 7
-#define InputPreSynType 20
+#define TstopEventType    1
+#define NetConType        2
+#define SelfEventType     3
+#define PreSynType        4
+#define NetParEventType   7
+#define InputPreSynType   20
 
 class DiscreteEvent {
   public:
@@ -46,7 +46,7 @@ class DiscreteEvent {
     virtual void pr(const char*, double t, NetCvode*);
 };
 
-class NetCon : public DiscreteEvent {
+class NetCon: public DiscreteEvent {
   public:
     bool active_;
     double delay_;
@@ -69,7 +69,7 @@ class NetCon : public DiscreteEvent {
     virtual void pr(const char*, double t, NetCvode*) override;
 };
 
-class SelfEvent : public DiscreteEvent {
+class SelfEvent: public DiscreteEvent {
   public:
     double flag_;
     Point_process* target_;
@@ -89,7 +89,7 @@ class SelfEvent : public DiscreteEvent {
     void call_net_receive(NetCvode*);
 };
 
-class ConditionEvent : public DiscreteEvent {
+class ConditionEvent: public DiscreteEvent {
   public:
     // condition detection factored out of PreSyn for re-use
     ConditionEvent();
@@ -103,7 +103,7 @@ class ConditionEvent : public DiscreteEvent {
                 // bug(?))
 };
 
-class PreSyn : public ConditionEvent {
+class PreSyn: public ConditionEvent {
   public:
 #if NRNMPI
     unsigned char localgid_;  // compressed gid for spike transfer
@@ -131,7 +131,7 @@ class PreSyn : public ConditionEvent {
 #endif
 };
 
-class InputPreSyn : public DiscreteEvent {
+class InputPreSyn: public DiscreteEvent {
   public:
     int nc_index_;  // replaces dil_, index into global NetCon** netcon_in_presyn_order_
     int nc_cnt_;    // how many netcon starting at nc_index_
@@ -148,7 +148,7 @@ class InputPreSyn : public DiscreteEvent {
 #endif
 };
 
-class NetParEvent : public DiscreteEvent {
+class NetParEvent: public DiscreteEvent {
   public:
     int ithread_;     // for pr()
     double wx_, ws_;  // exchange time and "spikes to Presyn" time

--- a/coreneuron/network/netpar.hpp
+++ b/coreneuron/network/netpar.hpp
@@ -13,6 +13,6 @@
 
 namespace coreneuron {
 
-    extern void nrn_spike_exchange_init(void);
-    extern void nrn_spike_exchange(NrnThread* nt);
-}
+extern void nrn_spike_exchange_init(void);
+extern void nrn_spike_exchange(NrnThread* nt);
+}  // namespace coreneuron

--- a/coreneuron/network/partrans.hpp
+++ b/coreneuron/network/partrans.hpp
@@ -56,33 +56,33 @@ using sgid_t = int;
  *  input_buf_. And on the source side, it is certainly simple to scatter
  *  to the outbut_buf_ in NrnThread.data order.  Note that one expects a wide
  *  scatter to the outsrc_buf and also a wide scatter within the insrc_buf_.
-**/
+ **/
 
 /*
-* In partrans.cpp: nrnmpi_v_transfer
-*   Copy NrnThead.data to outsrc_buf_ for all threads via
-*     gpu: gather src_gather[i] = NrnThread._data[src_indices[i]];
-*     gpu to host src_gather
-*     cpu: outsrc_buf_[outsrc_indices[i]] = src_gather[gather2outsrc_indices[i]];
-*
-*   MPI_Allgatherv outsrc_buf_ to insrc_buf_
-*
-*   host to gpu insrc_buf_
-*
-* In partrans.cpp: nrnthread_v_transfer
-*   insrc_buf_ to NrnThread._data via
-*   NrnThread.data[tar_indices[i]] = insrc_buf_[insrc_indices[i]];
-*     where tar_indices depends on layout, type, etc.
-*/
+ * In partrans.cpp: nrnmpi_v_transfer
+ *   Copy NrnThead.data to outsrc_buf_ for all threads via
+ *     gpu: gather src_gather[i] = NrnThread._data[src_indices[i]];
+ *     gpu to host src_gather
+ *     cpu: outsrc_buf_[outsrc_indices[i]] = src_gather[gather2outsrc_indices[i]];
+ *
+ *   MPI_Allgatherv outsrc_buf_ to insrc_buf_
+ *
+ *   host to gpu insrc_buf_
+ *
+ * In partrans.cpp: nrnthread_v_transfer
+ *   insrc_buf_ to NrnThread._data via
+ *   NrnThread.data[tar_indices[i]] = insrc_buf_[insrc_indices[i]];
+ *     where tar_indices depends on layout, type, etc.
+ */
 
 struct TransferThreadData {
-    std::vector<int> src_indices;   // indices into NrnThread._data
-    std::vector<double> src_gather; // copy of NrnThread._data[src_indices]
-    std::vector<int> gather2outsrc_indices; // ix of src_gather that send into outsrc_indices
-    std::vector<int> outsrc_indices;// ix of outsrc_buf that receive src_gather values
+    std::vector<int> src_indices;            // indices into NrnThread._data
+    std::vector<double> src_gather;          // copy of NrnThread._data[src_indices]
+    std::vector<int> gather2outsrc_indices;  // ix of src_gather that send into outsrc_indices
+    std::vector<int> outsrc_indices;         // ix of outsrc_buf that receive src_gather values
 
-    std::vector<int> insrc_indices; // insrc_buf_ indices copied to ...
-    std::vector<int> tar_indices;   // indices of NrnThread.data.
+    std::vector<int> insrc_indices;  // insrc_buf_ indices copied to ...
+    std::vector<int> tar_indices;    // indices of NrnThread.data.
 };
 extern TransferThreadData* transfer_thread_data_; /* array for threads */
 
@@ -106,5 +106,5 @@ extern void gap_cleanup();
 extern double* insrc_buf_;   // Receive buffer for gap voltages
 extern double* outsrc_buf_;  // Send buffer for gap voltages
 extern int *insrccnt_, *insrcdspl_, *outsrccnt_, *outsrcdspl_;
-}
+}  // namespace nrn_partrans
 }  // namespace coreneuron

--- a/coreneuron/network/tqueue.hpp
+++ b/coreneuron/network/tqueue.hpp
@@ -39,12 +39,12 @@ namespace coreneuron {
 #define STRCMP(a, b) (a - b)
 
 class TQItem;
-#define SPBLK TQItem
-#define leftlink left_
+#define SPBLK     TQItem
+#define leftlink  left_
 #define rightlink right_
-#define uplink parent_
-#define cnt cnt_
-#define key t_
+#define uplink    parent_
+#define cnt       cnt_
+#define key       t_
 
 struct SPTREE {
     SPBLK* root; /* root node */
@@ -53,11 +53,11 @@ struct SPTREE {
     int enqcmps; /* compares in spenq */
 };
 
-#define spinit sptq_spinit
-#define spenq sptq_spenq
-#define spdeq sptq_spdeq
-#define splay sptq_splay
-#define sphead sptq_sphead
+#define spinit   sptq_spinit
+#define spenq    sptq_spenq
+#define spdeq    sptq_spdeq
+#define splay    sptq_splay
+#define sphead   sptq_sphead
 #define spdelete sptq_spdelete
 
 extern void spinit(SPTREE*);           /* init tree */
@@ -113,11 +113,12 @@ class BinQ {
     TQItem* next(TQItem*);
     void remove(TQItem*);
     void resize(int);
+
   private:
     double tt_;  // time at beginning of qpt_ interval
     int nbin_, qpt_;
     TQItem** bins_;
-    std::vector<std::vector<TQItem*> > vec_bins;
+    std::vector<std::vector<TQItem*>> vec_bins;
 };
 
 enum container { spltree, pq_que };

--- a/coreneuron/nrnconf.h
+++ b/coreneuron/nrnconf.h
@@ -20,16 +20,16 @@ namespace coreneuron {
 #define NRNBBCORE 1
 
 using Datum = int;
-using Pfri = int(*)();
+using Pfri = int (*)();
 using Symbol = char;
 
-#define VEC_A(i) (_nt->_actual_a[(i)])
-#define VEC_B(i) (_nt->_actual_b[(i)])
-#define VEC_D(i) (_nt->_actual_d[(i)])
-#define VEC_RHS(i) (_nt->_actual_rhs[(i)])
-#define VEC_V(i) (_nt->_actual_v[(i)])
+#define VEC_A(i)    (_nt->_actual_a[(i)])
+#define VEC_B(i)    (_nt->_actual_b[(i)])
+#define VEC_D(i)    (_nt->_actual_d[(i)])
+#define VEC_RHS(i)  (_nt->_actual_rhs[(i)])
+#define VEC_V(i)    (_nt->_actual_v[(i)])
 #define VEC_AREA(i) (_nt->_actual_area[(i)])
-#define VECTORIZE 1
+#define VECTORIZE   1
 
 extern double celsius;
 
@@ -38,8 +38,8 @@ extern int rev_dt;
 extern int secondorder;
 extern bool stoprun;
 extern const char* bbcore_write_version;
-#define tstopbit (1 << 15)
-#define tstopset stoprun |= tstopbit
+#define tstopbit   (1 << 15)
+#define tstopset   stoprun |= tstopbit
 #define tstopunset stoprun &= (~tstopbit)
 
 extern void* nrn_cacheline_alloc(void** memptr, size_t size);

--- a/coreneuron/nrniv/nrniv_decl.h
+++ b/coreneuron/nrniv/nrniv_decl.h
@@ -17,11 +17,11 @@ namespace coreneuron {
 /// Mechanism type to be used from stdindex2ptr and nrn_dblpntr2nrncore (in Neuron)
 /// Values of the mechanism types should be negative numbers to avoid any conflict with
 /// mechanism types of Memb_list(>0) or time(0) passed from Neuron
-enum mech_type {voltage = -1, i_membrane_ = -2};
+enum mech_type { voltage = -1, i_membrane_ = -2 };
 
 extern bool cvode_active_;
 /// Vector of maps for negative presyns
-extern std::vector<std::map<int, PreSyn*> > neg_gid2out;
+extern std::vector<std::map<int, PreSyn*>> neg_gid2out;
 /// Maps for ouput and input presyns
 extern std::map<int, PreSyn*> gid2out;
 extern std::map<int, InputPreSyn*> gid2in;
@@ -32,7 +32,7 @@ extern std::vector<NetCon*> netcon_in_presyn_order_;
 extern std::vector<int*> nrnthreads_netcon_srcgid;
 /// Companion to nrnthreads_netcon_srcgid when src gid is negative to allow
 /// determination of the NrnThread of the source PreSyn.
-extern std::vector<std::vector<int> > nrnthreads_netcon_negsrcgid_tid;
+extern std::vector<std::vector<int>> nrnthreads_netcon_negsrcgid_tid;
 
 extern void mk_mech(const char* path);
 extern void set_globals(const char* path, bool cli_global_seed, int cli_global_seed_value);

--- a/coreneuron/nrnoc/nrnunits_modern.h
+++ b/coreneuron/nrnoc/nrnunits_modern.h
@@ -25,12 +25,15 @@
 
 
 #define _electron_charge_codata2018 1.602176634e-19 /* coulomb exact*/
-#define _avogadro_number_codata2018 6.02214076e+23 /* exact */
-#define _boltzmann_codata2018 1.380649e-23 /* joule/K exact */
-#define _faraday_codata2018 (_electron_charge_codata2018*_avogadro_number_codata2018) /* 96485.33212... coulomb/mol */
-#define _gasconstant_codata2018 (_boltzmann_codata2018*_avogadro_number_codata2018) /* 8.314462618... joule/mol-K */
+#define _avogadro_number_codata2018 6.02214076e+23  /* exact */
+#define _boltzmann_codata2018       1.380649e-23    /* joule/K exact */
+#define _faraday_codata2018 \
+    (_electron_charge_codata2018 * _avogadro_number_codata2018) /* 96485.33212... coulomb/mol */
+#define _gasconstant_codata2018 \
+    (_boltzmann_codata2018 * _avogadro_number_codata2018) /* 8.314462618... joule/mol-K */
 
 /* e/k in K/millivolt */
-#define _e_over_k_codata2018 (.001*_electron_charge_codata2018/_boltzmann_codata2018) /* 11.604518... K/mV */
+#define _e_over_k_codata2018 \
+    (.001 * _electron_charge_codata2018 / _boltzmann_codata2018) /* 11.604518... K/mV */
 
 #endif /* nrnunits_modern_h */

--- a/coreneuron/permute/cellorder.hpp
+++ b/coreneuron/permute/cellorder.hpp
@@ -65,7 +65,7 @@ void copy_array(T*& dest, T* src, size_t n) {
 // copy src array to dest with NRN_SOA_BYTE_ALIGN ecalloc_align allocation
 template <typename T>
 void copy_align_array(T*& dest, T* src, size_t n) {
-    dest = (T*)ecalloc_align(n, sizeof(T));
+    dest = (T*) ecalloc_align(n, sizeof(T));
     std::copy(src, src + n, dest);
 }
 

--- a/coreneuron/sim/fast_imem.hpp
+++ b/coreneuron/sim/fast_imem.hpp
@@ -34,4 +34,4 @@ void nrn_fast_imem_alloc();
 void nrn_calc_fast_imem(NrnThread* _nt);
 
 }  // namespace coreneuron
-#endif //fast_imem_h
+#endif  // fast_imem_h

--- a/coreneuron/sim/multicore.hpp
+++ b/coreneuron/sim/multicore.hpp
@@ -63,7 +63,7 @@ struct PreSynHelper {
     int flag_;
 };
 
-struct NrnThread : public MemoryManaged {
+struct NrnThread: public MemoryManaged {
     double _t = 0;
     double _dt = -1e9;
     double cj = 0.0;
@@ -73,7 +73,8 @@ struct NrnThread : public MemoryManaged {
     Point_process* pntprocs = nullptr;  // synapses and artificial cells with and without gid
     PreSyn* presyns = nullptr;          // all the output PreSyn with and without gid
     PreSynHelper* presyns_helper = nullptr;
-    int** pnt2presyn_ix = nullptr;  // eliminates Point_process._presyn used only by net_event sender.
+    int** pnt2presyn_ix = nullptr;  // eliminates Point_process._presyn used only by net_event
+                                    // sender.
     NetCon* netcons = nullptr;
     double* weights = nullptr;  // size n_weight. NetCon.weight_ points into this array.
 
@@ -91,11 +92,11 @@ struct NrnThread : public MemoryManaged {
 
     size_t _ndata = 0;
     size_t _nvdata = 0;
-    size_t _nidata = 0;                            /* sizes */
-    double* _data = nullptr;                   /* all the other double* and Datum to doubles point into here*/
-    int* _idata = nullptr;                     /* all the Datum to ints index into here */
-    void** _vdata = nullptr;                   /* all the Datum to pointers index into here */
-    void** _vecplay = nullptr;                 /* array of instances of VecPlayContinuous */
+    size_t _nidata = 0;        /* sizes */
+    double* _data = nullptr;   /* all the other double* and Datum to doubles point into here*/
+    int* _idata = nullptr;     /* all the Datum to ints index into here */
+    void** _vdata = nullptr;   /* all the Datum to pointers index into here */
+    void** _vecplay = nullptr; /* array of instances of VecPlayContinuous */
 
     double* _actual_rhs = nullptr;
     double* _actual_d = nullptr;
@@ -104,10 +105,10 @@ struct NrnThread : public MemoryManaged {
     double* _actual_v = nullptr;
     double* _actual_area = nullptr;
     double* _actual_diam = nullptr; /* nullptr if no mechanism has dparam with diam semantics */
-    double* _shadow_rhs = nullptr;  /* Not pointer into _data. Avoid race for multiple POINT_PROCESS in same
-                             compartment */
-    double* _shadow_d = nullptr;    /* Not pointer into _data. Avoid race for multiple POINT_PROCESS in same
-                             compartment */
+    double* _shadow_rhs = nullptr;  /* Not pointer into _data. Avoid race for multiple POINT_PROCESS
+                             in same  compartment */
+    double* _shadow_d = nullptr; /* Not pointer into _data. Avoid race for multiple POINT_PROCESS in
+                          same compartment */
 
     /* Fast membrane current calculation struct */
     NrnFastImem* nrn_fast_imem = nullptr;
@@ -140,17 +141,17 @@ struct NrnThread : public MemoryManaged {
 extern void nrn_threads_create(int n);
 extern int nrn_nthread;
 extern NrnThread* nrn_threads;
-template<typename F, typename... Args>
+template <typename F, typename... Args>
 void nrn_multithread_job(F&& job, Args&&... args) {
     int i;
-// clang-format off
+    // clang-format off
 
     #pragma omp parallel for private(i) shared(nrn_threads, job, nrn_nthread, \
                                            nrnmpi_myid) schedule(static, 1)
     for (i = 0; i < nrn_nthread; ++i) {
         job(nrn_threads + i, std::forward<Args>(args)...);
     }
-// clang-format on
+    // clang-format on
 }
 
 extern void nrn_thread_table_check(void);

--- a/coreneuron/utils/ivocvect.hpp
+++ b/coreneuron/utils/ivocvect.hpp
@@ -23,15 +23,16 @@ class fixed_vector {
 
     fixed_vector() = default;
 
-    fixed_vector(size_t n) : n_(n) {
+    fixed_vector(size_t n)
+        : n_(n) {
         data_ = new T[n_];
     }
 
     fixed_vector(const fixed_vector& vec) = delete;
     fixed_vector& operator=(const fixed_vector& vec) = delete;
     fixed_vector(fixed_vector&& vec)
-        : data_(nullptr), n_(vec.n_)
-    {
+        : data_(nullptr)
+        , n_(vec.n_) {
         std::swap(data_, vec.data_);
     }
     fixed_vector& operator=(fixed_vector&& vec) {

--- a/coreneuron/utils/memory.h
+++ b/coreneuron/utils/memory.h
@@ -48,29 +48,29 @@ inline void free_memory(void* pointer) {
  */
 class MemoryManaged {
   public:
-  void *operator new(size_t len) {
-    void *ptr;
-    cudaMallocManaged(&ptr, len);
-    cudaDeviceSynchronize();
-    return ptr;
-  }
+    void* operator new(size_t len) {
+        void* ptr;
+        cudaMallocManaged(&ptr, len);
+        cudaDeviceSynchronize();
+        return ptr;
+    }
 
-  void *operator new[](size_t len) {
-    void *ptr;
-    cudaMallocManaged(&ptr, len);
-    cudaDeviceSynchronize();
-    return ptr;
-  }
+    void* operator new[](size_t len) {
+        void* ptr;
+        cudaMallocManaged(&ptr, len);
+        cudaDeviceSynchronize();
+        return ptr;
+    }
 
-  void operator delete(void *ptr) {
-    cudaDeviceSynchronize();
-    cudaFree(ptr);
-  }
+    void operator delete(void* ptr) {
+        cudaDeviceSynchronize();
+        cudaFree(ptr);
+    }
 
-  void operator delete[](void *ptr) {
-    cudaDeviceSynchronize();
-    cudaFree(ptr);
-  }
+    void operator delete[](void* ptr) {
+        cudaDeviceSynchronize();
+        cudaFree(ptr);
+    }
 };
 
 
@@ -84,7 +84,7 @@ class MemoryManaged {
 
 inline void alloc_memory(void*& pointer, size_t num_bytes, size_t alignment) {
 #if defined(MINGW)
-    nrn_assert( (pointer = _aligned_malloc(num_bytes, alignment)) != nullptr);
+    nrn_assert((pointer = _aligned_malloc(num_bytes, alignment)) != nullptr);
 #else
     nrn_assert(posix_memalign(&pointer, alignment, num_bytes) == 0);
 #endif
@@ -121,7 +121,7 @@ inline int soa_padded_size(int cnt, int layout) {
 /** Check for the pointer alignment.
  */
 inline bool is_aligned(void* pointer, size_t alignment) {
-    return (((uintptr_t)(const void*)(pointer)) % (alignment) == 0);
+    return (((uintptr_t)(const void*) (pointer)) % (alignment) == 0);
 }
 
 /** Allocate the aligned memory.

--- a/coreneuron/utils/nrnmutdec.h
+++ b/coreneuron/utils/nrnmutdec.h
@@ -14,47 +14,47 @@
 #include <omp.h>
 #define USE_PTHREAD 0
 
-#define MUTDEC omp_lock_t* mut_;
-#define MUTCONSTRUCTED (mut_ != (omp_lock_t*)0)
+#define MUTDEC         omp_lock_t* mut_;
+#define MUTCONSTRUCTED (mut_ != (omp_lock_t*) 0)
 #if defined(__cplusplus)
 
 // This class respects the requirement *Mutex*
 class OMP_Mutex {
-    public:
-        // Default constructible
-        OMP_Mutex() {
-            omp_init_lock(&mut_);
-        }
+  public:
+    // Default constructible
+    OMP_Mutex() {
+        omp_init_lock(&mut_);
+    }
 
-        // Destructible
-        ~OMP_Mutex() {
-            omp_destroy_lock(&mut_);
-        }
+    // Destructible
+    ~OMP_Mutex() {
+        omp_destroy_lock(&mut_);
+    }
 
-        // Not copyable
-        OMP_Mutex(const OMP_Mutex&) = delete;
-        OMP_Mutex& operator=(const OMP_Mutex&) = delete;
+    // Not copyable
+    OMP_Mutex(const OMP_Mutex&) = delete;
+    OMP_Mutex& operator=(const OMP_Mutex&) = delete;
 
-        // Not movable
-        OMP_Mutex(const OMP_Mutex&&) = delete;
-        OMP_Mutex& operator=(const OMP_Mutex&&) = delete;
+    // Not movable
+    OMP_Mutex(const OMP_Mutex&&) = delete;
+    OMP_Mutex& operator=(const OMP_Mutex&&) = delete;
 
-        // Basic Lockable
-        void lock() {
-            omp_set_lock(&mut_);
-        }
+    // Basic Lockable
+    void lock() {
+        omp_set_lock(&mut_);
+    }
 
-        void unlock() {
-            omp_unset_lock(&mut_);
-        }
+    void unlock() {
+        omp_unset_lock(&mut_);
+    }
 
-        // Lockable
-        bool try_lock() {
-            return omp_test_lock(&mut_) != 0;
-        }
+    // Lockable
+    bool try_lock() {
+        return omp_test_lock(&mut_) != 0;
+    }
 
-    private:
-        omp_lock_t mut_;
+  private:
+    omp_lock_t mut_;
 };
 
 #define MUTCONSTRUCT(mkmut)        \
@@ -75,20 +75,20 @@ class OMP_Mutex {
         }                           \
     }
 #else
-#define MUTCONSTRUCT(mkmut)                                 \
-    {                                                       \
-        if (mkmut) {                                        \
-            mut_ = (omp_lock_t*)malloc(sizeof(omp_lock_t)); \
-            omp_init_lock(mut_);                            \
-        } else {                                            \
-            mut_ = 0;                                       \
-        }                                                   \
+#define MUTCONSTRUCT(mkmut)                                  \
+    {                                                        \
+        if (mkmut) {                                         \
+            mut_ = (omp_lock_t*) malloc(sizeof(omp_lock_t)); \
+            omp_init_lock(mut_);                             \
+        } else {                                             \
+            mut_ = 0;                                        \
+        }                                                    \
     }
 #define MUTDESTRUCT                 \
     {                               \
         if (mut_) {                 \
             omp_destroy_lock(mut_); \
-            free((char*)mut_);      \
+            free((char*) mut_);     \
             mut_ = nullptr;         \
         }                           \
     }
@@ -106,8 +106,8 @@ class OMP_Mutex {
         }                         \
     }
 #else
-#define MUTDEC /**/
-#define MUTCONSTRUCTED (0)
+#define MUTDEC              /**/
+#define MUTCONSTRUCTED      (0)
 #define MUTCONSTRUCT(mkmut) /**/
 #define MUTDESTRUCT         /**/
 #define MUTLOCK             /**/
@@ -115,30 +115,30 @@ class OMP_Mutex {
 
 // This class respects the requirement *Mutex*
 class OMP_Mutex {
-    public:
-        // Default constructible
-        OMP_Mutex() = default;
+  public:
+    // Default constructible
+    OMP_Mutex() = default;
 
-        // Destructible
-        ~OMP_Mutex() = default;
+    // Destructible
+    ~OMP_Mutex() = default;
 
-        // Not copyable
-        OMP_Mutex(const OMP_Mutex&) = delete;
-        OMP_Mutex& operator=(const OMP_Mutex&) = delete;
+    // Not copyable
+    OMP_Mutex(const OMP_Mutex&) = delete;
+    OMP_Mutex& operator=(const OMP_Mutex&) = delete;
 
-        // Not movable
-        OMP_Mutex(const OMP_Mutex&&) = delete;
-        OMP_Mutex& operator=(const OMP_Mutex&&) = delete;
+    // Not movable
+    OMP_Mutex(const OMP_Mutex&&) = delete;
+    OMP_Mutex& operator=(const OMP_Mutex&&) = delete;
 
-        // Basic Lockable
-        void lock() {}
+    // Basic Lockable
+    void lock() {}
 
-        void unlock() {}
+    void unlock() {}
 
-        // Lockable
-        bool try_lock() {
-            return true;
-        }
+    // Lockable
+    bool try_lock() {
+        return true;
+    }
 };
 #endif
 

--- a/coreneuron/utils/profile/profiler_interface.h
+++ b/coreneuron/utils/profile/profiler_interface.h
@@ -287,8 +287,9 @@ using InstrumentorImpl = detail::Instrumentor<
 
 namespace Instrumentor {
 struct phase {
-    const char * phase_name;
-    phase(const char* name) : phase_name(name) {
+    const char* phase_name;
+    phase(const char* name)
+        : phase_name(name) {
         detail::InstrumentorImpl::phase_begin(phase_name);
     }
     ~phase() {
@@ -319,6 +320,6 @@ inline static void init_profile() {
 inline static void finalize_profile() {
     detail::InstrumentorImpl::finalize_profile();
 }
-}
+}  // namespace Instrumentor
 
 }  // namespace coreneuron

--- a/coreneuron/utils/randoms/nrnran123.h
+++ b/coreneuron/utils/randoms/nrnran123.h
@@ -33,7 +33,7 @@ http://www.deshawresearch.com/resources_random123.html
 
 #ifdef __bgclang__
 #define R123_USE_MULHILO64_MULHI_INTRIN 0
-#define R123_USE_GNU_UINT128 1
+#define R123_USE_GNU_UINT128            1
 #endif
 
 #include <Random123/philox.h>
@@ -48,22 +48,22 @@ http://www.deshawresearch.com/resources_random123.html
 #endif
 
 #if (defined(__CUDACC__) || defined(_OPENACC)) && !defined(DISABLE_OPENACC)
-#define nrnran123_newstream cu_nrnran123_newstream
-#define nrnran123_newstream3 cu_nrnran123_newstream3
-#define nrnran123_deletestream cu_nrnran123_deletestream
-#define nrnran123_uint2dbl cu_nrnran123_uint2dbl
-#define nrnran123_negexp cu_nrnran123_negexp
-#define nrnran123_dblpick cu_nrnran123_dblpick
-#define nrnran123_ipick cu_nrnran123_ipick
-#define nrnran123_getids cu_nrnran123_getids
-#define nrnran123_setseq cu_nrnran123_setseq
-#define nrnran123_getseq cu_nrnran123_getseq
+#define nrnran123_newstream       cu_nrnran123_newstream
+#define nrnran123_newstream3      cu_nrnran123_newstream3
+#define nrnran123_deletestream    cu_nrnran123_deletestream
+#define nrnran123_uint2dbl        cu_nrnran123_uint2dbl
+#define nrnran123_negexp          cu_nrnran123_negexp
+#define nrnran123_dblpick         cu_nrnran123_dblpick
+#define nrnran123_ipick           cu_nrnran123_ipick
+#define nrnran123_getids          cu_nrnran123_getids
+#define nrnran123_setseq          cu_nrnran123_setseq
+#define nrnran123_getseq          cu_nrnran123_getseq
 #define nrnran123_get_globalindex cu_nrnran123_get_globalindex
 #define nrnran123_set_globalindex cu_nrnran123_set_globalindex
-#define nrnran123_state_size cu_nrnran123_state_size
-#define nrnran123_instance_count cu_nrnran123_instance_count
-#define nrnran123_normal cu_nrnran123_normal
-#define nrnran123_getids3 cu_nrnran123_getids3
+#define nrnran123_state_size      cu_nrnran123_state_size
+#define nrnran123_instance_count  cu_nrnran123_instance_count
+#define nrnran123_normal          cu_nrnran123_normal
+#define nrnran123_getids3         cu_nrnran123_getids3
 #endif
 
 namespace coreneuron {
@@ -74,7 +74,9 @@ typedef struct nrnran123_State {
     char which_;
 } nrnran123_State;
 
-typedef struct nrnran123_array4x32 { uint32_t v[4]; } nrnran123_array4x32;
+typedef struct nrnran123_array4x32 {
+    uint32_t v[4];
+} nrnran123_array4x32;
 
 /* do this on launch to make nrnran123_newstream threadsafe */
 extern DEVICE void nrnran123_mutconstruct(void);

--- a/coreneuron/utils/string_utils.h
+++ b/coreneuron/utils/string_utils.h
@@ -17,15 +17,16 @@
 
 /** @brief Appends a copy of the source string to the destination string.
  *
- *  A null-character is included at the end of the new string formed by the concatenation of both in destination.
- *  It has similar behavior to strcat but better performance in case that it is needed to append a char array to
- *  another very large char array.
+ *  A null-character is included at the end of the new string formed by the concatenation of both in
+ * destination. It has similar behavior to strcat but better performance in case that it is needed
+ * to append a char array to another very large char array.
  *
  *  @param dest Destination string
  *  @param start_position Position of dest to start writing src
  *  @param src Source string
  *  @param src_length Length of src to append to dest
- *  @return Position of the final character of dest after appending src (including the null terminating character)
+ *  @return Position of the final character of dest after appending src (including the null
+ * terminating character)
  */
 unsigned strcat_at_pos(char* dest, unsigned start_position, char* src, unsigned src_length);
 

--- a/coreneuron/utils/vrecitem.h
+++ b/coreneuron/utils/vrecitem.h
@@ -15,10 +15,10 @@ namespace coreneuron {
 class PlayRecord;
 
 #define VecPlayContinuousType 4
-#define PlayRecordEventType 21
+#define PlayRecordEventType   21
 
 // used by PlayRecord subclasses that utilize discrete events
-class PlayRecordEvent : public DiscreteEvent {
+class PlayRecordEvent: public DiscreteEvent {
   public:
     PlayRecordEvent();
     virtual ~PlayRecordEvent();
@@ -38,12 +38,10 @@ class PlayRecord {
   public:
     PlayRecord(double* pd, int ith);
     virtual ~PlayRecord();
-    virtual void play_init() {
-    }  // called near beginning of finitialize
+    virtual void play_init() {}  // called near beginning of finitialize
     virtual void continuous(double) {
     }  // play - every f(y, t) or res(y', y, t); record - advance_tn and initialize flag
-    virtual void deliver(double, NetCvode*) {
-    }  // at associated DiscreteEvent
+    virtual void deliver(double, NetCvode*) {}  // at associated DiscreteEvent
     virtual PlayRecordEvent* event() {
         return nullptr;
     }
@@ -56,7 +54,7 @@ class PlayRecord {
     int ith_;  // The thread index
 };
 
-class VecPlayContinuous : public PlayRecord {
+class VecPlayContinuous: public PlayRecord {
   public:
     VecPlayContinuous(double*, IvocVect&& yvec, IvocVect&& tvec, IvocVect* discon, int ith);
     virtual ~VecPlayContinuous();

--- a/tests/unit/alignment/alignment.cpp
+++ b/tests/unit/alignment/alignment.cpp
@@ -19,129 +19,124 @@
 
 #include "coreneuron/utils/memory.h"
 
-template<class T, int n=1>
-struct data{
-  typedef T value_type;
-  static const int chunk=n;
+template <class T, int n = 1>
+struct data {
+    typedef T value_type;
+    static const int chunk = n;
 };
 
-typedef boost::mpl::list<
-                          data<double>,
-                          data<long long int>
-                        > chunk_default_data_type;
+typedef boost::mpl::list<data<double>, data<long long int>> chunk_default_data_type;
 
-typedef boost::mpl::list<
-                          data<double, 2>,
-                          data<double, 4>,
-                          data<double, 8>,
-                          data<double, 16>,
-                          data<double, 32>, 
-                          data<int, 2>,
-                          data<int, 4>,
-                          data<int, 8>,
-                          data<int, 16>,
-                          data<int, 32>
-                        > chunk_data_type;
+typedef boost::mpl::list<data<double, 2>,
+                         data<double, 4>,
+                         data<double, 8>,
+                         data<double, 16>,
+                         data<double, 32>,
+                         data<int, 2>,
+                         data<int, 4>,
+                         data<int, 8>,
+                         data<int, 16>,
+                         data<int, 32>>
+    chunk_data_type;
 
 BOOST_AUTO_TEST_CASE(padding_simd) {
+    /** AOS test */
+    int pad = coreneuron::soa_padded_size<1>(11, 1);
+    BOOST_CHECK_EQUAL(pad, 11);
 
-  /** AOS test */
-  int pad = coreneuron::soa_padded_size<1>(11, 1);
-  BOOST_CHECK_EQUAL(pad,11);	
+    /** SOA tests with 11 */
+    pad = coreneuron::soa_padded_size<1>(11, 0);
+    BOOST_CHECK_EQUAL(pad, 11);
 
-  /** SOA tests with 11 */
-  pad = coreneuron::soa_padded_size<1>(11, 0);
-  BOOST_CHECK_EQUAL(pad,11);	
+    pad = coreneuron::soa_padded_size<2>(11, 0);
+    BOOST_CHECK_EQUAL(pad, 12);
 
-  pad = coreneuron::soa_padded_size<2>(11, 0);
-  BOOST_CHECK_EQUAL(pad,12);	
+    pad = coreneuron::soa_padded_size<4>(11, 0);
+    BOOST_CHECK_EQUAL(pad, 12);
 
-  pad = coreneuron::soa_padded_size<4>(11, 0);
-  BOOST_CHECK_EQUAL(pad,12);	
+    pad = coreneuron::soa_padded_size<8>(11, 0);
+    BOOST_CHECK_EQUAL(pad, 16);
 
-  pad = coreneuron::soa_padded_size<8>(11, 0);
-  BOOST_CHECK_EQUAL(pad,16);	
+    pad = coreneuron::soa_padded_size<16>(11, 0);
+    BOOST_CHECK_EQUAL(pad, 16);
 
-  pad = coreneuron::soa_padded_size<16>(11, 0);
-  BOOST_CHECK_EQUAL(pad,16);	
+    pad = coreneuron::soa_padded_size<32>(11, 0);
+    BOOST_CHECK_EQUAL(pad, 32);
 
-  pad = coreneuron::soa_padded_size<32>(11, 0);
-  BOOST_CHECK_EQUAL(pad,32);	
+    /** SOA tests with 32 */
+    pad = coreneuron::soa_padded_size<1>(32, 0);
+    BOOST_CHECK_EQUAL(pad, 32);
 
-  /** SOA tests with 32 */
-  pad = coreneuron::soa_padded_size<1>(32, 0);
-  BOOST_CHECK_EQUAL(pad,32);	
+    pad = coreneuron::soa_padded_size<2>(32, 0);
+    BOOST_CHECK_EQUAL(pad, 32);
 
-  pad = coreneuron::soa_padded_size<2>(32, 0);
-  BOOST_CHECK_EQUAL(pad,32);	
+    pad = coreneuron::soa_padded_size<4>(32, 0);
+    BOOST_CHECK_EQUAL(pad, 32);
 
-  pad = coreneuron::soa_padded_size<4>(32, 0);
-  BOOST_CHECK_EQUAL(pad,32);	
+    pad = coreneuron::soa_padded_size<8>(32, 0);
+    BOOST_CHECK_EQUAL(pad, 32);
 
-  pad = coreneuron::soa_padded_size<8>(32, 0);
-  BOOST_CHECK_EQUAL(pad,32);	
+    pad = coreneuron::soa_padded_size<16>(32, 0);
+    BOOST_CHECK_EQUAL(pad, 32);
 
-  pad = coreneuron::soa_padded_size<16>(32, 0);
-  BOOST_CHECK_EQUAL(pad,32);	
+    pad = coreneuron::soa_padded_size<32>(32, 0);
+    BOOST_CHECK_EQUAL(pad, 32);
 
-  pad = coreneuron::soa_padded_size<32>(32, 0);
-  BOOST_CHECK_EQUAL(pad,32);	
+    /** SOA tests with 33 */
+    pad = coreneuron::soa_padded_size<1>(33, 0);
+    BOOST_CHECK_EQUAL(pad, 33);
 
-  /** SOA tests with 33 */
-  pad = coreneuron::soa_padded_size<1>(33, 0);
-  BOOST_CHECK_EQUAL(pad,33);	
+    pad = coreneuron::soa_padded_size<2>(33, 0);
+    BOOST_CHECK_EQUAL(pad, 34);
 
-  pad = coreneuron::soa_padded_size<2>(33, 0);
-  BOOST_CHECK_EQUAL(pad,34);	
+    pad = coreneuron::soa_padded_size<4>(33, 0);
+    BOOST_CHECK_EQUAL(pad, 36);
 
-  pad = coreneuron::soa_padded_size<4>(33, 0);
-  BOOST_CHECK_EQUAL(pad,36);	
+    pad = coreneuron::soa_padded_size<8>(33, 0);
+    BOOST_CHECK_EQUAL(pad, 40);
 
-  pad = coreneuron::soa_padded_size<8>(33, 0);
-  BOOST_CHECK_EQUAL(pad,40);	
+    pad = coreneuron::soa_padded_size<16>(33, 0);
+    BOOST_CHECK_EQUAL(pad, 48);
 
-  pad = coreneuron::soa_padded_size<16>(33, 0);
-  BOOST_CHECK_EQUAL(pad,48);	
-
-  pad = coreneuron::soa_padded_size<32>(33, 0);
-  BOOST_CHECK_EQUAL(pad,64);	
-
+    pad = coreneuron::soa_padded_size<32>(33, 0);
+    BOOST_CHECK_EQUAL(pad, 64);
 }
 
 /// Even number is randomly depends of the TYPE!!! and the number of elements.
 /// This test work for 64 bits type not for 32 bits.
-BOOST_AUTO_TEST_CASE_TEMPLATE(memory_alignment_simd_false, T, chunk_default_data_type){
-  const int c = T::chunk;
-  int total_size_chunk = coreneuron::soa_padded_size<c>(247, 0);
-  int ne = 6*total_size_chunk;
+BOOST_AUTO_TEST_CASE_TEMPLATE(memory_alignment_simd_false, T, chunk_default_data_type) {
+    const int c = T::chunk;
+    int total_size_chunk = coreneuron::soa_padded_size<c>(247, 0);
+    int ne = 6 * total_size_chunk;
 
-  typename T::value_type* data = (typename T::value_type*)coreneuron::ecalloc_align(ne, sizeof(typename T::value_type), 16);
+    typename T::value_type* data =
+        (typename T::value_type*) coreneuron::ecalloc_align(ne, sizeof(typename T::value_type), 16);
 
-  for(int i=1; i < 6; i+=2){
-      bool b = coreneuron::is_aligned((data+i*total_size_chunk),16);
-      BOOST_CHECK_EQUAL(b,0);
-  }
+    for (int i = 1; i < 6; i += 2) {
+        bool b = coreneuron::is_aligned((data + i * total_size_chunk), 16);
+        BOOST_CHECK_EQUAL(b, 0);
+    }
 
-  for(int i=0; i < 6; i+=2){
-      bool b = coreneuron::is_aligned((data+i*total_size_chunk),16);
-      BOOST_CHECK_EQUAL(b,1);
-  }
+    for (int i = 0; i < 6; i += 2) {
+        bool b = coreneuron::is_aligned((data + i * total_size_chunk), 16);
+        BOOST_CHECK_EQUAL(b, 1);
+    }
 
-  free_memory(data);
-
+    free_memory(data);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(memory_alignment_simd_true, T, chunk_data_type){
-  const int c = T::chunk;
-  int total_size_chunk = coreneuron::soa_padded_size<c>(247, 0);
-  int ne = 6*total_size_chunk;
+BOOST_AUTO_TEST_CASE_TEMPLATE(memory_alignment_simd_true, T, chunk_data_type) {
+    const int c = T::chunk;
+    int total_size_chunk = coreneuron::soa_padded_size<c>(247, 0);
+    int ne = 6 * total_size_chunk;
 
-  typename T::value_type* data = (typename T::value_type*)coreneuron::ecalloc_align(ne, sizeof(typename T::value_type), 16);
+    typename T::value_type* data =
+        (typename T::value_type*) coreneuron::ecalloc_align(ne, sizeof(typename T::value_type), 16);
 
-  for(int i=0; i < 6; ++i){
-      bool b = coreneuron::is_aligned((data+i*total_size_chunk),16);
-      BOOST_CHECK_EQUAL(b,1);
-  }
+    for (int i = 0; i < 6; ++i) {
+        bool b = coreneuron::is_aligned((data + i * total_size_chunk), 16);
+        BOOST_CHECK_EQUAL(b, 1);
+    }
 
-  free_memory(data);
+    free_memory(data);
 }

--- a/tests/unit/cmdline_interface/test_cmdline_interface.cpp
+++ b/tests/unit/cmdline_interface/test_cmdline_interface.cpp
@@ -16,7 +16,6 @@
 using namespace coreneuron;
 
 BOOST_AUTO_TEST_CASE(cmdline_interface) {
-
     const char* argv[] = {
 
         "nrniv-core",
@@ -74,20 +73,21 @@ BOOST_AUTO_TEST_CASE(cmdline_interface) {
         "0.1",
 
         "--dt_io",
-        "0.2"
-        };
+        "0.2"};
 
     int argc = 0;
 
-    for (; strcmp(argv[argc], "0.2"); argc++);
+    for (; strcmp(argv[argc], "0.2"); argc++)
+        ;
 
     argc++;
-    
+
     corenrn_parameters corenrn_param_test;
 
-    corenrn_param_test.parse(argc, const_cast<char**>(argv)); //discarding const as CLI11 interface is not const
-    
-    BOOST_CHECK(corenrn_param_test.seed == -1);            // testing default value
+    corenrn_param_test.parse(argc, const_cast<char**>(argv));  // discarding const as CLI11
+                                                               // interface is not const
+
+    BOOST_CHECK(corenrn_param_test.seed == -1);  // testing default value
 
     BOOST_CHECK(corenrn_param_test.spikebuf == 100);
 
@@ -132,7 +132,6 @@ BOOST_AUTO_TEST_CASE(cmdline_interface) {
     argc = 1;
 
     corenrn_param_test.dt = 18.1;
-    
-    BOOST_CHECK(corenrn_param_test.dt == 18.1);
 
+    BOOST_CHECK(corenrn_param_test.dt == 18.1);
 }

--- a/tests/unit/interleave_info/check_constructors.cpp
+++ b/tests/unit/interleave_info/check_constructors.cpp
@@ -32,7 +32,9 @@ BOOST_AUTO_TEST_CASE(interleave_info_test) {
 
     // check if copy_array works
     BOOST_CHECK_NE(info1.firstnode, info1.lastnode);
-    BOOST_CHECK_EQUAL_COLLECTIONS(info1.firstnode, info1.firstnode + nwarp + 1, info1.lastnode,
+    BOOST_CHECK_EQUAL_COLLECTIONS(info1.firstnode,
+                                  info1.firstnode + nwarp + 1,
+                                  info1.lastnode,
                                   info1.lastnode + nwarp + 1);
 
     copy_array(info1.cellsize, data1 + 4, nwarp);
@@ -59,16 +61,24 @@ BOOST_AUTO_TEST_CASE(interleave_info_test) {
         BOOST_CHECK_EQUAL(info1.nwarp, infos[i]->nwarp);
         BOOST_CHECK_EQUAL(info1.nstride, infos[i]->nstride);
 
-        BOOST_CHECK_EQUAL_COLLECTIONS(info1.stridedispl, info1.stridedispl + nwarp + 1,
-                                      infos[i]->stridedispl, infos[i]->stridedispl + nwarp + 1);
+        BOOST_CHECK_EQUAL_COLLECTIONS(info1.stridedispl,
+                                      info1.stridedispl + nwarp + 1,
+                                      infos[i]->stridedispl,
+                                      infos[i]->stridedispl + nwarp + 1);
 
-        BOOST_CHECK_EQUAL_COLLECTIONS(info1.stride, info1.stride + nstride, infos[i]->stride,
+        BOOST_CHECK_EQUAL_COLLECTIONS(info1.stride,
+                                      info1.stride + nstride,
+                                      infos[i]->stride,
                                       infos[i]->stride + nstride);
 
-        BOOST_CHECK_EQUAL_COLLECTIONS(info1.cellsize, info1.cellsize + nwarp, infos[i]->cellsize,
+        BOOST_CHECK_EQUAL_COLLECTIONS(info1.cellsize,
+                                      info1.cellsize + nwarp,
+                                      infos[i]->cellsize,
                                       infos[i]->cellsize + nwarp);
 
-        BOOST_CHECK_EQUAL_COLLECTIONS(info1.child_race, info1.child_race + nwarp,
-                                      infos[i]->child_race, infos[i]->child_race + nwarp);
+        BOOST_CHECK_EQUAL_COLLECTIONS(info1.child_race,
+                                      info1.child_race + nwarp,
+                                      infos[i]->child_race,
+                                      infos[i]->child_race + nwarp);
     }
 }

--- a/tests/unit/queueing/test_queueing.cpp
+++ b/tests/unit/queueing/test_queueing.cpp
@@ -7,7 +7,7 @@
 */
 
 #define BOOST_TEST_MODULE QueueingTest
-#define TYPE T::cont
+#define TYPE              T::cont
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_case_template.hpp>
@@ -22,93 +22,91 @@
 
 namespace bfs = ::boost::filesystem;
 using namespace coreneuron;
-//UNIT TESTS
-BOOST_AUTO_TEST_CASE(priority_queue_nq_dq){
-	TQueue<pq_que> tq = TQueue<pq_que>();
-	const int num = 8;
-	int cnter = 0;
-	//enqueue 8 items with increasing time
-	for(int i = 0; i < num; ++i)
-		tq.insert(static_cast<double>(i), NULL);
+// UNIT TESTS
+BOOST_AUTO_TEST_CASE(priority_queue_nq_dq) {
+    TQueue<pq_que> tq = TQueue<pq_que>();
+    const int num = 8;
+    int cnter = 0;
+    // enqueue 8 items with increasing time
+    for (int i = 0; i < num; ++i)
+        tq.insert(static_cast<double>(i), NULL);
 
-	BOOST_CHECK(tq.pq_que_.size() == (num - 1));
+    BOOST_CHECK(tq.pq_que_.size() == (num - 1));
 
-	// dequeue items with time <= 5.0. Should be 6 events: from 0. to 5.
-	TQItem *item = NULL;
-	while((item = tq.atomic_dq(5.0)) != NULL){
-		++cnter;
-		delete item;
-	}
-	BOOST_CHECK(cnter == 6);
-	BOOST_CHECK(tq.pq_que_.size() == (num - 6 - 1));
+    // dequeue items with time <= 5.0. Should be 6 events: from 0. to 5.
+    TQItem* item = NULL;
+    while ((item = tq.atomic_dq(5.0)) != NULL) {
+        ++cnter;
+        delete item;
+    }
+    BOOST_CHECK(cnter == 6);
+    BOOST_CHECK(tq.pq_que_.size() == (num - 6 - 1));
 
-	//dequeue the rest
-	while((item = tq.atomic_dq(8.0)) != NULL){
-		++cnter;
-		delete item;
-	}
+    // dequeue the rest
+    while ((item = tq.atomic_dq(8.0)) != NULL) {
+        ++cnter;
+        delete item;
+    }
 
-	BOOST_CHECK(cnter == num);
-	BOOST_CHECK(tq.pq_que_.size() == 0);
-	BOOST_CHECK(tq.least() == NULL);
+    BOOST_CHECK(cnter == num);
+    BOOST_CHECK(tq.pq_que_.size() == 0);
+    BOOST_CHECK(tq.least() == NULL);
 }
 
-BOOST_AUTO_TEST_CASE(tqueue_ordered_test){
-	TQueue<pq_que> tq = TQueue<pq_que>();
-	const int num = 10;
-	int cnter = 0;
-	double time = double();
+BOOST_AUTO_TEST_CASE(tqueue_ordered_test) {
+    TQueue<pq_que> tq = TQueue<pq_que>();
+    const int num = 10;
+    int cnter = 0;
+    double time = double();
 
-	//insert N items with time < N
-	for(int i = 0; i < num; ++i){
-		time = static_cast<double>(rand() % num);
-		tq.insert(time, NULL);
-	}
+    // insert N items with time < N
+    for (int i = 0; i < num; ++i) {
+        time = static_cast<double>(rand() % num);
+        tq.insert(time, NULL);
+    }
 
-	time = 0.0;
-	TQItem *item = NULL;
-	//dequeue all items and check that previous item time <= current item time
-	while((item = tq.atomic_dq(10.0)) != NULL){
-		BOOST_CHECK(time <= item->t_);
-		++cnter;
-		time = item->t_;
-		delete item;
-	}
-	BOOST_CHECK(cnter == num);
-	BOOST_CHECK(tq.pq_que_.size() == 0);
-	BOOST_CHECK(tq.least() == NULL);
+    time = 0.0;
+    TQItem* item = NULL;
+    // dequeue all items and check that previous item time <= current item time
+    while ((item = tq.atomic_dq(10.0)) != NULL) {
+        BOOST_CHECK(time <= item->t_);
+        ++cnter;
+        time = item->t_;
+        delete item;
+    }
+    BOOST_CHECK(cnter == num);
+    BOOST_CHECK(tq.pq_que_.size() == 0);
+    BOOST_CHECK(tq.least() == NULL);
 }
 
-BOOST_AUTO_TEST_CASE(tqueue_move_nolock){
-}
+BOOST_AUTO_TEST_CASE(tqueue_move_nolock) {}
 
-BOOST_AUTO_TEST_CASE(tqueue_remove){
-}
+BOOST_AUTO_TEST_CASE(tqueue_remove) {}
 
-BOOST_AUTO_TEST_CASE(threaddata_interthread_send){
-	NetCvodeThreadData nt = NetCvodeThreadData();
-	const size_t num = 6;
-	for(size_t i = 0; i < num; ++i)
-		nt.interthread_send(static_cast<double>(i), NULL, NULL);
+BOOST_AUTO_TEST_CASE(threaddata_interthread_send) {
+    NetCvodeThreadData nt = NetCvodeThreadData();
+    const size_t num = 6;
+    for (size_t i = 0; i < num; ++i)
+        nt.interthread_send(static_cast<double>(i), NULL, NULL);
 
-	BOOST_CHECK(nt.inter_thread_events_.size() == num);
+    BOOST_CHECK(nt.inter_thread_events_.size() == num);
 }
 /*
 BOOST_AUTO_TEST_CASE(threaddata_enqueue){
-	NetCvode n = NetCvode();
-	const int num = 6;
-	for(int i = 0; i < num; ++i)
-		n.p[1].interthread_send(static_cast<double>(i), NULL, NULL);
+    NetCvode n = NetCvode();
+    const int num = 6;
+    for(int i = 0; i < num; ++i)
+        n.p[1].interthread_send(static_cast<double>(i), NULL, NULL);
 
-	BOOST_CHECK(n.p[1].inter_thread_events_.size() == num);
+    BOOST_CHECK(n.p[1].inter_thread_events_.size() == num);
 
-	//enqueue the inter_thread_events_
-	n.p[1].enqueue(&n, &(n.p[1]));
-	BOOST_CHECK(n.p[1].inter_thread_events_.size() == 0);
-	BOOST_CHECK(n.p[1].tqe_->pq_que_.size() == num);
+    //enqueue the inter_thread_events_
+    n.p[1].enqueue(&n, &(n.p[1]));
+    BOOST_CHECK(n.p[1].inter_thread_events_.size() == 0);
+    BOOST_CHECK(n.p[1].tqe_->pq_que_.size() == num);
 
-	//cleanup priority queue
-	TQItem* item = NULL;
-	while((item = n.p[1].tqe_->atomic_dq(6.0)) != NULL)
-		delete item;
+    //cleanup priority queue
+    TQItem* item = NULL;
+    while((item = n.p[1].tqe_->atomic_dq(6.0)) != NULL)
+        delete item;
 }*/


### PR DESCRIPTION
  - #465 applied clang-format to the project but many header files were missed.
  - the reason for this was that include directory from build folder was added
     from which headers were included
  - considering how hpc-coding-convention exclude files (see BlueBrain/hpc-coding-conventions/pull/92),
     these header were ignored from the clang-format
  - In this PR we now add project directory into include prior to build directories
  - Perform clang-format on previously missing files

CI_BRANCHES:NEURON_BRANCH=master,
