### PR TITLE
Prevent nrnivmodl running on every build

### DIFF
--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -157,16 +157,16 @@ set_target_properties(
 # =============================================================================
 set(modfile_directory "${CORENEURON_PROJECT_SOURCE_DIR}/tests/integration/ring_gap/mod")
 file(GLOB modfiles "${modfile_directory}/*.mod")
-set(special_name "${CMAKE_BINARY_DIR}/bin/${CMAKE_SYSTEM_PROCESSOR}/special")
-set(output_binaries "${special}" "${special_name}-core")
+set(output_binaries "${CMAKE_BINARY_DIR}/bin/${CMAKE_SYSTEM_PROCESSOR}/special-core"
+                    "${CMAKE_BINARY_DIR}/bin/${CMAKE_SYSTEM_PROCESSOR}/libcorenrnmech.a")
 add_custom_command(
   OUTPUT ${output_binaries}
-  DEPENDS nrniv_lib scopmath coreneuron ${NMODL_TARGET_TO_DEPEND} ${modfiles}
+  DEPENDS scopmath coreneuron ${NMODL_TARGET_TO_DEPEND} ${modfiles}
   COMMAND ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core -b STATIC -m ${CORENRN_MOD2CPP_BINARY} -p 1
           "${modfile_directory}"
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   COMMENT "Running nrnivmodl-core with halfgap.mod")
-add_custom_target(nrniv-core DEPENDS ${output_binaries})
+add_custom_target(nrniv-core ALL DEPENDS ${output_binaries})
 
 include_directories(${CORENEURON_PROJECT_SOURCE_DIR})
 

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -53,9 +53,29 @@ set(KINDERIV_HEADER_FILE "${CMAKE_CURRENT_BINARY_DIR}/_kinderiv.h")
 
 set(NMODL_UNITS_FILE "${CMAKE_BINARY_DIR}/share/mod2c/nrnunits.lib")
 
-# copy inbuilt mod files to share
-file(COPY ${CORENEURON_PROJECT_SOURCE_DIR}/coreneuron/mechanism/mech/modfile
-     DESTINATION ${CMAKE_BINARY_DIR}/share)
+# copy inbuilt mod files {source}/coreneuron/mechanism/mech/modfile/*.mod to
+# {build_dir}/share/modfile/
+file(GLOB builtin_modfiles
+     "${CORENEURON_PROJECT_SOURCE_DIR}/coreneuron/mechanism/mech/modfile/*.mod")
+# get the corresponding list of paths to the modfiles in the build directory
+set(builtin_modfile_in_build_dir)
+foreach(builtin_modfile ${builtin_modfiles})
+  get_filename_component(builtin_modfile_name "${builtin_modfile}" NAME)
+  list(APPEND builtin_modfile_in_build_dir
+       "${CMAKE_BINARY_DIR}/share/modfile/${builtin_modfile_name}")
+endforeach()
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/share/modfile")
+# set up a build rule that ensures the modfiles in the build directory are updated if their
+# counterparts in the source directory are touched
+add_custom_command(
+  OUTPUT ${builtin_modfile_in_build_dir}
+  DEPENDS ${builtin_modfiles}
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${builtin_modfiles}
+          "${CMAKE_BINARY_DIR}/share/modfile")
+add_custom_target(copy-builtin-modfiles ALL DEPENDS ${builtin_modfile_in_build_dir})
+set(CORENEURON_BUILTIN_MODFILES
+    "${builtin_modfile_in_build_dir}"
+    CACHE STRING "List of builtin modfiles that nrnivmodl-core implicitly depends on" FORCE)
 
 # =============================================================================
 # coreneuron GPU library
@@ -161,7 +181,7 @@ set(output_binaries "${CMAKE_BINARY_DIR}/bin/${CMAKE_SYSTEM_PROCESSOR}/special-c
                     "${CMAKE_BINARY_DIR}/bin/${CMAKE_SYSTEM_PROCESSOR}/libcorenrnmech.a")
 add_custom_command(
   OUTPUT ${output_binaries}
-  DEPENDS scopmath coreneuron ${NMODL_TARGET_TO_DEPEND} ${modfiles}
+  DEPENDS scopmath coreneuron ${NMODL_TARGET_TO_DEPEND} ${modfiles} ${CORENEURON_BUILTIN_MODFILES}
   COMMAND ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core -b STATIC -m ${CORENRN_MOD2CPP_BINARY} -p 1
           "${modfile_directory}"
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -155,14 +155,18 @@ set_target_properties(
 # =============================================================================
 # create special-core with halfgap.mod for tests
 # =============================================================================
-add_custom_target(
-  nrniv-core ALL
+set(modfile_directory "${CORENEURON_PROJECT_SOURCE_DIR}/tests/integration/ring_gap/mod")
+file(GLOB modfiles "${modfile_directory}/*.mod")
+set(special_name "${CMAKE_BINARY_DIR}/bin/${CMAKE_SYSTEM_PROCESSOR}/special")
+set(output_binaries "${special}" "${special_name}-core")
+add_custom_command(
+  OUTPUT ${output_binaries}
+  DEPENDS nrniv_lib scopmath coreneuron ${NMODL_TARGET_TO_DEPEND} ${modfiles}
   COMMAND ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core -b STATIC -m ${CORENRN_MOD2CPP_BINARY} -p 1
-          ${CORENEURON_PROJECT_SOURCE_DIR}/tests/integration/ring_gap/mod
+          "${modfile_directory}"
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  BYPRODUCTS ${CMAKE_BINARY_DIR}/bin/${CMAKE_SYSTEM_PROCESSOR}/special-core
   COMMENT "Running nrnivmodl-core with halfgap.mod")
-add_dependencies(nrniv-core scopmath coreneuron ${NMODL_TARGET_TO_DEPEND})
+add_custom_target(nrniv-core DEPENDS ${output_binaries})
 
 include_directories(${CORENEURON_PROJECT_SOURCE_DIR})
 


### PR DESCRIPTION
**Description**

This changes how dependencies are declared in CMake to ensure that `nrnivmodl` is not called to recompile `halfgap.mod` ever time the project is built.

**How to test this?**

I tested with CoreNEURON built as a submodule of NEURON. After running
```bash
cmake ..
make -j
make -j # this should barely do anything, but without it this PR it was rerunning nrnivmodl.
```

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,