### PR TITLE
CMake v3.20+ no longer labels NVHPC as PGI.

### DIFF
--- a/CMake/OpenAccHelper.cmake
+++ b/CMake/OpenAccHelper.cmake
@@ -23,7 +23,7 @@ if(CORENRN_ENABLE_GPU)
   endif()
 
   # various flags for PGI compiler with GPU build
-  if(${CMAKE_C_COMPILER_ID} STREQUAL "PGI")
+  if(${CMAKE_C_COMPILER_ID} STREQUAL "PGI" OR ${CMAKE_C_COMPILER_ID} STREQUAL "NVHPC")
 
     # workaround for old PGI version
     set(PGI_ACC_FLAGS "-acc")


### PR DESCRIPTION
**Description**

The CoreNEURON CMake has some special handling for PGI/NVHPC compilers. In older CMake versions these were all labelled as "PGI", but in CMake v3.20+ then the NVHPC compilers have their own identifier.

**How to test this?**
Build with CMake v3.20+, an NVHPC compiler and GPU support. The build will fail without this change.

**Test System**
 - OS: BB5
 - Compiler: NVHPC 21.2
 - Version: master
 - Backend: GPU

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
