### PR TITLE
Add missing includes, fix gcc11 compilation.

### DIFF
--- a/coreneuron/io/output_spikes.cpp
+++ b/coreneuron/io/output_spikes.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 #include <algorithm>
 #include <numeric>
+#include <limits>
 
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrniv/nrniv_decl.h"

--- a/coreneuron/io/reports/report_configuration_parser.cpp
+++ b/coreneuron/io/reports/report_configuration_parser.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
**Description**

The [scheduled NEURON CI](https://github.com/neuronsimulator/nrn-build-ci) [failed](https://github.com/neuronsimulator/nrn-build-ci/runs/2453857595?check_suite_focus=true) this morning. This was because the `fedora:latest` Docker image is now Fedora 34, which uses gcc 11.0.1.

The new compiler / standard library seems to be more pedantic about includes; this PR adds some missing `#include <limits>` where `std::numeric_limits<...>` is used.

The tests actually fail locally with an illegal instruction error, but I suspect this might be a problem with Docker etc. so let's try this in the CI anyway.

**How to test this?**

```bash
docker run -it --rm fedora:latest
dnf install -y bison cmake diffutils dnf flex gcc gcc-c++ git \
  openmpi-devel libXcomposite-devel libXext-devel make ncurses-devel \
  ninja-build python3-devel python3-pip python3-wheel sudo which
git clone https://github.com/neuronsimulator/nrn
cd nrn
git submodule init
git submodule update
cd external/coreneuron/
git checkout olupton/fix-gcc11-compilation
cd ../../../
useradd --create-home runner
chown -R runner:runner nrn
su runner
cd nrn
source /etc/profile.d/modules.sh
module load mpi
export PYTHON=$(command -v python3)
${PYTHON} -m pip install --user --upgrade pip
${PYTHON} -m pip install --user --upgrade bokeh cython ipython matplotlib \
  mpi4py pytest pytest-cov scikit-build
mkdir build && pushd build
export CC=${CC:-gcc}
export CXX=${CXX:-g++}
INSTALL_DIR=${PWD}../install
export CMAKE_OPTION="-G Ninja -DNRN_ENABLE_BINARY_SPECIAL=ON \
 -DNRN_ENABLE_MPI=ON -DNRN_ENABLE_INTERVIEWS=ON \
 -DNRN_ENABLE_CORENEURON=ON -DPYTHON_EXECUTABLE=${PYTHON} \
 -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} \
 -DNRN_ENABLE_TESTS=ON -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}"
cmake ${CMAKE_OPTION} ..
cmake --build . --parallel
```

**Test System**
 - OS: `fedora:latest` Docker image, macOS 10.15.7 host
 - Compiler: GCC 11.0.1
 - Version: master
 - Backend: CPU

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
