### PR TITLE
Support SONATA report units

### DIFF
--- a/coreneuron/io/reports/sonata_report_handler.cpp
+++ b/coreneuron/io/reports/sonata_report_handler.cpp
@@ -50,6 +50,7 @@ void SonataReportHandler::register_report(const NrnThread& nt,
                          config.start,
                          config.stop,
                          config.report_dt,
+                         config.unit.data(),
                          config.type_str.data());
     sonata_set_report_max_buffer_size_hint(config.output_path.data(), config.buffer_size);
 


### PR DESCRIPTION
**Description**

Passes the report units to the libsonatareport library

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURODAMUS_CORE_BRANCH=sandbox/jblanco/report_units,SPACK_BRANCH=report_units,