### PR TITLE
Bug fix for GPU : Patternstim shouldn't be copied from GPU to CPU

### DIFF
--- a/coreneuron/gpu/nrn_acc_manager.cpp
+++ b/coreneuron/gpu/nrn_acc_manager.cpp
@@ -610,6 +610,12 @@ void update_nrnthreads_on_host(NrnThread* threads, int nthreads) {
                 int is_art = corenrn.get_is_artificial()[type];
                 int layout = corenrn.get_mech_data_layout()[type];
 
+                // PatternStim is a special mechanim of type artificial cell
+                // and it's not copied on GPU. So we shouldn't update it from GPU.
+                if (type == nrn_get_mechtype("PatternStim")) {
+                    continue;
+                }
+
                 int pcnt = nrn_soa_padded_size(n, layout) * szp;
 
                 acc_update_self(ml->data, pcnt * sizeof(double));


### PR DESCRIPTION
 - patternstim is a special mechanism whose data is not copied on
   gpu
 - when we update whole GPU data back to CPU, we should skip the
   patternstim

fixes #503

CI_BRANCHES:NEURON_BRANCH=master,
