### PR TITLE
Restrict which GPU nodes the GitLab CI builds run on.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,10 @@ spack_setup:
 .spack_nvhpc:
   variables:
     # We have to run GPU builds on GPU nodes for driver/makelocalrc reasons.
-    bb5_constraint: volta
+    # Because there is an outstanding issue with HTTPS downloads on the phase 2
+    # nodes (HELP-13868), which makes Spack build jobs fail there, we restrict
+    # to phase 1 nodes for building.
+    bb5_constraint: 'volta&rack2'
     SPACK_PACKAGE_COMPILER: nvhpc
 .spack_neuron:
   variables:


### PR DESCRIPTION
This should make the CI more reliable until an issue with some nodes is resolved.

**How to test this?**

Look at the GitLab CI and check that the NVHPC/GPU build jobs are not failing when downloading the sources for dependencies.

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
