### PR TITLE
Add codecov coverage tests

### DIFF
--- a/.github/workflows/coreneuron-ci.yml
+++ b/.github/workflows/coreneuron-ci.yml
@@ -171,7 +171,8 @@ jobs:
           sudo apt-get install doxygen bison flex libboost-all-dev libopenmpi-dev openmpi-bin python3-dev python3-pip lcov
         shell: bash
       - uses: actions/checkout@v2
-        fetch-depth: 2
+        with:
+          fetch-depth: 2
       - name: Build and Test for Coverage
         id: build-test
         shell: bash
@@ -186,5 +187,3 @@ jobs:
           lcov --add-tracefile coverage-base.info --add-tracefile coverage-run.info --output-file coverage-combined.info
           genhtml coverage-combined.info --output-directory coverage --demangle-cpp --ignore-errors source
           bash <(curl -s https://codecov.io/bash)
-        env:
-          CODECOV_TOKEN: "bf236b89-a8e0-4dbf-9661-b26e9e4f50de"

--- a/.github/workflows/coreneuron-ci.yml
+++ b/.github/workflows/coreneuron-ci.yml
@@ -161,3 +161,30 @@ jobs:
 #           BRANCH: gh-pages # The branch the action should deploy to.
 #           FOLDER: ${{runner.workspace}}/nrn/build/docs # The folder the action should deploy.
 #           CLEAN: false # Automatically remove deleted files from the deploy branch
+  coverage:
+    runs-on: ubuntu-16.04
+    name: "Coverage Test"
+    env:
+      INSTALL_DIR: install
+    steps:
+      - name: Install packages
+        run: |
+          sudo apt-get install doxygen bison flex libboost-all-dev libopenmpi-dev openmpi-bin python3-dev python3-pip lcov
+        shell: bash
+      - uses: actions/checkout@v2
+      - name: Build and Test for Coverage
+        id: build-test
+        shell: bash
+        working-directory: ${{runner.workspace}}/CoreNeuron
+        run:  |
+          mkdir build && cd build
+          cmake .. -DCORENRN_ENABLE_MPI=ON -DCMAKE_C_FLAGS="-coverage -O0" -DCMAKE_CXX_FLAGS="-coverage -O0";
+          make
+          (cd ..;  lcov --capture  --initial --directory . --no-external --output-file build/coverage-base.info)
+          make test
+          (cd ..; lcov --capture  --directory . --no-external --output-file build/coverage-run.info)
+          lcov --add-tracefile coverage-base.info --add-tracefile coverage-run.info --output-file coverage-combined.info
+          genhtml coverage-combined.info --output-directory coverage --demangle-cpp --ignore-errors source
+          bash <(curl -s https://codecov.io/bash)
+        env:
+          CODECOV_TOKEN: "bf236b89-a8e0-4dbf-9661-b26e9e4f50de"

--- a/.github/workflows/coreneuron-ci.yml
+++ b/.github/workflows/coreneuron-ci.yml
@@ -2,7 +2,7 @@ name: CoreNEURON CI
 
 on:
   push:
-    branches: 
+    branches:
       - master
       - live-debug*
       - release/**
@@ -59,8 +59,8 @@ jobs:
         run: |
           sudo apt-get install g++-${GCC_VERSION}
         shell: bash
-        env: 
-          GCC_VERSION: ${{ matrix.config.gcc_version }} 
+        env:
+          GCC_VERSION: ${{ matrix.config.gcc_version }}
 
       - name: Set up Python3
         uses: actions/setup-python@v2
@@ -88,7 +88,7 @@ jobs:
         if: ${{ matrix.config.use_nmodl == 'ON' ||  matrix.config.use_ispc == 'ON' }}
         run: |
           python3 -m pip install --upgrade pip jinja2 pyyaml pytest "sympy<1.6";
-       
+
       - uses: actions/checkout@v2
 
       - name: Install Python3 documentation dependencies
@@ -97,7 +97,7 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install --upgrade -r docs/docs_requirements.txt
-        
+
       - name: Build and Test
         id: build-test
         shell: bash
@@ -124,7 +124,7 @@ jobs:
           fi
           make
           ctest --output-on-failure
-          make install         
+          make install
         env:
           cmake_option: ${{ matrix.config.cmake_option }}
           USE_ISPC: ${{ matrix.config.use_ispc }}
@@ -139,8 +139,7 @@ jobs:
       - name: live debug session on failure
         if: failure() && startsWith(github.ref, 'refs/heads/live-debug')
         uses: mxschmitt/action-tmate@v3
-
-      - name: Documentation 
+      - name: Documentation
         if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.config.documentation == 'ON' }}
         id: documentation
         working-directory: ${{runner.workspace}}/CoreNeuron
@@ -172,6 +171,7 @@ jobs:
           sudo apt-get install doxygen bison flex libboost-all-dev libopenmpi-dev openmpi-bin python3-dev python3-pip lcov
         shell: bash
       - uses: actions/checkout@v2
+        fetch-depth: 2
       - name: Build and Test for Coverage
         id: build-test
         shell: bash

--- a/.github/workflows/coreneuron-ci.yml
+++ b/.github/workflows/coreneuron-ci.yml
@@ -163,8 +163,6 @@ jobs:
   coverage:
     runs-on: ubuntu-16.04
     name: "Coverage Test"
-    env:
-      INSTALL_DIR: install
     steps:
       - name: Install packages
         run: |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/BlueBrain/CoreNeuron.svg?branch=master)](https://travis-ci.org/BlueBrain/CoreNeuron) ![CoreNEURON CI](https://github.com/BlueBrain/CoreNeuron/workflows/CoreNEURON%20CI/badge.svg)
+[![Build Status](https://travis-ci.org/BlueBrain/CoreNeuron.svg?branch=master)](https://travis-ci.org/BlueBrain/CoreNeuron) ![CoreNEURON CI](https://github.com/BlueBrain/CoreNeuron/workflows/CoreNEURON%20CI/badge.svg) [![codecov](https://codecov.io/gh/BlueBrain/CoreNeuron/branch/master/graph/badge.svg?token=mguTdBx93p)](https://codecov.io/gh/BlueBrain/CoreNeuron)
 
 # CoreNEURON
 > Optimised simulator engine for [NEURON](https://github.com/neuronsimulator/nrn)


### PR DESCRIPTION
**Description**

Use gcov/lcov to generate coverage reports on running `make test` and report coverage in codecov.io


**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
