### PR TITLE
Fix fast_imem initialization to 0

### DIFF
--- a/coreneuron/sim/fast_imem.cpp
+++ b/coreneuron/sim/fast_imem.cpp
@@ -35,8 +35,8 @@ void nrn_fast_imem_alloc() {
         for (auto nt = nrn_threads; nt < nrn_threads + nrn_nthread; ++nt) {
             int n = nt->end;
             nt->nrn_fast_imem = (NrnFastImem*) ecalloc(1, sizeof(NrnFastImem));
-            nt->nrn_fast_imem->nrn_sav_rhs = (double*) emalloc_align(n * sizeof(double));
-            nt->nrn_fast_imem->nrn_sav_d = (double*) emalloc_align(n * sizeof(double));
+            nt->nrn_fast_imem->nrn_sav_rhs = (double*) ecalloc_align(n, sizeof(double));
+            nt->nrn_fast_imem->nrn_sav_d = (double*) ecalloc_align(n, sizeof(double));
         }
     }
 }


### PR DESCRIPTION
**Description**

Initialize `fast_imem` struct with 0 in the beginning to make sure that there are no garbage in the first iteration.

**How to test this?**

There is no easy way to do this but comparing reports of `i_membrane` in `Neurodamus`.

**Test System**
 - OS: Linux
 - Compiler: Intel
 - Version: master
 - Backend: CPU
