### PR TITLE
Fixes neuron_direct test in the Jenkins CI

### DIFF
--- a/tests/jenkins/run_neuron.sh
+++ b/tests/jenkins/run_neuron.sh
@@ -23,12 +23,12 @@ if [ "${TEST_DIR}" = "testcorenrn" ]; then
     rm out${TEST}.dat
 elif [ "${TEST_DIR}" = "ringtest" ]; then
     mkdir ${TEST}
-    mpirun -n 6 ./x86_64/special ringtest.py -mpi
-    if [ ! -f coredat/spk6.std ]; then
+    mpirun -n 6 ./x86_64/special ringtest.py -mpi -dumpmodel
+    if [ ! -f spk6.std ]; then
       echo "Neuron simulation didn't run correctly"
       exit 1
     fi
-    cat coredat/spk6.std | sort -k 1n,1n -k 2n,2n > ${TEST}/out_nrn_${TEST}.spk
+    cat spk6.std | sort -k 1n,1n -k 2n,2n > ${TEST}/out_nrn_${TEST}.spk
 elif [ "${TEST_DIR}" = "tqperf" ]; then
     mkdir ${TEST}
     mpirun -n ${MPI_RANKS} ./x86_64/special -c tstop=50 run.hoc -mpi

--- a/tests/jenkins/run_neuron_direct.sh
+++ b/tests/jenkins/run_neuron_direct.sh
@@ -22,7 +22,7 @@ ls -la x86_64
 module unload intel
 
 # run test sim with external mechanism
-mpirun -n 1 ./x86_64/special -python -mpi $WORKSPACE/tests/jenkins/neuron_direct.py
+mpirun -n 1 ./x86_64/special -python -mpi $WORKSPACE/tests/jenkins/neuron_direct.py | grep "Voltage times and i_membrane_ are same and difference is less than 1e-10"
 
 # remove build directory
 cd -

--- a/tests/jenkins/run_neuron_direct.sh
+++ b/tests/jenkins/run_neuron_direct.sh
@@ -14,15 +14,15 @@ build_dir=$(mktemp -d $(pwd)/build_XXXX)
 cd $build_dir
 
 # build special and special-core
-nrnivmodl ../tests/jenkins/mod
 nrnivmodl-core ../tests/jenkins/mod
+nrnivmodl ../tests/jenkins/mod
 ls -la x86_64
 
 # Unload intel module to avoid issue whith mpirun
 module unload intel
 
 # run test sim with external mechanism
-mpirun -n 1 nrniv -python $WORKSPACE/tests/jenkins/neuron_direct.py -mpi
+mpirun -n 1 ./x86_64/special -python -mpi $WORKSPACE/tests/jenkins/neuron_direct.py
 
 # remove build directory
 cd -


### PR DESCRIPTION
**Description**

Fixes neuron direct test run in Jenkins pipeline CI.
The test was failing with the following output:
```
 mpirun -n 1 nrniv -python /jenkins/07/workspace/oss.coreneuron.pipeline/tests/jenkins/neuron_direct.py -mpi
numprocs=1
NEURON -- VERSION + master (d28fcb8+) 2021-01-30
Duke, Yale, and the BlueBrain Project -- Copyright 1984-2019
See http://neuron.yale.edu/neuron/credits
Traceback (most recent call last):
  File "/jenkins/07/workspace/oss.coreneuron.pipeline/tests/jenkins/neuron_direct.py", line 14, in <module>
    h.soma.insert("CaDynamics_E2")
ValueError: argument not a density mechanism name.
>>> 
+ cd -
/jenkins/07/workspace/oss.coreneuron.pipeline
+ rm -rf /jenkins/07/workspace/oss.coreneuron.pipeline/build_Wonv
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
Traceback (most recent call last):
  File "/jenkins/07/workspace/oss.coreneuron.pipeline/tests/jenkins/neuron_direct.py", line 14, in <module>
    h.soma.insert("CaDynamics_E2")
ValueError: argument not a density mechanism name.
>>> 
```
The problem was that when `nrnivmodl-core` runs after `nrnivmodl` it deletes the `.libs` folder inside `x86_64` and neuron cannot find the proper library inside `.libs`.

- [x] Fixed above issue
- [x] Added pipe to `grep` after running the sim to make sure that the proper output message is printed after a successful run

**How to test this?**

Check the `neuron_direct` tests in the Jenkins pipeline CI of `CoreNEURON`.