### PR TITLE
Export GitLab CI logs.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,8 @@ include:
     file:
       - spack-build-components.gitlab-ci.yml
       - github-project-pipelines.gitlab-ci.yml
+  - project: hpc/gitlab-upload-logs
+    file: enable-upload.yml
 
 stages:
     - .pre


### PR DESCRIPTION
**Description**
This will enable the export of log files from the GitLab CI so they are accessible directly from GitHub.

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,