### PR TITLE
Enable auto checkpointing on SIGTERM

### DIFF
--- a/coreneuron/io/file_utils.cpp
+++ b/coreneuron/io/file_utils.cpp
@@ -51,3 +51,13 @@ int mkdir_p(const char* path) {
     delete[] dirpath;
     return 0;
 }
+
+bool fs_exists(const char* path) {
+    struct stat buffer;
+    return (stat(path, &buffer) == 0);
+}
+
+bool fs_isdir(const char* path) {
+    struct stat buffer;
+    return (stat(path, &buffer) == 0 && S_ISDIR(buffer.st_mode));
+}

--- a/coreneuron/io/file_utils.hpp
+++ b/coreneuron/io/file_utils.hpp
@@ -21,4 +21,12 @@
  */
 int mkdir_p(const char* path);
 
+/** @brief Checks an arbitrary path exists
+ */
+bool fs_exists(const char* path);
+
+/** @brief Checks an arbitrary path is an existing directory
+ */
+bool fs_isdir(const char* path);
+
 #endif /* ifndef NRN_FILE_UTILS */

--- a/coreneuron/nrnconf.h
+++ b/coreneuron/nrnconf.h
@@ -37,7 +37,7 @@ extern double pi;
 extern double t, dt;
 extern int rev_dt;
 extern int secondorder;
-extern bool stoprun;
+extern bool volatile stoprun;
 extern const char* bbcore_write_version;
 #define tstopbit   (1 << 15)
 #define tstopset   stoprun |= tstopbit

--- a/coreneuron/utils/nrnoc_aux.cpp
+++ b/coreneuron/utils/nrnoc_aux.cpp
@@ -15,7 +15,7 @@
 #include "coreneuron/utils/nrnoc_aux.hpp"
 
 namespace coreneuron {
-bool stoprun;
+bool volatile stoprun;
 int v_structure_change;
 int diam_changed;
 #define MAXERRCOUNT 5


### PR DESCRIPTION
**Motivation**
As a follow up to #252, we want CoreNeuron to be able to create checkpoints right before an allocation expires.
Since most job schedulers send a SIGTERM before sigkill, we implement a handler for such signal. It may, however, be needed  to tune the time to sending this signal, since long simulations may take a bit of time to write everything out.

*Implementation*
Checkpoints are created in a folder `_corenrn_ckpt` inside the output root only if a minimum amount of time elapsed.
This directory is checked for existence on startup if no `--restore` is provided.