### PR TITLE
Check that c++14 is fully supported before compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,10 @@ set(CMAKE_BUILD_TYPE
     RelWithDebInfo
     CACHE STRING "Empty or one of Debug, Release, RelWithDebInfo")
 
-if (NOT "cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
-  message(FATAL_ERROR "This compiler does not fully support C++14, choose an higher version or an other compiler.")
+if(NOT "cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+  message(
+    FATAL_ERROR
+      "This compiler does not fully support C++14, choose an higher version or an other compiler.")
 endif()
 
 # =============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ set(CMAKE_BUILD_TYPE
     RelWithDebInfo
     CACHE STRING "Empty or one of Debug, Release, RelWithDebInfo")
 
+if (NOT "cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+  message(FATAL_ERROR "This compiler does not fully support C++14, choose an higher version or an other compiler.")
+endif()
+
 # =============================================================================
 # Settings to enable project as submodule
 # =============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,8 @@ set(CMAKE_BUILD_TYPE
     RelWithDebInfo
     CACHE STRING "Empty or one of Debug, Release, RelWithDebInfo")
 
-if(NOT "cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES OR NOT "cxx_digit_separators" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+if(NOT "cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES OR NOT "cxx_digit_separators" IN_LIST
+                                                          CMAKE_CXX_COMPILE_FEATURES)
   message(
     FATAL_ERROR
       "This compiler does not fully support C++14, choose an higher version or an other compiler.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CMAKE_BUILD_TYPE
     RelWithDebInfo
     CACHE STRING "Empty or one of Debug, Release, RelWithDebInfo")
 
-if(NOT "cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+if(NOT "cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES OR NOT "cxx_digit_separators" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
   message(
     FATAL_ERROR
       "This compiler does not fully support C++14, choose an higher version or an other compiler.")


### PR DESCRIPTION
Setting CMAKE_CXX_STANDARD only add the flag, but maybe that the compiler is
too old and does not fully support it.

This way, it will fail before compiling and avoid understandable errors during
compilation.

Fix #228 