### PR TITLE
Remove call to acc_shutdown when cleaning up GPU data.

### DIFF
--- a/coreneuron/gpu/nrn_acc_manager.cpp
+++ b/coreneuron/gpu/nrn_acc_manager.cpp
@@ -998,8 +998,6 @@ void delete_nrnthreads_on_device(NrnThread* threads, int nthreads) {
     }
     acc_delete(threads, sizeof(NrnThread) * nthreads);
     nrn_ion_global_map_delete_from_device();
-
-    acc_shutdown(acc_device_nvidia);
 #endif
 }
 


### PR DESCRIPTION
**Description**
Remove the call to `acc_shutdown(acc_device_nvidia)` (OpenACC API) when cleaning up GPU data. This invoked undefined behaviour in case CoreNEURON was executed on GPU multiple times in the same process. See also: https://github.com/BlueBrain/CoreNeuron/pull/515.

**How to test this?**
The `coreneuron_modtests::datareturn_py` test, which runs three multiple CoreNEURON simulations from one Python script, is sensitive to this issue. This was not actually failing on `master`, but it probably could have been. Some other draft modifications that  used the `acc_map_data` and `acc_unmap_data` calls exposed the issue.

**Test System**
 - OS: BB5
 - Compiler: NVHPC 21.2
 - Version: master
 - Backend: GPU

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
