### PR TITLE
shasum checks for codecov.io bash uploader

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,5 +46,22 @@ jobs:
           lcov --remove coverage-combined.info --output-file coverage.info "*/external/*"
           lcov --list coverage.info
       - name: Upload to codecov.io
-        run: bash <(curl -s https://codecov.io/bash) -f build/coverage.info
+        run: |
+          # Download codecov script and perform shasum checks
+          curl -fLso codecov https://codecov.io/bash;
+          VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
+          for i in 1 256 512
+          do
+            unset LCL_CHECSUM;
+            LCL_CHECSUM=$(shasum -a $i codecov);
+            unset CHECSUM;
+            CHECSUM=$(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM" | grep "codecov")
+            if test "$LCL_CHECSUM" != "$CHECSUM" ; then
+              echo "Codecov CHECSUM failed!";
+              echo "Local: ${LCL_CHECSUM}";
+              echo "Online: ${CHECSUM}";
+              exit 1;
+            fi;
+          done
+          bash ./codecov -f build/coverage.info
 


### PR DESCRIPTION
After codecov.io's security issue, it's worth adding extra checks for the bash uploader.

CI_BRANCHES:NEURON_BRANCH=master,
