### PR TITLE
Bug fix for copying VecPlay's IvocVect object on GPU

### DIFF
--- a/coreneuron/gpu/nrn_acc_manager.cpp
+++ b/coreneuron/gpu/nrn_acc_manager.cpp
@@ -402,7 +402,7 @@ void setup_nrnthreads_on_device(NrnThread* threads, int nthreads) {
 void copy_ivoc_vect_to_device(const IvocVect& from, IvocVect& to) {
 #ifdef _OPENACC
     IvocVect* d_iv = (IvocVect*) acc_copyin((void*) &from, sizeof(IvocVect));
-    acc_memcpy_to_device(&to, d_iv, sizeof(IvocVect));
+    acc_memcpy_to_device(&to, &d_iv, sizeof(IvocVect*));
 
     size_t n = from.size();
     if (n) {


### PR DESCRIPTION
- acc_memcpy_to_device is used to copy the device pointer
- so we have to use an address of the device pointer and size of 
   pointer ie. `sizeof(IvocVect*)`
- note that IvocVect is already copied by previous acc_copyin call
- this issue was introduced in #283

fixes #501

See #501 for how to test this

CI_BRANCHES:NEURON_BRANCH=master,
