### PR TITLE
Avoid duplicating `acc --oacc` arguments to NMODL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,9 +274,6 @@ if(CORENRN_ENABLE_NMODL)
   set(CORENRN_NMODL_FLAGS
       ""
       CACHE STRING "Extra NMODL options such as passes")
-  if(CORENRN_ENABLE_GPU)
-    string(APPEND CORENRN_NMODL_FLAGS " acc --oacc")
-  endif()
 else()
   include(AddMod2cSubmodule)
   set(CORENRN_MOD2CPP_BINARY ${CMAKE_BINARY_DIR}/bin/mod2c_core${CMAKE_EXECUTABLE_SUFFIX})

--- a/tests/jenkins/run_neuron.sh
+++ b/tests/jenkins/run_neuron.sh
@@ -23,7 +23,7 @@ if [ "${TEST_DIR}" = "testcorenrn" ]; then
     rm out${TEST}.dat
 elif [ "${TEST_DIR}" = "ringtest" ]; then
     mkdir ${TEST}
-    mpirun -n 6 ./x86_64/special ringtest.py -mpi
+    mpirun -n 6 ./x86_64/special ringtest.py -mpi -dumpmodel
     if [ ! -f spk6.std ]; then
       echo "Neuron simulation didn't run correctly"
       exit 1

--- a/tests/jenkins/run_neuron.sh
+++ b/tests/jenkins/run_neuron.sh
@@ -24,11 +24,11 @@ if [ "${TEST_DIR}" = "testcorenrn" ]; then
 elif [ "${TEST_DIR}" = "ringtest" ]; then
     mkdir ${TEST}
     mpirun -n 6 ./x86_64/special ringtest.py -mpi
-    if [ ! -f coredat/spk6.std ]; then
+    if [ ! -f spk6.std ]; then
       echo "Neuron simulation didn't run correctly"
       exit 1
     fi
-    cat coredat/spk6.std | sort -k 1n,1n -k 2n,2n > ${TEST}/out_nrn_${TEST}.spk
+    cat spk6.std | sort -k 1n,1n -k 2n,2n > ${TEST}/out_nrn_${TEST}.spk
 elif [ "${TEST_DIR}" = "tqperf" ]; then
     mkdir ${TEST}
     mpirun -n ${MPI_RANKS} ./x86_64/special -c tstop=50 run.hoc -mpi


### PR DESCRIPTION
**Description**

When both `CORENRN_ENABLE_NMODL` and `CORENRN_ENABLE_GPU` are true then these arguments were added twice, which triggers a compilation error:
```
  file: File does not exist: acc
```

This PR removes the duplication. It arises because in this case [we take](https://github.com/BlueBrain/CoreNeuron/blob/88e02a533764de29aadfcddec2eb0b64ca1ff884/extra/nrnivmodl_core_makefile.in#L73)
```
        nmodl_arguments_c=@NMODL_ACC_BACKEND_ARGS@ @NMODL_COMMON_ARGS@
```
where [`NMODL_ACC_BACKEND_ARGS` contains `acc --oacc`](https://github.com/BlueBrain/CoreNeuron/blob/88e02a533764de29aadfcddec2eb0b64ca1ff884/CMake/MakefileBuildOptions.cmake#L29) and [`NMODL_COMMON_ARGS` includes `CORENRN_NMODL_FLAGS`](https://github.com/BlueBrain/CoreNeuron/blob/88e02a533764de29aadfcddec2eb0b64ca1ff884/CMake/MakefileBuildOptions.cmake#L24), which (without this PR) also contains `acc --oacc` if `CORENRN_ENABLE_GPU` is set.

**How to test this?**

My CMake invocation was:
```
cmake .. -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF -DCORENRN_ENABLE_GPU=ON -DCORENRN_ENABLE_NMODL=ON
```
Using CUDA and the NVHPC toolkit compilers (on BB5).

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,