### PR TITLE
Enable CoreNEURON tests when running as a submodule of NEURON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND CMAKE_MODULE_PATH ${CORENEURON_PROJECT_SOURCE_DIR}/CMake
 # HPC Coding Conventions
 # =============================================================================
 set(CODING_CONV_PREFIX "CORENRN")
+set(CORENRN_3RDPARTY_DIR "external")
 set(CORENRN_ClangFormat_EXCLUDES_RE
     ".*/external/.*$$"
     CACHE STRING "list of regular expressions to exclude C/C++ files from formatting" FORCE)
@@ -93,10 +94,6 @@ set(CORENRN_NMODL_DIR
 set(LIKWID_DIR
     ""
     CACHE PATH "Path to likwid performance analysis suite")
-
-if(CORENEURON_AS_SUBPROJECT)
-  set(CORENRN_ENABLE_UNIT_TESTS OFF)
-endif()
 
 # =============================================================================
 # Project version from git and project directories

--- a/tests/unit/alignment/CMakeLists.txt
+++ b/tests/unit/alignment/CMakeLists.txt
@@ -3,16 +3,13 @@
 #
 # See top-level LICENSE file for details.
 # =============================================================================
-
 include_directories(${CMAKE_SOURCE_DIR}/coreneuron ${Boost_INCLUDE_DIRS})
-file(GLOB alignment_test_src "*.cpp")
 
-add_executable(alignment_test_bin ${alignment_test_src})
+add_executable(alignment_test_bin alignment.cpp)
 target_link_libraries(alignment_test_bin ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 
 if(CORENRN_ENABLE_GPU)
   target_link_libraries(alignment_test_bin ${link_cudacoreneuron} ${CUDA_LIBRARIES})
 endif()
 
-add_test(NAME alignment_test COMMAND ${TEST_EXEC_PREFIX}
-                                     ${CMAKE_CURRENT_BINARY_DIR}/alignment_test_bin)
+add_test(NAME alignment_test COMMAND ${TEST_EXEC_PREFIX} $<TARGET_FILE:alignment_test_bin>)

--- a/tests/unit/cmdline_interface/CMakeLists.txt
+++ b/tests/unit/cmdline_interface/CMakeLists.txt
@@ -3,10 +3,7 @@
 #
 # See top-level LICENSE file for details.
 # =============================================================================
-
-file(GLOB cmd_interface_test_src "*.cpp")
-
-add_executable(cmd_interface_test_bin ${cmd_interface_test_src})
+add_executable(cmd_interface_test_bin test_cmdline_interface.cpp)
 target_link_libraries(
   cmd_interface_test_bin
   ${MPI_CXX_LIBRARIES}
@@ -19,5 +16,4 @@ target_include_directories(cmd_interface_test_bin SYSTEM
                            PRIVATE ${CORENEURON_PROJECT_SOURCE_DIR}/external/CLI11/include)
 add_dependencies(cmd_interface_test_bin nrniv-core)
 
-add_test(NAME cmd_interface_test COMMAND ${TEST_EXEC_PREFIX}
-                                         ${CMAKE_CURRENT_BINARY_DIR}/cmd_interface_test_bin)
+add_test(NAME cmd_interface_test COMMAND ${TEST_EXEC_PREFIX} $<TARGET_FILE:cmd_interface_test_bin>)

--- a/tests/unit/interleave_info/CMakeLists.txt
+++ b/tests/unit/interleave_info/CMakeLists.txt
@@ -3,10 +3,7 @@
 #
 # See top-level LICENSE file for details.
 # =============================================================================
-
-file(GLOB interleave_info_src "*.cpp")
-
-add_executable(interleave_info_bin ${interleave_info_src})
+add_executable(interleave_info_bin check_constructors.cpp)
 target_link_libraries(
   interleave_info_bin
   ${MPI_CXX_LIBRARIES}
@@ -17,5 +14,5 @@ target_link_libraries(
   ${sonatareport_LIBRARY})
 add_dependencies(interleave_info_bin nrniv-core)
 
-add_test(NAME interleave_info_constructor_test
-         COMMAND ${TEST_EXEC_PREFIX} ${CMAKE_CURRENT_BINARY_DIR}/interleave_info_bin)
+add_test(NAME interleave_info_constructor_test COMMAND ${TEST_EXEC_PREFIX}
+                                                       $<TARGET_FILE:interleave_info_bin>)

--- a/tests/unit/queueing/CMakeLists.txt
+++ b/tests/unit/queueing/CMakeLists.txt
@@ -3,10 +3,7 @@
 #
 # See top-level LICENSE file for details.
 # =============================================================================
-
-file(GLOB queuing_test_src "*.cpp")
-
-add_executable(queuing_test_bin ${queuing_test_src})
+add_executable(queuing_test_bin test_queueing.cpp)
 target_link_libraries(
   queuing_test_bin
   ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
@@ -17,4 +14,4 @@ target_link_libraries(
   ${sonatareport_LIBRARY})
 add_dependencies(queuing_test_bin nrniv-core)
 
-add_test(NAME queuing_test COMMAND ${TEST_EXEC_PREFIX} ${CMAKE_CURRENT_BINARY_DIR}/queuing_test_bin)
+add_test(NAME queuing_test COMMAND ${TEST_EXEC_PREFIX} $<TARGET_FILE:queuing_test_bin>)


### PR DESCRIPTION
**Description**

- CoreNEURON's CTest tests may now run as part of the top-level `make test` target when CoreNEURON is built as a submodule of NEURON.
- Removed some trivial usage of `file(GLOB ...)` to collect lists of source files. [The CMake documentation advises against this pattern](https://cmake.org/cmake/help/v3.19/command/file.html#glob).

    
**How to test this?**

Build NEURON with `-DNRN_ENABLE_CORENEURON=ON` and `-DNRN_ENABLE_TESTS=ON`, changing `nrn/external/coreneuron` to point at this branch. Run `make test` in the NEURON build directory.

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,