### PR TITLE
Explicitly specify NVIDIA compute capabilities.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,9 @@ option(CORENRN_ENABLE_GPU "Enable GPU support using OpenACC" OFF)
 option(CORENRN_ENABLE_SHARED "Enable shared library build" ON)
 option(CORENRN_ENABLE_LEGACY_UNITS "Enable legacy FARADAY, R, etc" OFF)
 
+set(CORENRN_GPU_CUDA_COMPUTE_CAPABILITY
+    "60" "70"
+    CACHE STRING "List of CUDA compute capabilities to compile CUDA/OpenACC for")
 set(CORENRN_NMODL_DIR
     ""
     CACHE PATH "Path to nmodl source-to-source compiler installation")

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Note that if you are building on Cray system with the GNU toolchain, you have to
    -DCMAKE_CXX_COMPILER=nvc++
   ```
 
+  By default the GPU code will be compiled for NVIDIA devices with compute
+  capability 6.0 or 7.0. This can be steered by passing, for example,
+  `-DCORENRN_GPU_CUDA_COMPUTE_CAPABILITY:STRING=50;60;70` to CMake.
+
 NOTE : If the CMake command fails, please make sure to delete temporary CMake cache files (`CMakeCache.txt`) before rerunning CMake.
 
 4. Build and Install :  once the configure step is done, you can build and install the project as:

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -124,13 +124,19 @@ if(CORENRN_ENABLE_GPU)
   set_source_files_properties(${OPENACC_EXCLUDED_FILES} PROPERTIES COMPILE_FLAGS
                                                                    "-DDISABLE_OPENACC")
 
-  # compile cuda files for multiple architecture
-  # ~~~
-  cuda_add_library(
-    "cudacoreneuron" ${CORENEURON_CUDA_FILES}
-    OPTIONS -arch=sm_60 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_72,code=sm_72
-            -gencode=arch=compute_52,code=compute_52 -Xcompiler -fPIC)
-  # ~~~
+  # if ${CORENRN_GPU_CUDA_COMPUTE_CAPABILITY} is {60[, ...]} then generate
+  # --generate-code=arch=compute_60,code=sm_60 --generate-code=arch=compute_60,code=compute_60, this
+  # is modelled after
+  # https://github.com/spack/spack/blob/a586fa6dd342ec39f2044f9dc035dd61b58f197d/lib/spack/spack/build_systems/cuda.py#L41-L47
+  # and the links therein.
+  foreach(compute_capability ${CORENRN_GPU_CUDA_COMPUTE_CAPABILITY})
+    list(APPEND cuda_arch_flags
+         "--generate-code=arch=compute_${compute_capability},code=sm_${compute_capability}")
+    list(APPEND cuda_arch_flags
+         "--generate-code=arch=compute_${compute_capability},code=compute_${compute_capability}")
+  endforeach()
+  cuda_add_library("cudacoreneuron" ${CORENEURON_CUDA_FILES} OPTIONS ${cuda_arch_flags} -Xcompiler
+                                                                     -fPIC)
   set(link_cudacoreneuron cudacoreneuron)
 else()
   set(link_cudacoreneuron "")


### PR DESCRIPTION
**Description**

This means we can force consistency between the CUDA and OpenACC code and avoid linker errors.

Previously, compilation was successful on machines with a sufficiently modern GPU, [as the NVHPC compiler modifies its behaviour based on the current system hardware](https://docs.nvidia.com/hpc-sdk/archive/21.2/compilers/hpc-compilers-user-guide/index.html#compute-cap), but it failed on machines with no GPU. This was because the default list of compute capabilities (3.5, 5.0, 6.0 and 7.0 in NVHPC 21.2) included a value (3.5) that was not compatible with the options used to compile the CoreNEURON CUDA library.

Also explicitly specify the CUDA version to avoid a similar issue with a newer CUDA version being assumed for the OpenACC compilation than was used for the CUDA part on a machine with no GPU.

With this change it should be possible to **build** CoreNEURON and `.mod` files that call CUDA routines on a machine without a modern GPU. This should allow https://github.com/BlueBrain/spack/pull/1172 to work.

**How to test this?**
```
spack install -j 36 neuron+coreneuron~debug~legacy-unit+tests%nvhpc ^coreneuron+gpu~legacy-unit~report+tests ^py-cython%gcc ^py-numpy%gcc
```
on a machine without a GPU with/without this change.

**Test System**
 - OS: BB5
 - Compiler: NVHPC 21.2
 - Version: master
 - Backend: GPU on a non-GPU machine

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
