### PR TITLE
More changes for CMake v3.20+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ endif()
 # =============================================================================
 # Build option specific compiler flags
 # =============================================================================
-if(${CMAKE_CXX_COMPILER_ID} STREQUAL "PGI")
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "PGI" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "NVHPC")
   # PGI with llvm code generation doesn't have necessary assembly intrinsic headers
   add_definitions(-DEIGEN_DONT_VECTORIZE=1)
 endif()


### PR DESCRIPTION
**Description**

In CMake v3.20+ then the NVHPC compilers are recognised as `NVHPC`, not `PGI`. This has the effect of disabling various workarounds when NVHPC is used with new CMake versions. This one fixes compilation of CoreNEURON+NMODL (with GPU support) with CMake v3.20.1 and NVHPC 21.2.

**How to test this?**

```bash
cmake .. -G Ninja -DNRN_ENABLE_TESTS=ON -DNRN_ENABLE_CORENEURON=ON -DCORENRN_ENABLE_GPU=ON -DCORENRN_ENABLE_NMODL=ON
cmake --build . --parallel
```

**Test System**
 - OS: BB5
 - Compiler: NVHPC 21.2
 - Version: master
 - Backend: GPU

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
