### PR TITLE
GHA CIs: drop previous runs

### DIFF
--- a/.github/workflows/clang_cmake_format_check.yaml
+++ b/.github/workflows/clang_cmake_format_check.yaml
@@ -1,4 +1,9 @@
 name: clang-cmake-format-check
+
+concurrency:
+  group: ${{ github.workflow }}#${{ github.ref }}
+  cancel-in-progress: true
+
 on:
     push:
 

--- a/.github/workflows/coreneuron-ci.yml
+++ b/.github/workflows/coreneuron-ci.yml
@@ -1,5 +1,9 @@
 name: CoreNEURON CI
 
+concurrency:
+  group: ${{ github.workflow }}#${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,9 @@
 name: Coverage
 
+concurrency:
+  group: ${{ github.workflow }}#${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:


### PR DESCRIPTION
* drop previous runs for subsequent updates (master, release & PRs)
* make use of new GHA concurrency feature
* concurrency group consists of workflow_name#github_ref
* see https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency


CI_BRANCHES:NEURON_BRANCH=master,
