### PR TITLE
Do not remove <arch>/.libs but only coreneuron mechanism libray

### DIFF
--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -187,9 +187,9 @@ $(SPECIAL_EXE): coremech_lib_target
 	  -Wl,-rpath,'$(LIB_RPATH)' -Wl,-rpath,$(CORENRN_LIB_DIR)
 
 coremech_lib_target: $(corenrnmech_lib_target)
-	rm -rf $(OUTPUT_DIR)/.libs; \
+	rm -rf $(OUTPUT_DIR)/.libs/libcorenrnmech$(LIB_SUFFIX); \
 	mkdir -p $(OUTPUT_DIR)/.libs; \
-	ln -s ${COREMECH_LIB_PATH} $(OUTPUT_DIR)/.libs/libcorenrnmech$(LIB_SUFFIX)
+	ln -s ../libcorenrnmech$(LIB_SUFFIX) $(OUTPUT_DIR)/.libs/libcorenrnmech$(LIB_SUFFIX)
 
 $(ENGINEMECH_OBJ): | $(MOD_OBJS_DIR)
 	$(CXX_COMPILE_CMD) -c -DADDITIONAL_MECHS $(CORENRN_SHARE_CORENRN_DIR)/enginemech.cpp -o $(ENGINEMECH_OBJ)

--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -187,9 +187,9 @@ $(SPECIAL_EXE): coremech_lib_target
 	  -Wl,-rpath,'$(LIB_RPATH)' -Wl,-rpath,$(CORENRN_LIB_DIR)
 
 coremech_lib_target: $(corenrnmech_lib_target)
-	rm -rf $(OUTPUT_DIR)/.libs/libcorenrnmech$(LIB_SUFFIX); \
+	rm -rf $(OUTPUT_DIR)/.libs/lib$(COREMECH_LIB_NAME)$(LIB_SUFFIX); \
 	mkdir -p $(OUTPUT_DIR)/.libs; \
-	ln -s ../libcorenrnmech$(LIB_SUFFIX) $(OUTPUT_DIR)/.libs/libcorenrnmech$(LIB_SUFFIX)
+	ln -s ../lib$(COREMECH_LIB_NAME)$(LIB_SUFFIX) $(OUTPUT_DIR)/.libs/lib$(COREMECH_LIB_NAME)$(LIB_SUFFIX)
 
 $(ENGINEMECH_OBJ): | $(MOD_OBJS_DIR)
 	$(CXX_COMPILE_CMD) -c -DADDITIONAL_MECHS $(CORENRN_SHARE_CORENRN_DIR)/enginemech.cpp -o $(ENGINEMECH_OBJ)

--- a/tests/jenkins/run_neuron_direct.sh
+++ b/tests/jenkins/run_neuron_direct.sh
@@ -14,8 +14,8 @@ build_dir=$(mktemp -d $(pwd)/build_XXXX)
 cd $build_dir
 
 # build special and special-core
-nrnivmodl-core ../tests/jenkins/mod
 nrnivmodl ../tests/jenkins/mod
+nrnivmodl-core ../tests/jenkins/mod
 ls -la x86_64
 
 # Unload intel module to avoid issue whith mpirun


### PR DESCRIPTION
  - coreneuron mechanism lib is `<arch>/.libs`/libcorenrnmech*
  - fix symlink : it must be relative path to the parent directory 

**Description**

* We were deleting `<arch>/.libs` directory. This potentially break the workflow if user execute nrnivmodl first and then nrnivmodl-core.
* symlink should be relative from `x86_64/.libs` directory 

Fixes # (issue)

Should fix https://github.com/neuronsimulator/nrn/issues/1007

CI_BRANCHES:NEURON_BRANCH=master,
