### PR TITLE
Pass PI value from NEURON to CoreNEURON

### DIFF
--- a/coreneuron/io/global_vars.cpp
+++ b/coreneuron/io/global_vars.cpp
@@ -48,6 +48,7 @@ void set_globals(const char* path, bool cli_global_seed, int cli_global_seed_val
     (*n2v)["celsius"] = PSD(0, &celsius);
     (*n2v)["dt"] = PSD(0, &dt);
     (*n2v)["t"] = PSD(0, &t);
+    (*n2v)["PI"] = PSD(0, &pi);
 
     if (corenrn_embedded) {  // CoreNEURON embedded, get info direct from NEURON
 

--- a/coreneuron/io/lfp.hpp
+++ b/coreneuron/io/lfp.hpp
@@ -6,8 +6,7 @@
 #include <iostream>
 #include <vector>
 
-#include <boost/math/constants/constants.hpp>
-
+#include "coreneuron/nrnconf.h"
 #include "coreneuron/utils/nrn_assert.h"
 #include "coreneuron/mpi/nrnmpidec.h"
 
@@ -156,7 +155,7 @@ struct LFPCalculator {
         if (seg_start.size() != radius.size()) {
             throw std::invalid_argument("Different number of segments and radii.");
         }
-        double f(1.0 / (extra_cellular_conductivity * 4.0 * boost::math::constants::pi<double>()));
+        double f(1.0 / (extra_cellular_conductivity * 4.0 * pi));
 
         m.resize(electrodes.size());
         for (size_t k = 0; k < electrodes.size(); ++k) {

--- a/coreneuron/mechanism/register_mech.cpp
+++ b/coreneuron/mechanism/register_mech.cpp
@@ -19,10 +19,11 @@
 
 namespace coreneuron {
 int secondorder = 0;
-double t, dt, celsius;
+double t, dt, celsius, pi;
 // declare copyin required for correct initialization
 #pragma acc declare copyin(secondorder)
 #pragma acc declare copyin(celsius)
+#pragma acc declare copyin(pi)
 int rev_dt;
 
 using Pfrv = void (*)();

--- a/coreneuron/nrnconf.h
+++ b/coreneuron/nrnconf.h
@@ -32,6 +32,7 @@ using Symbol = char;
 #define VECTORIZE   1
 
 extern double celsius;
+extern double pi;
 
 extern double t, dt;
 extern int rev_dt;

--- a/tests/unit/alignment/alignment.cpp
+++ b/tests/unit/alignment/alignment.cpp
@@ -14,7 +14,6 @@
 #include <stdint.h>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/test/test_case_template.hpp>
 #include <boost/mpl/list.hpp>
 
 #include "coreneuron/utils/memory.h"

--- a/tests/unit/lfp/lfp.cpp
+++ b/tests/unit/lfp/lfp.cpp
@@ -4,10 +4,11 @@
 #include <iostream>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/test/test_case_template.hpp>
 
 #include "coreneuron/io/lfp.hpp"
 #include "coreneuron/mpi/nrnmpi.h"
+
+using namespace coreneuron;
 
 template <typename F>
 double integral(F f, double a, double b, int n) {
@@ -28,7 +29,6 @@ std::array<double, 3> operator+(const std::array<double, 3>& x, const std::array
 }
 
 BOOST_AUTO_TEST_CASE(LFP_PointSource_LineSource) {
-    using namespace coreneuron;
 #if NRNMPI
     nrnmpi_init(nullptr, nullptr);
 #endif
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(LFP_PointSource_LineSource) {
     std::array<double, 3> segment_end = segment_start +
                                         std::array<double, 3>{0.0, 0.0, segment_length};
     double floor{1.0e-6};
-    double pi{3.141592653589};
+    pi = 3.141592653589;
 
     std::array<double, 10> vals;
     double circling_radius{1.0e-6};

--- a/tests/unit/queueing/test_queueing.cpp
+++ b/tests/unit/queueing/test_queueing.cpp
@@ -10,7 +10,6 @@
 #define TYPE              T::cont
 
 #include <boost/test/unit_test.hpp>
-#include <boost/test/test_case_template.hpp>
 #include <boost/filesystem.hpp>
 
 #include <cstdlib>


### PR DESCRIPTION
**Description**

In the `lfp` PR during the calculation of `lfp` there is a variable `PI` used. The value of this variable should be same as `NEURON` and the variable used by the mod files.

- [x] Created new pi global parameter which is read by NEURON `globals.dat` or directly NEURON in online mode
- [x] Use this pi in lfp calculation and test
- [x] Removed a deprecated boost test header file
