### PR TITLE
Handle correctly destructor block

### DIFF
--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -729,6 +729,11 @@ void nrn_cleanup() {
         for (NrnThreadMembList* tml = nt->tml; tml; tml = next_tml) {
             Memb_list* ml = tml->ml;
 
+            mod_f_t s = corenrn.get_memb_func(tml->index).destructor;
+            if (s) {
+                (*s)(nt, ml, tml->index);
+            }
+
             ml->data = nullptr;  // this was pointing into memory owned by nt
             free_memory(ml->pdata);
             ml->pdata = nullptr;

--- a/coreneuron/mechanism/membfunc.hpp
+++ b/coreneuron/mechanism/membfunc.hpp
@@ -30,7 +30,7 @@ struct Memb_func {
     mod_f_t jacob;
     mod_f_t state;
     mod_f_t initialize;
-    mod_f_t destructor; /* only for point processes */
+    mod_f_t destructor;
     Symbol* sym;
     int vectorized;
     int thread_size_;                       /* how many Datum needed in Memb_list if vectorized */

--- a/coreneuron/mechanism/membfunc.hpp
+++ b/coreneuron/mechanism/membfunc.hpp
@@ -30,7 +30,7 @@ struct Memb_func {
     mod_f_t jacob;
     mod_f_t state;
     mod_f_t initialize;
-    mod_f_t destructor;
+    mod_f_t destructor; /* only for point processes */
     Symbol* sym;
     int vectorized;
     int thread_size_;                       /* how many Datum needed in Memb_list if vectorized */
@@ -96,7 +96,6 @@ extern int point_register_mech(const char**,
                                void* (*constructor)(),
                                mod_f_t destructor,
                                int vectorized);
-extern void register_destructor(mod_f_t destructor);
 using NetBufReceive_t = void (*)(NrnThread*);
 extern void hoc_register_net_receive_buffering(NetBufReceive_t, int);
 

--- a/coreneuron/mechanism/membfunc.hpp
+++ b/coreneuron/mechanism/membfunc.hpp
@@ -30,7 +30,7 @@ struct Memb_func {
     mod_f_t jacob;
     mod_f_t state;
     mod_f_t initialize;
-    Pfri destructor; /* only for point processes */
+    mod_f_t destructor; /* only for point processes */
     Symbol* sym;
     int vectorized;
     int thread_size_;                       /* how many Datum needed in Memb_list if vectorized */
@@ -96,6 +96,7 @@ extern int point_register_mech(const char**,
                                void* (*constructor)(),
                                void (*destructor)(),
                                int vectorized);
+extern void register_destructor(mod_f_t destructor);
 using NetBufReceive_t = void (*)(NrnThread*);
 extern void hoc_register_net_receive_buffering(NetBufReceive_t, int);
 

--- a/coreneuron/mechanism/membfunc.hpp
+++ b/coreneuron/mechanism/membfunc.hpp
@@ -94,7 +94,7 @@ extern int point_register_mech(const char**,
                                mod_f_t initialize,
                                int nrnpointerindex,
                                void* (*constructor)(),
-                               void (*destructor)(),
+                               mod_f_t destructor,
                                int vectorized);
 extern void register_destructor(mod_f_t destructor);
 using NetBufReceive_t = void (*)(NrnThread*);

--- a/coreneuron/mechanism/register_mech.cpp
+++ b/coreneuron/mechanism/register_mech.cpp
@@ -144,7 +144,7 @@ int register_mech(const char** m,
     memb_func[type].alloc = alloc;
     memb_func[type].state = stat;
     memb_func[type].initialize = initialize;
-    memb_func[type].destructor = (Pfri) 0;
+    memb_func[type].destructor = nullptr;
 #if VECTORIZE
     memb_func[type].vectorized = vectorized ? 1 : 0;
     memb_func[type].thread_size_ = vectorized ? (vectorized - 1) : 0;
@@ -313,7 +313,7 @@ int nrn_mech_depend(int type, int* dependencies) {
     return idep;
 }
 
-void register_destructor(Pfri d) {
+void register_destructor(mod_f_t d) {
     corenrn.get_memb_funcs().back().destructor = d;
 }
 

--- a/coreneuron/mechanism/register_mech.cpp
+++ b/coreneuron/mechanism/register_mech.cpp
@@ -339,12 +339,12 @@ int point_register_mech(const char** m,
                         mod_f_t initialize,
                         int nrnpointerindex,
                         void* (*constructor)(),
-                        void (*destructor)(),
+                        mod_f_t destructor,
                         int vectorized) {
     (void) constructor;
-    (void) destructor; /* unused */
     const Symbol* s = m[1];
     register_mech(m, alloc, cur, jacob, stat, initialize, nrnpointerindex, vectorized);
+    register_destructor(destructor);
     return point_reg_helper(s);
 }
 


### PR DESCRIPTION
* This feature was not entirely supported and only placeholders were there
* Add the correct signature of destructor's callbacks (mod_f_t)