### PR TITLE
Cherry-pick bug fixes from master for release/1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,9 +269,6 @@ if(CORENRN_ENABLE_NMODL)
   set(CORENRN_NMODL_FLAGS
       ""
       CACHE STRING "Extra NMODL options such as passes")
-  if(CORENRN_ENABLE_GPU)
-    string(APPEND CORENRN_NMODL_FLAGS " acc --oacc")
-  endif()
 else()
   include(AddMod2cSubmodule)
   set(CORENRN_MOD2CPP_BINARY ${CMAKE_BINARY_DIR}/bin/mod2c_core${CMAKE_EXECUTABLE_SUFFIX})

--- a/tests/jenkins/run_neuron.sh
+++ b/tests/jenkins/run_neuron.sh
@@ -23,12 +23,12 @@ if [ "${TEST_DIR}" = "testcorenrn" ]; then
     rm out${TEST}.dat
 elif [ "${TEST_DIR}" = "ringtest" ]; then
     mkdir ${TEST}
-    mpirun -n 6 ./x86_64/special ringtest.py -mpi
-    if [ ! -f coredat/spk6.std ]; then
+    mpirun -n 6 ./x86_64/special ringtest.py -mpi -dumpmodel
+    if [ ! -f spk6.std ]; then
       echo "Neuron simulation didn't run correctly"
       exit 1
     fi
-    cat coredat/spk6.std | sort -k 1n,1n -k 2n,2n > ${TEST}/out_nrn_${TEST}.spk
+    cat spk6.std | sort -k 1n,1n -k 2n,2n > ${TEST}/out_nrn_${TEST}.spk
 elif [ "${TEST_DIR}" = "tqperf" ]; then
     mkdir ${TEST}
     mpirun -n ${MPI_RANKS} ./x86_64/special -c tstop=50 run.hoc -mpi

--- a/tests/jenkins/run_neuron_direct.sh
+++ b/tests/jenkins/run_neuron_direct.sh
@@ -14,15 +14,15 @@ build_dir=$(mktemp -d $(pwd)/build_XXXX)
 cd $build_dir
 
 # build special and special-core
-nrnivmodl ../tests/jenkins/mod
 nrnivmodl-core ../tests/jenkins/mod
+nrnivmodl ../tests/jenkins/mod
 ls -la x86_64
 
 # Unload intel module to avoid issue whith mpirun
 module unload intel
 
 # run test sim with external mechanism
-mpirun -n 1 nrniv -python $WORKSPACE/tests/jenkins/neuron_direct.py -mpi
+mpirun -n 1 ./x86_64/special -python -mpi $WORKSPACE/tests/jenkins/neuron_direct.py | grep "Voltage times and i_membrane_ are same and difference is less than 1e-10"
 
 # remove build directory
 cd -


### PR DESCRIPTION
* Fixes neuron_direct test in the Jenkins CI (#487)
* Avoid duplicating `acc --oacc` arguments to NMODL (#486)

CI_BRANCHES:NEURON_BRANCH=master,
