### PR TITLE
[Trivial] Fix compilation if git signatures shown by default

### DIFF
--- a/CMake/GitRevision.cmake
+++ b/CMake/GitRevision.cmake
@@ -14,13 +14,13 @@ find_package(Git)
 if(GIT_FOUND)
   # get last commit sha1
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
+    COMMAND ${GIT_EXECUTABLE} -c log.showSignature=false log -1 --format=%h
     WORKING_DIRECTORY ${CORENEURON_PROJECT_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_REVISION_SHA1
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
   # get last commit date
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} show -s --format=%ci
+    COMMAND ${GIT_EXECUTABLE} -c log.showSignature=false show -s --format=%ci
     WORKING_DIRECTORY ${CORENEURON_PROJECT_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_REVISION_DATE
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
**Description**

Without this change then the presence of:
```
[log]
  showSignature = True
```
in the local `~/.gitconfig` file breaks compilation of CoreNEURON because the signature information is not escaped properly for inclusion in the generated C++ string literal.

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,

(see also: https://github.com/neuronsimulator/nrn/pull/955)