### PR TITLE
Bug fix for the GPU execution of BBP model: issue with mechanism data offset

### DIFF
--- a/coreneuron/gpu/nrn_acc_manager.cpp
+++ b/coreneuron/gpu/nrn_acc_manager.cpp
@@ -186,7 +186,7 @@ void setup_nrnthreads_on_device(NrnThread* threads, int nthreads) {
             int layout = corenrn.get_mech_data_layout()[type];
 
             // get device pointer for corresponding mechanism data
-            dptr = (double *) acc_deviceptr(tml->ml->data);
+            dptr = (double*) acc_deviceptr(tml->ml->data);
             acc_memcpy_to_device(&(d_ml->data), &(dptr), sizeof(double*));
 
 

--- a/coreneuron/gpu/nrn_acc_manager.cpp
+++ b/coreneuron/gpu/nrn_acc_manager.cpp
@@ -139,6 +139,15 @@ void setup_nrnthreads_on_device(NrnThread* threads, int nthreads) {
             acc_memcpy_to_device(&(d_nt->_actual_diam), &(dptr), sizeof(double*));
         }
 
+        size_t offset = 6 * ne;
+
+        // see Phase2::populate(): some mechanisms can have diam semantics
+        // added after matrix data in nt._data. Take that into account while
+        // calculating the offset for start of mechanism data.
+        if (nt->_actual_diam) {
+            offset += ne;
+        }
+
         int* d_v_parent_index = (int*) acc_copyin(nt->_v_parent_index, nt->end * sizeof(int));
         acc_memcpy_to_device(&(d_nt->_v_parent_index), &(d_v_parent_index), sizeof(int*));
 
@@ -153,7 +162,6 @@ void setup_nrnthreads_on_device(NrnThread* threads, int nthreads) {
         NrnThreadMembList* d_last_tml;
 
         bool first_tml = true;
-        size_t offset = 6 * ne;
 
         for (auto tml = nt->tml; tml; tml = tml->next) {
             /*copy tml to device*/


### PR DESCRIPTION
    * Analysis of the bug:
      - Blue Brain model (channel-benchmark) was showing diferent spikes
        after few timesteps. Spikes were shifted and initially appeared
        to be floating point discrepencies.
      - Closely looking into NET_RECEIVE method revealed that the mechanism
        data accessed in net_receieve function was wrong. Somehow accessing
        variables like NMDA_ratio was showing wrong values. The nrn_state()
        had correct values.
      - The net_receieve function was accessing ml->data inside OpenACC loop.
        Accessing ml->data was providing different pointer inside OpenACC loop.
    * Fix for the bug:
      - some mechanisms can have dparam semantics for diam data and it is
        added into nt->data (after matrix elements).
      - When calculating offert for mechanism data, this extra semantics
        data was not considered. Adjusting the offset fixes the issue.
      - Additionally, we do not need to rely on offset but we can use
        acc_deviceptr to find corresponding device pointer directly.
        This is more reliable than manually calculating offset.

See initial fix in a7a95c9 and then simplification in 0ac3ab9.

**How to Run?**

Run channel benchmark on CPU vs GPU and compare spikes

```console
export SIM_TIME=100
export NUM_CELLS=100
export PRCELL_GID=1

srun -n 1 dplace ./cpu/x86_64/special -mpi -c arg_tstop=$SIM_TIME -c arg_dump_coreneuron_model=1 -c arg_target_count=$NUM_CELLS -c arg_prcell_gid=$PRCELL_GID $HOC_LIBRARY_PATH/init.hoc 2>&1 | tee neuron.log
srun -n 1 dplace ./cpu/x86_64/special-core -e $SIM_TIME --mpi -d coredat --prcellgid $PRCELL_GID 2>&1 | tee coreneuron.log
mv out.dat out.dat.cpu
srun -n 1 dplace ./gpu/x86_64/special-core -e $SIM_TIME --mpi -d coredat --prcellgid $PRCELL_GID --gpu --cell-permute=1 2>&1 | tee coreneuron.gpu.log
mv out.dat out.dat.gpu
diff out.dat out.dat.cpu out.dat out.dat.gpu
```

**Test System**
 BB5 + GPU

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,