### PR TITLE
Remove -Minline flag.

### DIFF
--- a/CMake/OpenAccHelper.cmake
+++ b/CMake/OpenAccHelper.cmake
@@ -43,9 +43,6 @@ if(CORENRN_ENABLE_GPU)
     endforeach()
     # disable very verbose diagnosis messages and obvious warnings for mod2c
     set(PGI_DIAG_FLAGS "--diag_suppress 161,177,550")
-    # inlining of large functions for OpenACC
-    set(PGI_INLINE_FLAGS "-Minline=size:200,levels:10")
-
     # avoid PGI adding standard compliant "-A" flags
     set(CMAKE_CXX11_STANDARD_COMPILE_OPTION --c++11)
     set(CMAKE_CXX14_STANDARD_COMPILE_OPTION --c++14)
@@ -57,7 +54,7 @@ if(CORENRN_ENABLE_GPU)
   endif()
 
   set(CORENRN_ACC_GPU_DEFS "${UNIFIED_MEMORY_DEF} ${CUDA_PROFILING_DEF}")
-  set(CORENRN_ACC_GPU_FLAGS "${PGI_ACC_FLAGS} ${PGI_DIAG_FLAGS} ${PGI_INLINE_FLAGS}")
+  set(CORENRN_ACC_GPU_FLAGS "${PGI_ACC_FLAGS} ${PGI_DIAG_FLAGS}")
 
   add_definitions(${CORENRN_ACC_GPU_DEFS})
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CORENRN_ACC_GPU_FLAGS}")


### PR DESCRIPTION
**Description**

This was needed for old PGI versions (circa 16.x), but it does not seem to be important any more.
The documentation also suggests that the syntax of this option has changed and the old formulation is no longer valid.
(`-Minline` also seems to have strange semantics when it is passed alongside `-MD` and `-MT` -- as is done by modern CMake versions for dependency tracking -- leading to a huge amount of debug information being printed, so removing this is desirable.)

**How to test this?**
Build NEURON+CoreNEURON with MOD2C+GPU backends and ran the CTest suite. Also checked that the `.mod` files from https://github.com/pramodk/nrntraub and https://github.com/pramodk/dentate compile with `nrnivmodl-core` (with the exception of `ri.mod`).

**Test System**
 - OS: BB5
 - Compiler: NVHPC 21.2
 - Version: master
 - Backend: GPU

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
