### PR TITLE
Fix for make clang-format when project is submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,10 @@ list(APPEND CMAKE_MODULE_PATH ${CORENEURON_PROJECT_SOURCE_DIR}/CMake
 set(CODING_CONV_PREFIX "CORENRN")
 set(CORENRN_3RDPARTY_DIR "external")
 set(CORENRN_ClangFormat_EXCLUDES_RE
-    ".*/external/.*$$"
+    "${CORENRN_PROJECT_SOURCE_DIR}/external/.*$$"
     CACHE STRING "list of regular expressions to exclude C/C++ files from formatting" FORCE)
 set(CORENRN_CMakeFormat_EXCLUDES_RE
-    ".*/external/.*$$" ".*/CMake/packages/.*$$"
+    "${CORENRN_PROJECT_SOURCE_DIR}/external/.*$$" ".*/CMake/packages/.*$$"
     CACHE STRING "list of regular expressions to exclude CMake files from formatting" FORCE)
 include(AddHpcCodingConvSubmodule)
 add_subdirectory(CMake/hpc-coding-conventions/cpp)


### PR DESCRIPTION
If Coreneuron is itself inside an external directory it will be excluded.

Fix #547