### PR TITLE
Fix compilation error with derivimplicit solver and use of celsius as extern variable

### DIFF
--- a/coreneuron/mechanism/eion.cpp
+++ b/coreneuron/mechanism/eion.cpp
@@ -190,9 +190,6 @@ the USEION statement of any model using this ion\n",
 #define gasconstant _gasconstant_codata2018
 #endif
 
-// extern variables require acc declare
-#pragma acc declare create(celsius)
-
 #define ktf (1000. * gasconstant * (celsius + 273.15) / FARADAY)
 
 double nrn_nernst(double ci, double co, double z, double celsius) {

--- a/coreneuron/nrnconf.h
+++ b/coreneuron/nrnconf.h
@@ -36,10 +36,13 @@ extern double celsius;
 #pragma acc declare create(celsius)
 
 extern double pi;
+#pragma acc declare create(pi)
+
+extern int secondorder;
+#pragma acc declare create(secondorder)
 
 extern double t, dt;
 extern int rev_dt;
-extern int secondorder;
 extern bool stoprun;
 extern const char* bbcore_write_version;
 #define tstopbit   (1 << 15)

--- a/coreneuron/nrnconf.h
+++ b/coreneuron/nrnconf.h
@@ -31,7 +31,10 @@ using Symbol = char;
 #define VEC_AREA(i) (_nt->_actual_area[(i)])
 #define VECTORIZE   1
 
+// extern variables require acc declare
 extern double celsius;
+#pragma acc declare create(celsius)
+
 extern double pi;
 
 extern double t, dt;


### PR DESCRIPTION
As described in #498, all extern variables require acc declare
create/copyin caluse. As variables can be updated after device
attachment (like celsius), #498 has taken care to update them.

fixes BlueBrain/nmodl/issues/707

Todos:

- [x] Merge NMODL PR first BlueBrain/nmodl/pull/709
- [x] Update nmodl submodule in this PR and then merge 

Fixes # (issue)

**How to test this?**

Run testderiv.hoc test from testcorenrn repository

**Test System**
 - OS: BB5
 - Compiler: default nvhpc + CUDA
 - Backend: GPU

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=pramodk/derivimplicit-legacy-fix,
