### PR TITLE
Use enum Layout everywhere

### DIFF
--- a/coreneuron/io/core2nrn_data_return.cpp
+++ b/coreneuron/io/core2nrn_data_return.cpp
@@ -135,7 +135,7 @@ void core2nrn_data_return() {
             double* cndat = ml->data;
             int layout = corenrn.get_mech_data_layout()[mtype];
             int sz = corenrn.get_prop_param_size()[mtype];
-            if (layout == 0) { /* SoA */
+            if (layout == Layout::SoA) {
                 int stride = ml->_nodecount_padded;
                 if (permute) {
                     soa2aos_inverse_permute_copy(n, sz, stride, cndat, mdata, permute);

--- a/coreneuron/io/mem_layout_util.hpp
+++ b/coreneuron/io/mem_layout_util.hpp
@@ -19,11 +19,6 @@ namespace coreneuron {
 #define NRN_SOA_PAD 8
 #endif
 
-// If MATRIX_LAYOUT is 1 then a,b,d,rhs,v,area is not padded using NRN_SOA_PAD
-// When MATRIX_LAYOUT is 0 then mechanism pdata index values into _actual_v
-// and _actual_area data need to be updated.
-enum Layout { SoA = 0, AoS = 1 };
-
 #if !defined(LAYOUT)
 #define LAYOUT        Layout::AoS
 #define MATRIX_LAYOUT Layout::AoS

--- a/coreneuron/io/nrn_checkpoint.cpp
+++ b/coreneuron/io/nrn_checkpoint.cpp
@@ -88,11 +88,11 @@ T* chkpnt_soa2aos(T* data, int cnt, int sz, int layout, int* permute) {
     // original file order depends on padding and permutation.
     // Good for a, b, area, v, diam, Memb_list.data, or anywhere values do not change.
     T* d = new T[cnt * sz];
-    if (layout == 1) { /* AoS */
+    if (layout == Layout::AoS) {
         for (int i = 0; i < cnt * sz; ++i) {
             d[i] = data[i];
         }
-    } else if (layout == 0) { /* SoA */
+    } else if (layout == Layout::SoA) {
         int align_cnt = nrn_soa_padded_size(cnt, layout);
         for (int i = 0; i < cnt; ++i) {
             int ip = i;
@@ -328,7 +328,7 @@ static void write_phase2(NrnThread& nt, FileHandlerWrap& fh) {
                             int p = d[ix] - (eml->data - nt._data);
                             int ei_instance, ei;
                             nrn_inverse_i_layout(p, ei_instance, ecnt, ei, esz, elayout);
-                            if (elayout == 0) {
+                            if (elayout == Layout::SoA) {
                                 if (eml->_permute) {
                                     if (!ml_pinv[etype]) {
                                         ml_pinv[etype] = inverse_permute(eml->_permute,

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -654,10 +654,10 @@ double* stdindex2ptr(int mtype, int index, NrnThread& nt) {
 
 // from i to (icnt, isz)
 void nrn_inverse_i_layout(int i, int& icnt, int cnt, int& isz, int sz, int layout) {
-    if (layout == 1) {
+    if (layout == Layout::AoS) {
         icnt = i / sz;
         isz = i % sz;
-    } else if (layout == 0) {
+    } else if (layout == Layout::SoA) {
         int padded_cnt = nrn_soa_padded_size(cnt, layout);
         icnt = i % padded_cnt;
         isz = i / padded_cnt;

--- a/coreneuron/io/setup_fornetcon.cpp
+++ b/coreneuron/io/setup_fornetcon.cpp
@@ -64,9 +64,9 @@ static int* fornetcon_slot(const int mtype,
     int sz = corenrn.get_prop_dparam_size()[mtype];
     Memb_list* ml = nt._ml_list[mtype];
     int* fn = nullptr;
-    if (layout == 1) { /* AoS */
+    if (layout == Layout::AoS) {
         fn = ml->pdata + (instance * sz + fnslot);
-    } else if (layout == 0) { /* SoA */
+    } else if (layout == Layout::SoA) {
         int padded_cnt = nrn_soa_padded_size(ml->nodecount, layout);
         fn = ml->pdata + (fnslot * padded_cnt + instance);
     }

--- a/coreneuron/mechanism/patternstim.cpp
+++ b/coreneuron/mechanism/patternstim.cpp
@@ -86,10 +86,10 @@ void nrn_mkPatternStim(const char* fname, double tstop) {
     int _iml = pnt->_i_instance;
     double* _p = ml->data;
     Datum* _ppvar = ml->pdata;
-    if (layout == 1) {
+    if (layout == Layout::AoS) {
         _p += _iml * sz;
         _ppvar += _iml * psz;
-    } else if (layout == 0) {
+    } else if (layout == Layout::SoA) {
         ;
     } else {
         assert(0);

--- a/coreneuron/nrniv/nrniv_decl.h
+++ b/coreneuron/nrniv/nrniv_decl.h
@@ -71,5 +71,10 @@ extern int nrn_soa_padded_size(int cnt, int layout);
 
 extern int interleave_permute_type;
 extern int cellorder_nwarp;
+
+// If MATRIX_LAYOUT is 1 then a,b,d,rhs,v,area is not padded using NRN_SOA_PAD
+// When MATRIX_LAYOUT is 0 then mechanism pdata index values into _actual_v
+// and _actual_area data need to be updated.
+enum Layout { SoA = 0, AoS = 1 };
 }  // namespace coreneuron
 #endif

--- a/coreneuron/permute/node_permute.cpp
+++ b/coreneuron/permute/node_permute.cpp
@@ -93,7 +93,7 @@ void permute(T* data, int cnt, int sz, int layout, int* p) {
         return;
     }
 
-    if (layout == 0) {  // for SoA, n might be larger due to cnt padding
+    if (layout == Layout::SoA) {  // for SoA, n might be larger due to cnt padding
         n = nrn_soa_padded_size(cnt, layout) * sz;
     }
 
@@ -208,12 +208,12 @@ void update_pdata_values(Memb_list* ml, int type, NrnThread& nt) {
                 int ix = *pd - edata0;
                 // from ix determine i_ecnt and i_esz (need to permute i_ecnt)
                 int i_ecnt, i_esz, padded_ecnt;
-                if (elayout == 1) {  // AoS
+                if (elayout == Layout::AoS) {
                     padded_ecnt = ecnt;
                     i_ecnt = ix / esz;
                     i_esz = ix % esz;
                 } else {  // SoA
-                    assert(elayout == 0);
+                    assert(elayout == Layout::SoA);
                     padded_ecnt = nrn_soa_padded_size(ecnt, elayout);
                     i_ecnt = ix % padded_ecnt;
                     i_esz = ix / padded_ecnt;
@@ -258,13 +258,13 @@ int nrn_index_permute(int ix, int type, Memb_list* ml) {
         return ix;
     }
     int layout = corenrn.get_mech_data_layout()[type];
-    if (layout == 1) {
+    if (layout == Layout::AoS) {
         int sz = corenrn.get_prop_param_size()[type];
         int i_cnt = ix / sz;
         int i_sz = ix % sz;
         return p[i_cnt] * sz + i_sz;
     } else {
-        assert(layout == 0);
+        assert(layout == Layout::SoA);
         int padded_cnt = nrn_soa_padded_size(ml->nodecount, layout);
         int i_cnt = ix % padded_cnt;
         int i_sz = ix / padded_cnt;

--- a/coreneuron/utils/memory.h
+++ b/coreneuron/utils/memory.h
@@ -13,6 +13,7 @@
 #include <cstring>
 
 #include "coreneuron/utils/nrn_assert.h"
+#include "coreneuron/nrniv/nrniv_decl.h"
 
 #if !defined(NRN_SOA_BYTE_ALIGN)
 // for layout 0, every range variable array must be aligned by at least 16 bytes (the size of the
@@ -109,7 +110,7 @@ namespace coreneuron {
 template <int chunk>
 inline int soa_padded_size(int cnt, int layout) {
     int imod = cnt % chunk;
-    if (layout == 1)
+    if (layout == Layout::AoS)
         return cnt;
     if (imod) {
         int idiv = cnt / chunk;


### PR DESCRIPTION
An enum exists to know that 0 mean SoA and 1 AoS, use it.

I have to move it, so that enum is available everywhere.

CI_BRANCHES:NEURON_BRANCH=master,
