### PR TITLE
Do not use __managed__ in GPU builds. Add utils.

### DIFF
--- a/CMake/OpenAccHelper.cmake
+++ b/CMake/OpenAccHelper.cmake
@@ -9,7 +9,7 @@
 # =============================================================================
 if(CORENRN_ENABLE_GPU)
   # Enable cudaProfiler{Start,Stop}() behind the Instrumentor::phase... APIs
-  add_compile_definitions(CORENEURON_CUDA_PROFILING)
+  add_compile_definitions(CORENEURON_CUDA_PROFILING CORENEURON_ENABLE_GPU)
   # cuda unified memory support
   if(CORENRN_ENABLE_CUDA_UNIFIED_MEMORY)
     add_compile_definitions(CORENEURON_UNIFIED_MEMORY)
@@ -49,8 +49,8 @@ if(CORENRN_ENABLE_GPU)
   endif()
   # -acc enables OpenACC support, -cuda links CUDA libraries and (very importantly!) seems to be
   # required to make the NVHPC compiler do the device code linking. Otherwise the explicit CUDA
-  # device code (.cu files in libcudacoreneuron) has to be linked in a separate, earlier, step,
-  # which apparently causes problems with interoperability with OpenACC. Passing -cuda to nvc++ when
+  # device code (.cu files in libcoreneuron) has to be linked in a separate, earlier, step, which
+  # apparently causes problems with interoperability with OpenACC. Passing -cuda to nvc++ when
   # compiling (as opposed to linking) seems to enable CUDA C++ support, which has other consequences
   # due to e.g. __CUDACC__ being defined. See https://github.com/BlueBrain/CoreNeuron/issues/607 for
   # more information about this. -gpu=cudaX.Y ensures that OpenACC code is compiled with the same
@@ -80,7 +80,7 @@ if(CORENRN_ENABLE_GPU)
     GLOBAL
     PROPERTY
       CORENEURON_LIB_LINK_FLAGS
-      "${NVHPC_ACC_COMP_FLAGS} ${NVHPC_ACC_LINK_FLAGS} -rdynamic -lrt -Wl,--whole-archive -L${CMAKE_HOST_SYSTEM_PROCESSOR} -lcorenrnmech -L${CMAKE_INSTALL_PREFIX}/lib -lcoreneuron -lcudacoreneuron -Wl,--no-whole-archive"
+      "${NVHPC_ACC_COMP_FLAGS} ${NVHPC_ACC_LINK_FLAGS} -rdynamic -lrt -Wl,--whole-archive -L${CMAKE_HOST_SYSTEM_PROCESSOR} -lcorenrnmech -L${CMAKE_INSTALL_PREFIX}/lib -lcoreneuron -Wl,--no-whole-archive"
   )
 else()
   set_property(GLOBAL PROPERTY CORENEURON_LIB_LINK_FLAGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,11 @@ list(APPEND CMAKE_MODULE_PATH ${CORENEURON_PROJECT_SOURCE_DIR}/CMake
 # =============================================================================
 set(CODING_CONV_PREFIX "CORENRN")
 set(CORENRN_3RDPARTY_DIR "external")
+# Adds .cu with respect to the current default in hpc-coding-conventions, and drops various patterns
+# that don't match anything in CoreNEURON. Note there's only one .c file left!
+set(CORENRN_ClangFormat_FILES_RE
+    "^.*\\\\.cu?$$" "^.*\\\\.[chi]pp$$"
+    CACHE STRING "List of regular expressions matching C/C++ filenames" FORCE)
 set(CORENRN_ClangFormat_EXCLUDES_RE
     "${CORENRN_PROJECT_SOURCE_DIR}/external/.*$$"
     CACHE STRING "list of regular expressions to exclude C/C++ files from formatting" FORCE)

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -108,6 +108,7 @@ if(CORENRN_ENABLE_GPU)
   # ~~~
   # artificial cells and some other cpp files (using Random123) should be compiled
   # without OpenACC to avoid use of GPU Random123 streams
+  # OL210813: this shouldn't be needed anymore, but it may have a small performance benefit
   # ~~~
   set(OPENACC_EXCLUDED_FILES
       ${CMAKE_CURRENT_BINARY_DIR}/netstim.cpp
@@ -118,24 +119,19 @@ if(CORENRN_ENABLE_GPU)
       ${CMAKE_CURRENT_SOURCE_DIR}/io/setup_fornetcon.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/io/corenrn_data_return.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/io/global_vars.cpp)
-
+  # OL210831: why?
   set_source_files_properties(${DIMPLIC_CODE_FILE} ${NMODL_INBUILT_MOD_OUTPUTS}
                               PROPERTIES COMPILE_FLAGS "")
 
   set_source_files_properties(${OPENACC_EXCLUDED_FILES} PROPERTIES COMPILE_FLAGS
                                                                    "-DDISABLE_OPENACC")
-
-  add_library(cudacoreneuron STATIC ${CORENEURON_CUDA_FILES})
-  set_target_properties(cudacoreneuron PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-  set(link_cudacoreneuron cudacoreneuron)
   # nrnran123.cpp is a symlink to nrnran123.cu, in GPU builds we compile this as CUDA code (so we
   # want to remove the .cpp here), while in non-GPU builds we compile it as plain C++. Unfortunately
   # CMake <v3.20 does not pass explicit -x <lang> options based on the LANGUAGE property
   # (https://cmake.org/cmake/help/latest/policy/CMP0119.html), so using a single .cu file and
   # setting LANGUAGE=CXX in non-GPU builds does not work.
   list(REMOVE_ITEM CORENEURON_CODE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/utils/randoms/nrnran123.cpp")
-else()
-  set(link_cudacoreneuron "")
+  list(APPEND CORENEURON_CODE_FILES ${CORENEURON_CUDA_FILES})
 endif()
 
 # =============================================================================
@@ -171,9 +167,7 @@ add_library(
              ${CORENEURON_CODE_FILES} ${cudacorenrn_objs} ${NMODL_INBUILT_MOD_OUTPUTS})
 # Prevent CMake from running a device code link step when assembling libcoreneuron.a in GPU builds.
 # The device code linking needs to be deferred to the final step, where it is done by `nvc++ -cuda`.
-# OL210811: it's not clear why this is needed, given that coreneuron is a static library in GPU
-# builds.
-set_target_properties(coreneuron PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS OFF)
+set_target_properties(coreneuron PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
 # need to have _kinderiv.h for mod2c generated files and nrnivmodl-core and nmodl building
 add_dependencies(coreneuron kin_deriv_header nrnivmodl-core)
@@ -181,21 +175,15 @@ add_dependencies(coreneuron kin_deriv_header nrnivmodl-core)
 # scopmath is created separately for nrnivmodl-core workflow
 add_library(scopmath STATIC ${CORENEURON_HEADER_FILES} ${SCOPMATH_CODE_FILES})
 
-target_link_libraries(
-  coreneuron
-  ${reportinglib_LIBRARY}
-  ${sonatareport_LIBRARY}
-  ${link_cudacoreneuron}
-  ${CALIPER_LIB}
-  ${likwid_LIBRARIES}
-  ${MPI_C_LIBRARIES})
+target_link_libraries(coreneuron ${reportinglib_LIBRARY} ${sonatareport_LIBRARY} ${CALIPER_LIB}
+                      ${likwid_LIBRARIES} ${MPI_C_LIBRARIES})
 target_include_directories(coreneuron SYSTEM
                            PRIVATE ${CORENEURON_PROJECT_SOURCE_DIR}/external/Random123/include)
 target_include_directories(coreneuron SYSTEM
                            PRIVATE ${CORENEURON_PROJECT_SOURCE_DIR}/external/CLI11/include)
 
 set_target_properties(
-  coreneuron scopmath ${link_cudacoreneuron}
+  coreneuron scopmath
   PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
              LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
              POSITION_INDEPENDENT_CODE ON)
@@ -253,7 +241,7 @@ file(COPY apps/coreneuron.cpp DESTINATION ${CMAKE_BINARY_DIR}/share/coreneuron)
 
 # coreneuron main libraries
 install(
-  TARGETS coreneuron ${link_cudacoreneuron}
+  TARGETS coreneuron
   EXPORT coreneuron
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -119,9 +119,6 @@ if(CORENRN_ENABLE_GPU)
       ${CMAKE_CURRENT_SOURCE_DIR}/io/setup_fornetcon.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/io/corenrn_data_return.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/io/global_vars.cpp)
-  # OL210831: why?
-  set_source_files_properties(${DIMPLIC_CODE_FILE} ${NMODL_INBUILT_MOD_OUTPUTS}
-                              PROPERTIES COMPILE_FLAGS "")
 
   set_source_files_properties(${OPENACC_EXCLUDED_FILES} PROPERTIES COMPILE_FLAGS
                                                                    "-DDISABLE_OPENACC")

--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -140,9 +140,6 @@ void nrn_init_and_load_data(int argc,
     // initialise default coreneuron parameters
     initnrn();
 
-    // create mutex for nrn123, protect instance_count_
-    nrnran123_mutconstruct();
-
     // set global variables
     // precedence is: set by user, globals.dat, 34.0
     celsius = corenrn_param.celsius;

--- a/coreneuron/utils/memory.cpp
+++ b/coreneuron/utils/memory.cpp
@@ -1,0 +1,55 @@
+/*
+# =============================================================================
+# Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
+#
+# See top-level LICENSE file for details.
+# =============================================================================.
+*/
+#include "coreneuron/apps/corenrn_parameters.hpp"
+#include "coreneuron/utils/memory.h"
+
+#ifdef CORENEURON_ENABLE_GPU
+#include <cuda_runtime_api.h>
+#endif
+
+#include <cassert>
+
+namespace coreneuron {
+bool unified_memory_enabled() {
+#ifdef CORENEURON_ENABLE_GPU
+    return corenrn_param.gpu;
+#endif
+    return false;
+}
+
+void* allocate_unified(std::size_t num_bytes) {
+#ifdef CORENEURON_ENABLE_GPU
+    // The build supports GPU execution, check if --gpu was passed to actually
+    // enable it. We should not call CUDA APIs in GPU builds if --gpu was not passed.
+    if (corenrn_param.gpu) {
+        // Allocate managed/unified memory.
+        void* ptr{nullptr};
+        auto const code = cudaMallocManaged(&ptr, num_bytes);
+        assert(code == cudaSuccess);
+        return ptr;
+    }
+#endif
+    // Either the build does not have GPU support or --gpu was not passed.
+    // Allocate using standard operator new.
+    // When we have C++17 support then propagate `alignment` here.
+    return ::operator new(num_bytes);
+}
+
+void deallocate_unified(void* ptr, std::size_t num_bytes) {
+    // See comments in allocate_unified to understand the different branches.
+#ifdef CORENEURON_ENABLE_GPU
+    if (corenrn_param.gpu) {
+        // Don't assert success because it will fail if called at application
+        // teardown, e.g. by a global std::unique_ptr destructor...this is not very nice.
+        cudaFree(ptr);
+        return;
+    }
+#endif
+    ::operator delete(ptr, num_bytes);
+}
+}  // namespace coreneuron

--- a/coreneuron/utils/profile/cuda_profile.cu
+++ b/coreneuron/utils/profile/cuda_profile.cu
@@ -20,11 +20,13 @@ void print_gpu_memory_usage() {
         exit(1);
     }
 
-    double free_db = (double)free_byte;
-    double total_db = (double)total_byte;
+    double free_db = (double) free_byte;
+    double total_db = (double) total_byte;
     double used_db = total_db - free_db;
     printf("\n  => GPU MEMORY USAGE (MB) : Used = %f, Free = %f MB, Total = %f",
-           used_db / 1024.0 / 1024.0, free_db / 1024.0 / 1024.0, total_db / 1024.0 / 1024.0);
+           used_db / 1024.0 / 1024.0,
+           free_db / 1024.0 / 1024.0,
+           total_db / 1024.0 / 1024.0);
     fflush(stdout);
 }
 

--- a/coreneuron/utils/randoms/nrnran123.cu
+++ b/coreneuron/utils/randoms/nrnran123.cu
@@ -10,9 +10,9 @@
 #include "coreneuron/utils/randoms/nrnran123.h"
 
 #include <cmath>
+#include <iostream>
 #include <memory>
 #include <mutex>
-#include <sstream>
 
 // In a GPU build this file will be compiled by NVCC as CUDA code
 // In a CPU build this file will be compiled by a C++ compiler as C++ code
@@ -174,13 +174,12 @@ void nrnran123_set_globalindex(uint32_t gix) {
     // If the global seed is changing then we shouldn't have any active streams.
     {
         std::lock_guard<OMP_Mutex> _{g_instance_count_mutex};
-        if (g_instance_count != 0) {
-            std::ostringstream oss;
-            oss << "nrnran123_set_globalindex(" << gix
+        if (g_instance_count != 0 && nrnmpi_myid == 0) {
+            std::cout
+                << "nrnran123_set_globalindex(" << gix
                 << ") called when a non-zero number of Random123 streams (" << g_instance_count
                 << ") were active. This is not safe, some streams will remember the old value ("
                 << get_global_state().v[0] << ')';
-            throw std::runtime_error(oss.str());
         }
     }
     get_global_state().v[0] = gix;

--- a/coreneuron/utils/randoms/nrnran123.cu
+++ b/coreneuron/utils/randoms/nrnran123.cu
@@ -5,29 +5,81 @@
 # See top-level LICENSE file for details.
 # =============================================================================.
 */
+#include "coreneuron/utils/memory.h"
 #include "coreneuron/utils/nrnmutdec.h"
 #include "coreneuron/utils/randoms/nrnran123.h"
 
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-
+#include <cmath>
+#include <memory>
 #include <mutex>
+#include <sstream>
 
 // In a GPU build this file will be compiled by NVCC as CUDA code
 // In a CPU build this file will be compiled by a C++ compiler as C++ code
 #ifdef __CUDACC__
-#define CORENRN_MANAGED __managed__
+#define CORENRN_DEVICE __device__
 #else
-#define CORENRN_MANAGED
+#define CORENRN_DEVICE
 #endif
 
 namespace {
 /* global data structure per process */
-CORENRN_MANAGED philox4x32_key_t g_k = {{0}};
+using g_k_allocator_t = coreneuron::unified_allocator<philox4x32_key_t>;
+std::unique_ptr<philox4x32_key_t, coreneuron::alloc_deleter<g_k_allocator_t>> g_k;
+
+// In a GPU build we need a device-side global pointer to this global state.
+// This is set to the same unified memory address as `g_k` in
+// `setup_global_state()` if the GPU is enabled. It would be cleaner to use
+// __managed__ here, but unfortunately that does not work on machines that do
+// not have a GPU.
+#ifdef __CUDACC__
+CORENRN_DEVICE philox4x32_key_t* g_k_dev;
+#endif
+
 OMP_Mutex g_instance_count_mutex;
 std::size_t g_instance_count{};
+
 constexpr double SHIFT32 = 1.0 / 4294967297.0; /* 1/(2^32 + 1) */
+
+void setup_global_state() {
+    if (g_k) {
+        // Already initialised, nothing to do
+        return;
+    }
+    g_k = coreneuron::allocate_unique<philox4x32_key_t>(g_k_allocator_t{});
+#ifdef __CUDACC__
+    if (coreneuron::unified_memory_enabled()) {
+        // Set the device-side global g_k_dev to point to the newly-allocated
+        // unified memory. If this is false, g_k is just a host pointer and
+        // there is no point initialising the device global to it.
+        {
+            auto* k = g_k.get();
+            auto const code = cudaMemcpyToSymbol(g_k_dev, &k, sizeof(k));
+            assert(code == cudaSuccess);
+        }
+        // Make sure g_k_dev is updated.
+        {
+            auto const code = cudaDeviceSynchronize();
+            assert(code == cudaSuccess);
+        }
+    }
+#endif
+}
+
+/** @brief Get the Random123 global state from either host or device code.
+ */
+CORENRN_HOST_DEVICE philox4x32_key_t& get_global_state() {
+    philox4x32_key_t* ret{nullptr};
+#ifdef __CUDA_ARCH__
+    // Called from device code
+    ret = g_k_dev;
+#else
+    // Called from host code
+    ret = g_k.get();
+#endif
+    assert(ret);
+    return *ret;
+}
 }  // namespace
 
 namespace coreneuron {
@@ -35,19 +87,10 @@ std::size_t nrnran123_instance_count() {
     return g_instance_count;
 }
 
-#ifdef _OPENMP
-static MUTDEC void nrnran123_mutconstruct() {
-    if (!mut_) {
-        MUTCONSTRUCT(1);
-    }
-}
-#else
-void nrnran123_mutconstruct() {}
-#endif
-
 /* if one sets the global, one should reset all the stream sequences. */
-CORENRN_HOST_DEVICE uint32_t nrnran123_get_globalindex() {
-    return g_k.v[0];
+uint32_t nrnran123_get_globalindex() {
+    setup_global_state();
+    return get_global_state().v[0];
 }
 
 CORENRN_HOST_DEVICE void nrnran123_getseq(nrnran123_State* s, uint32_t* seq, char* which) {
@@ -62,7 +105,7 @@ CORENRN_HOST_DEVICE void nrnran123_setseq(nrnran123_State* s, uint32_t seq, char
         s->which_ = which;
     }
     s->c.v[0] = seq;
-    s->r = philox4x32(s->c, g_k);
+    s->r = philox4x32(s->c, get_global_state());
 }
 
 CORENRN_HOST_DEVICE void nrnran123_getids(nrnran123_State* s, uint32_t* id1, uint32_t* id2) {
@@ -86,7 +129,7 @@ CORENRN_HOST_DEVICE uint32_t nrnran123_ipick(nrnran123_State* s) {
     if (which > 3) {
         which = 0;
         s->c.v[0]++;
-        s->r = philox4x32(s->c, g_k);
+        s->r = philox4x32(s->c, get_global_state());
     }
     s->which_ = which;
     return rval;
@@ -98,7 +141,7 @@ CORENRN_HOST_DEVICE double nrnran123_dblpick(nrnran123_State* s) {
 
 CORENRN_HOST_DEVICE double nrnran123_negexp(nrnran123_State* s) {
     /* min 2.3283064e-10 to max 22.18071 */
-    return -log(nrnran123_dblpick(s));
+    return -std::log(nrnran123_dblpick(s));
 }
 
 /* at cost of a cached  value we could compute two at a time. */
@@ -114,7 +157,7 @@ CORENRN_HOST_DEVICE double nrnran123_normal(nrnran123_State* s) {
         w = (u1 * u1) + (u2 * u2);
     } while (w > 1);
 
-    y = sqrt((-2. * log(w)) / w);
+    y = std::sqrt((-2. * log(w)) / w);
     x = u1 * y;
     return x;
 }
@@ -127,27 +170,47 @@ CORENRN_HOST_DEVICE double nrnran123_uint2dbl(uint32_t u) {
 
 /* nrn123 streams are created from cpu launcher routine */
 void nrnran123_set_globalindex(uint32_t gix) {
-    g_k.v[0] = gix;
+    setup_global_state();
+    // If the global seed is changing then we shouldn't have any active streams.
+    {
+        std::lock_guard<OMP_Mutex> _{g_instance_count_mutex};
+        if (g_instance_count != 0) {
+            std::ostringstream oss;
+            oss << "nrnran123_set_globalindex(" << gix
+                << ") called when a non-zero number of Random123 streams (" << g_instance_count
+                << ") were active. This is not safe, some streams will remember the old value ("
+                << get_global_state().v[0] << ')';
+            throw std::runtime_error(oss.str());
+        }
+    }
+    get_global_state().v[0] = gix;
 }
 
+/** @brief Allocate a new Random123 stream.
+ *  @todo  It would be nicer if the API return type was
+ *  std::unique_ptr<nrnran123_State, ...not specified...>, so we could use a
+ *  custom allocator/deleter and avoid the (fragile) need for matching
+ *  nrnran123_deletestream calls. See `g_k` for an example.
+ */
 nrnran123_State* nrnran123_newstream3(uint32_t id1,
                                       uint32_t id2,
                                       uint32_t id3,
                                       bool use_unified_memory) {
+    // The `use_unified_memory` argument is an implementation detail to keep the
+    // old behaviour that some Random123 streams that are known to only be used
+    // from the CPU are allocated using new/delete instead of unified memory.
+    // See OPENACC_EXCLUDED_FILES in coreneuron/CMakeLists.txt. If we dropped
+    // this feature then we could always use coreneuron::unified_allocator.
+#ifndef CORENEURON_ENABLE_GPU
+    if (use_unified_memory) {
+        throw std::runtime_error("Tried to use CUDA unified memory in a non-GPU build.");
+    }
+#endif
     nrnran123_State* s{nullptr};
     if (use_unified_memory) {
-#ifdef __CUDACC__
-        {
-            auto const code = cudaMallocManaged(&s, sizeof(nrnran123_State));
-            assert(code == cudaSuccess);
-        }
-        {
-            auto const code = cudaMemset(s, 0, sizeof(nrnran123_State));
-            assert(code == cudaSuccess);
-        }
-#else
-        throw std::runtime_error("Tried to use CUDA unified memory in a non-GPU build.");
-#endif
+        s = coreneuron::allocate_unique<nrnran123_State>(
+                coreneuron::unified_allocator<nrnran123_State>{})
+                .release();
     } else {
         s = new nrnran123_State{};
     }
@@ -157,6 +220,8 @@ nrnran123_State* nrnran123_newstream3(uint32_t id1,
     s->c.v[3] = id2;
     nrnran123_setseq(s, 0, 0);
     {
+        // TODO: can I assert something useful about the instance count going
+        // back to zero anywhere? Or that it is zero when some operations happen?
         std::lock_guard<OMP_Mutex> _{g_instance_count_mutex};
         ++g_instance_count;
     }
@@ -165,16 +230,19 @@ nrnran123_State* nrnran123_newstream3(uint32_t id1,
 
 /* nrn123 streams are destroyed from cpu launcher routine */
 void nrnran123_deletestream(nrnran123_State* s, bool use_unified_memory) {
+#ifndef CORENEURON_ENABLE_GPU
+    if (use_unified_memory) {
+        throw std::runtime_error("Tried to use CUDA unified memory in a non-GPU build.");
+    }
+#endif
     {
         std::lock_guard<OMP_Mutex> _{g_instance_count_mutex};
         --g_instance_count;
     }
     if (use_unified_memory) {
-#ifdef __CUDACC__
-        cudaFree(s);
-#else
-        throw std::runtime_error("Tried to use CUDA unified memory in a non-GPU build.");
-#endif
+        std::unique_ptr<nrnran123_State,
+                        coreneuron::alloc_deleter<coreneuron::unified_allocator<nrnran123_State>>>
+            _{s};
     } else {
         delete s;
     }

--- a/coreneuron/utils/randoms/nrnran123.h
+++ b/coreneuron/utils/randoms/nrnran123.h
@@ -74,13 +74,10 @@ struct nrnran123_array4x32 {
     uint32_t v[4];
 };
 
-/* do this on launch to make nrnran123_newstream threadsafe */
-void nrnran123_mutconstruct();
-
 /* global index. eg. run number */
 /* all generator instances share this global index */
 void nrnran123_set_globalindex(uint32_t gix);
-CORENRN_HOST_DEVICE_ACC uint32_t nrnran123_get_globalindex();
+uint32_t nrnran123_get_globalindex();
 
 // Utilities used for calculating model size, only called from the CPU.
 std::size_t nrnran123_instance_count();


### PR DESCRIPTION
**Description**
This fixes CPU execution of GPU builds on machines that do not have GPUs, which were previously segfaulting due to the use of the `__managed__` keyword. Now the handling of Random123 state is more explicit for host/device. This was only added in https://github.com/BlueBrain/CoreNeuron/pull/595, but the issue wasn't noticed at the time because the GPU-enabled CI only executes tests on machines with GPUs.

Also add a pair of helper functions `coreneuron::[de]allocate_unified()` that wrap `cudaMallocManaged()` in GPU builds if `--gpu` was passed at runtime and fall back to `new`/`delete` otherwise, and a method `coreneuron::unified_memory_enabled()` that queries whether this condition is met.

Additionally add a C++ allocator template `coreneuron::unified_allocator<T>` that wraps these functions, and a templated `coreneuron::alloc_deleter<T>` for use with `std::unique_ptr<T, D>`. Also add `coreneuron::allocate_unique` helper from SO.

Cleanup Random123 code by dropping an unused `nrnran123_mutconstruct()` method.

Tweak compilation scripts to allow for circular dependencies between `libcoreneuron.a` and `libcudacoreneuron.a`.
In future these should just be merged into a single library.

This addresses https://github.com/BlueBrain/CoreNeuron/issues/599#issuecomment-888416482. #599 should stay open because various OpenACC calls are still not conditional on `--gpu`.

**How to test this?**
Try running a GPU-built `special-core` without `--gpu` on a machine that does not have an NVIDIA GPU.

**Test System**
 - OS: BB5
 - Compiler: NVHPC 21.7 / CUDA 11.0 / GCC 9.3
 - Version: master
 - Backend: GPU/CPU

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
