### PR TITLE
Fix lfp test when running from NEURON

### DIFF
--- a/tests/unit/lfp/CMakeLists.txt
+++ b/tests/unit/lfp/CMakeLists.txt
@@ -23,4 +23,4 @@ endif()
 
 add_dependencies(lfp_test_bin nrniv-core)
 
-add_test(NAME lfp_test COMMAND ${TEST_EXEC_PREFIX} ${CMAKE_CURRENT_BINARY_DIR}/lfp_test_bin)
+add_test(NAME lfp_test COMMAND ${TEST_EXEC_PREFIX} $<TARGET_FILE:lfp_test_bin>)


### PR DESCRIPTION
**Description**

- [x] Fixes running the `lfp_test` when `CoreNEURON` is `NEURON` submodule
 ```      
   Start  5: lfp_test
Could not find executable /home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/lfp_test_bin
Looked in the following places:
/home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/lfp_test_bin
/home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/lfp_test_bin
/home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Release/lfp_test_bin
/home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Release/lfp_test_bin
/home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Debug/lfp_test_bin
/home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Debug/lfp_test_bin
/home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/MinSizeRel/lfp_test_bin
/home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/MinSizeRel/lfp_test_bin
/home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/RelWithDebInfo/lfp_test_bin
/home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/RelWithDebInfo/lfp_test_bin
/home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Deployment/lfp_test_bin
/home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Deployment/lfp_test_bin
/home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Development/lfp_test_bin
/home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Development/lfp_test_bin
home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/lfp_test_bin
home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/lfp_test_bin
home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Release/lfp_test_bin
home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Release/lfp_test_bin
home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Debug/lfp_test_bin
home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Debug/lfp_test_bin
home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/MinSizeRel/lfp_test_bin
home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/MinSizeRel/lfp_test_bin
home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/RelWithDebInfo/lfp_test_bin
home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/RelWithDebInfo/lfp_test_bin
home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Deployment/lfp_test_bin
home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Deployment/lfp_test_bin
home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Development/lfp_test_bin
home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/Development/lfp_test_bin
Unable to find executable: /home/magkanar/bbp_repos/nrn/build_test/external/coreneuron/tests/unit/lfp/lfp_test_bin
 5/82 Test  #5: lfp_test ....................................................***Not Run   0.00 sec
```

**How to test this?**

```bash
git clone https://github.com/neuronsimulator/nrn.git
cd nrn
mkdir build && cd build
cmake .. -DCMAKE_INSTALL_PREFIX=./install -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_TESTS=ON
make -j
make test
```

**Test System**
 - OS: Ubuntu 20.04
 - Compiler: GCC 10.2.0
 - Version: master branch
 - Backend: CPU
