### PR TITLE
Fix VecPlayContinuous direct mode error with multiple threads.

### DIFF
--- a/coreneuron/io/nrn2core_direct.h
+++ b/coreneuron/io/nrn2core_direct.h
@@ -77,7 +77,7 @@ extern int (*nrn2core_get_dat2_corepointer_mech_)(int tid,
                                                   int*& iarray,
                                                   double*& darray);
 
-extern int (*nrn2core_get_dat2_vecplay_)(int tid, int& n);
+extern int (*nrn2core_get_dat2_vecplay_)(int tid, std::vector<int>& indices);
 
 extern int (*nrn2core_get_dat2_vecplay_inst_)(int tid,
                                               int i,

--- a/coreneuron/io/phase2.cpp
+++ b/coreneuron/io/phase2.cpp
@@ -62,7 +62,7 @@ int (*nrn2core_get_dat2_corepointer_mech_)(int tid,
                                            int*& iarray,
                                            double*& darray);
 
-int (*nrn2core_get_dat2_vecplay_)(int tid, int& n);
+int (*nrn2core_get_dat2_vecplay_)(int tid, std::vector<int>& indices);
 
 int (*nrn2core_get_dat2_vecplay_inst_)(int tid,
                                        int i,
@@ -373,10 +373,13 @@ void Phase2::read_direct(int thread_id, const NrnThread& nt) {
         delete[] dArray_;
     }
 
-    int n_vec_play_continuous;
-    (*nrn2core_get_dat2_vecplay_)(thread_id, n_vec_play_continuous);
+    // Get from NEURON, the VecPlayContinuous indices in
+    // NetCvode::fixed_play_ for this thread.
+    std::vector<int> indices_vec_play_continuous;
+    (*nrn2core_get_dat2_vecplay_)(thread_id, indices_vec_play_continuous);
 
-    for (size_t i = 0; i < n_vec_play_continuous; ++i) {
+    // i is an index into NEURON's NetCvode::fixed_play_ for this thread.
+    for (auto i: indices_vec_play_continuous) {
         VecPlayContinuous_ item;
         // yvec_ and tvec_ are not deleted as that space is within
         // NEURON Vector


### PR DESCRIPTION
**Fixes neuronsimulator/nrn#1154**
Changes related to neuronsimulator/nrn#1155

Without this fix, the problem is exhibited with a modified tests/testcorenrn/testvecplay.hoc
```
hines@hines-T7500:~/neuron/vecplay-transfer/external/tests/testcorenrn$ git diffdiff --git a/testvecplay.hoc b/testvecplay.hoc
index ac1cc82..a9e34aa 100644
--- a/testvecplay.hoc
+++ b/testvecplay.hoc
@@ -45,6 +45,8 @@ for (gid = pc.id; gid < ncell; gid += pc.nhost) {
   cells.append(cell)
 }
 
+pc.nthread(2)
+
 pc.spike_record(-1, tvec, idvec)
 
 cvode.cache_efficient(1)
```
With
```
ctest -R testcorenrn_vecplay
```
NEURON is configured with:
```
$ cmake .. -DCMAKE_INSTALL_PREFIX=install -DIV_DIR=$HOME/neuron/ivcmake/build/install -DPYTHON_EXECUTABLE=`which python3` -DNRN_ENABLE_TESTS=ON -DNRN_ENABLE_CORENEURON=ON -DCMAKE_BUILD_TYPE=Debug -DNRN_ENABLE_RX3D=OFF
```

CI_BRANCHES:NEURON_BRANCH=vecplay-transfer,
