### PR TITLE
Fixed issue with "variable in data clause is partially present on the device: name=(unknown)"

### DIFF
--- a/coreneuron/gpu/nrn_acc_manager.cpp
+++ b/coreneuron/gpu/nrn_acc_manager.cpp
@@ -979,6 +979,7 @@ void delete_nrnthreads_on_device(NrnThread* threads, int nthreads) {
         if (nt->nrn_fast_imem) {
             acc_delete(nt->nrn_fast_imem->nrn_sav_d, nt->end * sizeof(double));
             acc_delete(nt->nrn_fast_imem->nrn_sav_rhs, nt->end * sizeof(double));
+            acc_delete(nt->nrn_fast_imem, sizeof(NrnFastImem));
         }
 
         if (nt->shadow_rhs_cnt) {


### PR DESCRIPTION
**Description**

- [x] `acc_delete` fast_imem struct as well to avoid issues with partially present data on device in the same order as it is initialized

Fixes #586 

**How to test this?**

This issue is a bit hard to reproduce however I managed to reproduce it consistently with the tests added for the `psolve-direct` branch in `NEURON` and `CoreNEURON`, where `psolve` is running multiple times from the same script using `CoreNEURON`.

```bash
git clone git@github.com:neuronsimulator/nrn.git -b psolve-direct
cd nrn
git submodule update --init --recursive
cd external/coreneuron
git checkout fix_openacc
cd ../..
cmake .. -DCMAKE_INSTALL_PREFIX=./install -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_TESTS=ON -DCORENRN_ENABLE_GPU=ON
make -j16
make install
ctest -V -R coreneuron_modtest
```

**Test System**
 - OS: RedHat
 - Compiler: NVHPC 21.2/CUDA 11.0.2
 - Version: `psolve-direct`/`master` branch
 - Backend: GPU