### PR TITLE
Enable branch specification in GitLab CI.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,10 @@ stages:
 # Set up Spack
 spack_setup:
   extends: .spack_setup_ccache
+  variables:
+    # Enable fetching GitHub PR descriptions and parsing them to find out what
+    # branches to build of other projects.
+    PARSE_GITHUB_PR_DESCRIPTIONS: "true"
   script:
     - !reference [.spack_setup_ccache, script]
     # This allows us to use the CoreNEURON repository in regression tests of


### PR DESCRIPTION
Enable support for `CI_BRANCHES` specifications in PR descriptions for the GitLab CI. The implementation lives in [hpc/gitlab-pipelines!17](https://bbpgitlab.epfl.ch/hpc/gitlab-pipelines/-/merge_requests/17).

Closes #505.

**Use certain branches for the CI**

CI_BRANCHES:NEURON_BRANCH=master