### PR TITLE
Jenkins CI: Find latest libsonata-report version

### DIFF
--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -6,7 +6,7 @@ set -x
 source ${JENKINS_DIR:-.}/_env_setup.sh
 
 reportinglib_dir=$(spack location --install-dir --latest reportinglib%intel)
-libsonata_report_dir=$(spack location --install-dir --latest libsonata-report%intel)
+libsonata_report_dir=$(spack location --install-dir --latest libsonata-report@1.0:%intel)
 
 CORENRN_TYPE="$1"
 


### PR DESCRIPTION
**Description**

spack location --latest was not finding the latest installed libsonata-report version.
In order to fix this issue now we force to find versions > 1.0

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
