### PR TITLE
Added dependency for nrnivmodl-core and nmodl

### DIFF
--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -168,7 +168,7 @@ add_library(
   coreneuron ${COMPILE_LIBRARY_TYPE} ${CORENEURON_HEADER_FILES} ${CORENEURON_TEMPLATE_FILES}
              ${CORENEURON_CODE_FILES} ${cudacorenrn_objs} ${NMODL_INBUILT_MOD_OUTPUTS})
 
-# need to have _kinderiv.h for mod2c generated files
+# need to have _kinderiv.h for mod2c generated files and nrnivmodl-core and nmodl building
 add_dependencies(coreneuron kin_deriv_header nrnivmodl-core)
 
 # scopmath is created separately for nrnivmodl-core workflow

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -169,7 +169,7 @@ add_library(
              ${CORENEURON_CODE_FILES} ${cudacorenrn_objs} ${NMODL_INBUILT_MOD_OUTPUTS})
 
 # need to have _kinderiv.h for mod2c generated files
-add_dependencies(coreneuron kin_deriv_header)
+add_dependencies(coreneuron kin_deriv_header nrnivmodl-core)
 
 # scopmath is created separately for nrnivmodl-core workflow
 add_library(scopmath STATIC ${CORENEURON_HEADER_FILES} ${SCOPMATH_CODE_FILES})

--- a/extra/CMakeLists.txt
+++ b/extra/CMakeLists.txt
@@ -10,7 +10,10 @@
 configure_file(nrnivmodl_core_makefile.in
                ${CMAKE_BINARY_DIR}/share/coreneuron/nrnivmodl_core_makefile @ONLY)
 configure_file(nrnivmodl-core.in ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core @ONLY)
-add_custom_target(nrnivmodl-core ALL DEPENDS ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core ${CMAKE_BINARY_DIR}/share/coreneuron/nrnivmodl_core_makefile ${NMODL_TARGET_TO_DEPEND})
+add_custom_target(
+  nrnivmodl-core ALL
+  DEPENDS ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core
+          ${CMAKE_BINARY_DIR}/share/coreneuron/nrnivmodl_core_makefile ${NMODL_TARGET_TO_DEPEND})
 
 # =============================================================================
 # Install for end users

--- a/extra/CMakeLists.txt
+++ b/extra/CMakeLists.txt
@@ -10,6 +10,9 @@
 configure_file(nrnivmodl_core_makefile.in
                ${CMAKE_BINARY_DIR}/share/coreneuron/nrnivmodl_core_makefile @ONLY)
 configure_file(nrnivmodl-core.in ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core @ONLY)
+# nrnivmodl-core depends on the building of NMODL_TARGET_TO_DEPEND and the configuration of the
+# nrnivmodl-core and nrnivmodl_core_makefile this doesn't imply that whenever there is a change in
+# one of those files then the prebuilt mod files are going to be rebuilt
 add_custom_target(
   nrnivmodl-core ALL
   DEPENDS ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core

--- a/extra/CMakeLists.txt
+++ b/extra/CMakeLists.txt
@@ -10,6 +10,7 @@
 configure_file(nrnivmodl_core_makefile.in
                ${CMAKE_BINARY_DIR}/share/coreneuron/nrnivmodl_core_makefile @ONLY)
 configure_file(nrnivmodl-core.in ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core @ONLY)
+add_custom_target(nrnivmodl-core ALL DEPENDS ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core ${CMAKE_BINARY_DIR}/share/coreneuron/nrnivmodl_core_makefile ${NMODL_TARGET_TO_DEPEND})
 
 # =============================================================================
 # Install for end users


### PR DESCRIPTION
**Description**

While trying to build `NEURON` with `CoreNEURON` and `NMODL` I came across an issue where the tests of `NEURON` were trying to compile mod files using `nrnivmodl_core_makefile` that used `nmodl`, before the compilation of `nmodl` binary.
This pull request does the following:
- Adds dependency of `nmodl` if needed when configuring `nrnivmodl-core`
- Addsdependency of `nrnivmodl-core` in `coreneuron` target to make sure all the components of `coreneuron` are built before other external targets depend on it

**How to test this?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce if there is no integration test added with this PR. Please also list any relevant details for your test configuration

```bash
git clone git@github.com:neuronsimulator/nrn.git
cd nrn
mkdir build
cd build
cmake .. -DCMAKE_INSTALL_PREFIX=./install -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_CORENEURON=ON -DCORENRN_ENABLE_NMODL=ON -DNRN_ENABLE_TESTS=ON
make -j8
```

**Test System**
 - OS: Ubuntu 20.04
 - Compiler: GCC 10.2.0
 - Version: master branch
 - Backend: CPU + `NMODL`