### PR TITLE
Adapt to the new api in libsonata-report for sonata spike report

### DIFF
--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -481,7 +481,7 @@ extern "C" int run_solve_core(int argc, char** argv) {
 
     std::vector<ReportConfiguration> configs;
     std::vector<std::unique_ptr<ReportHandler>> report_handlers;
-    std::string spikes_population_name;
+    std::vector<std::pair<std::string, int>> spikes_population_name_offset;
     bool reports_needs_finalize = false;
 
     if (!corenrn_param.is_quiet()) {
@@ -496,7 +496,7 @@ extern "C" int run_solve_core(int argc, char** argv) {
     if (!corenrn_param.reportfilepath.empty()) {
         configs = create_report_configurations(corenrn_param.reportfilepath,
                                                corenrn_param.outpath,
-                                               spikes_population_name);
+                                               spikes_population_name_offset);
         reports_needs_finalize = configs.size();
     }
 
@@ -600,7 +600,7 @@ extern "C" int run_solve_core(int argc, char** argv) {
     // write spike information to outpath
     {
         Instrumentor::phase p("output-spike");
-        output_spikes(output_dir.c_str(), spikes_population_name);
+        output_spikes(output_dir.c_str(), spikes_population_name_offset);
     }
 
     // copy weights back to NEURON NetCon

--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -498,6 +498,9 @@ extern "C" int run_solve_core(int argc, char** argv) {
                                                corenrn_param.outpath,
                                                spikes_population_name_offset);
         reports_needs_finalize = configs.size();
+    } else {
+        // set default population name and offset in case of no report config file
+        spikes_population_name_offset.emplace_back(std::make_pair("All", 0));
     }
 
     CheckPoints checkPoints{corenrn_param.checkpointpath, corenrn_param.restorepath};

--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -498,9 +498,6 @@ extern "C" int run_solve_core(int argc, char** argv) {
                                                corenrn_param.outpath,
                                                spikes_population_name_offset);
         reports_needs_finalize = configs.size();
-    } else {
-        // set default population name and offset in case of no report config file
-        spikes_population_name_offset.emplace_back(std::make_pair("All", 0));
     }
 
     CheckPoints checkPoints{corenrn_param.checkpointpath, corenrn_param.restorepath};

--- a/coreneuron/io/output_spikes.cpp
+++ b/coreneuron/io/output_spikes.cpp
@@ -163,12 +163,13 @@ void output_spikes_parallel(const char* outpath, const std::string& population_n
     // gid offset for each population, default is 0
     int population_offset = 0;
     sonata_create_spikefile(outpath);
-    sonata_write_spikes(population_name.data(),
-                        population_offset,
-                        spikevec_time.data(),
-                        spikevec_time.size(),
-                        spikevec_gid.data(),
-                        spikevec_gid.size());
+    sonata_add_spikes_population(population_name.data(),
+                                 population_offset,
+                                 spikevec_time.data(),
+                                 spikevec_time.size(),
+                                 spikevec_gid.data(),
+                                 spikevec_gid.size());
+    sonata_write_spike_populations();
     sonata_close_spikefile();
 #endif  // ENABLE_SONATA_REPORTS
 

--- a/coreneuron/io/output_spikes.cpp
+++ b/coreneuron/io/output_spikes.cpp
@@ -180,9 +180,9 @@ void output_spike_populations(
                                      pop_spikevec_time.size(),
                                      pop_spikevec_gid.data(),
                                      pop_spikevec_gid.size());
-#endif  // ENABLE_SONATA_REPORTS
     }
 }
+#endif  // ENABLE_SONATA_REPORTS
 
 /** Write generated spikes to out.dat using mpi parallel i/o.
  *  \todo : MPI related code should be factored into nrnmpi.c

--- a/coreneuron/io/output_spikes.cpp
+++ b/coreneuron/io/output_spikes.cpp
@@ -160,12 +160,16 @@ void output_spikes_parallel(const char* outpath, const std::string& population_n
         remove(fname.c_str());
     }
 #ifdef ENABLE_SONATA_REPORTS
+    // gid offset for each population, default is 0
+    int population_offset = 0;
+    sonata_create_spikefile(outpath);
     sonata_write_spikes(population_name.data(),
+                        population_offset,
                         spikevec_time.data(),
                         spikevec_time.size(),
                         spikevec_gid.data(),
-                        spikevec_gid.size(),
-                        outpath);
+                        spikevec_gid.size());
+    sonata_close_spikefile();
 #endif  // ENABLE_SONATA_REPORTS
 
     sort_spikes(spikevec_time, spikevec_gid);

--- a/coreneuron/io/output_spikes.cpp
+++ b/coreneuron/io/output_spikes.cpp
@@ -171,18 +171,17 @@ void output_spike_populations(
         std::string population_name = cur_pop.first;
         int population_offset = cur_pop.second;
         int gid_lower = population_offset;
-        int gid_upper = -1;
+        int gid_upper = std::numeric_limits<int>::max();
         if (idx != n_populations - 1) {
             gid_upper = population_name_offset[idx + 1].second - 1;
         }
         std::vector<double> pop_spikevec_time;
         std::vector<int> pop_spikevec_gid;
         for (int j = 0; j < spikevec_gid.size(); j++) {
-            if (spikevec_gid[j] < gid_lower || spikevec_gid[j] > gid_upper && gid_upper >= 0) {
-                continue;
+            if (spikevec_gid[j] >= gid_lower && spikevec_gid[j] <= gid_upper) {
+                pop_spikevec_time.push_back(spikevec_time[j]);
+                pop_spikevec_gid.push_back(spikevec_gid[j]);
             }
-            pop_spikevec_time.push_back(spikevec_time[j]);
-            pop_spikevec_gid.push_back(spikevec_gid[j]);
         }
         sonata_add_spikes_population(population_name.data(),
                                      population_offset,

--- a/coreneuron/io/output_spikes.cpp
+++ b/coreneuron/io/output_spikes.cpp
@@ -169,20 +169,18 @@ void output_spikes_parallel(
     sonata_create_spikefile(outpath);
     // split spikevec_time and spikevec_gid by population and write to report
     int n_populations = population_name_offset.size();
-    for (int idx = 0; idx < n_populations; idx++)
-    {
+    for (int idx = 0; idx < n_populations; idx++) {
         auto cur_pop = population_name_offset[idx];
         std::string population_name = cur_pop.first;
         int population_offset = cur_pop.second;
         int gid_lower = population_offset;
         int gid_upper = -1;
-        if ( idx != n_populations - 1 ) {
+        if (idx != n_populations - 1) {
             gid_upper = population_name_offset[idx + 1].second - 1;
         }
         std::vector<double> pop_spikevec_time;
         std::vector<int> pop_spikevec_gid;
-        for (int j = 0; j < spikevec_gid.size(); j++)
-        {
+        for (int j = 0; j < spikevec_gid.size(); j++) {
             if (spikevec_gid[j] < gid_lower || spikevec_gid[j] > gid_upper && gid_upper >= 0) {
                 continue;
             }
@@ -264,7 +262,8 @@ void output_spikes_serial(const char* outpath) {
     fclose(f);
 }
 
-void output_spikes(const char* outpath, const std::vector<std::pair<std::string, int>>& population_name_offset) {
+void output_spikes(const char* outpath,
+                   const std::vector<std::pair<std::string, int>>& population_name_offset) {
     // try to transfer spikes to NEURON. If successfull, don't write out.dat
     if (all_spikes_return(spikevec_time, spikevec_gid)) {
         clear_spike_vectors();

--- a/coreneuron/io/output_spikes.cpp
+++ b/coreneuron/io/output_spikes.cpp
@@ -155,6 +155,16 @@ void sort_spikes(std::vector<double>& spikevec_time, std::vector<int>& spikevec_
  */
 void output_spike_populations(
     const std::vector<std::pair<std::string, int>>& population_name_offset) {
+    // Write spikes with default population name and offset
+    if (population_name_offset.empty()) {
+        sonata_add_spikes_population("All",
+                                     0,
+                                     spikevec_time.data(),
+                                     spikevec_time.size(),
+                                     spikevec_gid.data(),
+                                     spikevec_gid.size());
+        return;
+    }
     int n_populations = population_name_offset.size();
     for (int idx = 0; idx < n_populations; idx++) {
         auto cur_pop = population_name_offset[idx];

--- a/coreneuron/io/output_spikes.hpp
+++ b/coreneuron/io/output_spikes.hpp
@@ -13,7 +13,9 @@
 #include <vector>
 #include <utility>
 namespace coreneuron {
-void output_spikes(const char* outpath, const std::string& population_name);
+void output_spikes(
+    const char* outpath,
+    const std::vector<std::pair<std::string, int>>& population_name_offset);
 void mk_spikevec_buffer(int);
 
 extern std::vector<double> spikevec_time;

--- a/coreneuron/io/output_spikes.hpp
+++ b/coreneuron/io/output_spikes.hpp
@@ -13,9 +13,8 @@
 #include <vector>
 #include <utility>
 namespace coreneuron {
-void output_spikes(
-    const char* outpath,
-    const std::vector<std::pair<std::string, int>>& population_name_offset);
+void output_spikes(const char* outpath,
+                   const std::vector<std::pair<std::string, int>>& population_name_offset);
 void mk_spikevec_buffer(int);
 
 extern std::vector<double> spikevec_time;

--- a/coreneuron/io/reports/nrnreport.hpp
+++ b/coreneuron/io/reports/nrnreport.hpp
@@ -102,9 +102,10 @@ struct ReportConfiguration {
 };
 
 void setup_report_engine(double dt_report, double mindelay);
-std::vector<ReportConfiguration> create_report_configurations(const std::string& filename,
-                                                              const std::string& output_dir,
-                                                              std::vector<std::pair<std::string, int>>& spikes_population_name);
+std::vector<ReportConfiguration> create_report_configurations(
+    const std::string& filename,
+    const std::string& output_dir,
+    std::vector<std::pair<std::string, int>>& spikes_population_name);
 void finalize_report();
 void nrn_flush_reports(double t);
 void set_report_buffer_size(int n);

--- a/coreneuron/io/reports/nrnreport.hpp
+++ b/coreneuron/io/reports/nrnreport.hpp
@@ -104,7 +104,7 @@ struct ReportConfiguration {
 void setup_report_engine(double dt_report, double mindelay);
 std::vector<ReportConfiguration> create_report_configurations(const std::string& filename,
                                                               const std::string& output_dir,
-                                                              std::string& spikes_population_name);
+                                                              std::vector<std::pair<std::string, int>>& spikes_population_name);
 void finalize_report();
 void nrn_flush_reports(double t);
 void set_report_buffer_size(int n);

--- a/coreneuron/io/reports/report_configuration_parser.cpp
+++ b/coreneuron/io/reports/report_configuration_parser.cpp
@@ -102,9 +102,10 @@ void register_target_type(ReportConfiguration& report, ReportType report_type) {
     }
 }
 
-std::vector<ReportConfiguration> create_report_configurations(const std::string& conf_file,
-                                                              const std::string& output_dir,
-                                                              std::vector<std::pair<std::string, int>>& spikes_population_name_offset) {
+std::vector<ReportConfiguration> create_report_configurations(
+    const std::string& conf_file,
+    const std::string& output_dir,
+    std::vector<std::pair<std::string, int>>& spikes_population_name_offset) {
     std::vector<ReportConfiguration> reports;
     std::string report_on;
     int target;
@@ -161,9 +162,10 @@ std::vector<ReportConfiguration> create_report_configurations(const std::string&
     report_conf >> num_populations;
     std::string spikes_population_name;
     int spikes_population_offset;
-    for (int i = 0; i< num_populations; i++) {
+    for (int i = 0; i < num_populations; i++) {
         report_conf >> spikes_population_name >> spikes_population_offset;
-        spikes_population_name_offset.emplace_back(std::make_pair(spikes_population_name, spikes_population_offset));
+        spikes_population_name_offset.emplace_back(
+            std::make_pair(spikes_population_name, spikes_population_offset));
     }
 
     return reports;

--- a/coreneuron/io/reports/report_configuration_parser.cpp
+++ b/coreneuron/io/reports/report_configuration_parser.cpp
@@ -104,7 +104,7 @@ void register_target_type(ReportConfiguration& report, ReportType report_type) {
 
 std::vector<ReportConfiguration> create_report_configurations(const std::string& conf_file,
                                                               const std::string& output_dir,
-                                                              std::string& spikes_population_name) {
+                                                              std::vector<std::pair<std::string, int>>& spikes_population_name_offset) {
     std::vector<ReportConfiguration> reports;
     std::string report_on;
     int target;
@@ -157,8 +157,15 @@ std::vector<ReportConfiguration> create_report_configurations(const std::string&
         }
         reports.push_back(report);
     }
+    int num_populations = 0;
+    report_conf >> num_populations;
+    std::string spikes_population_name;
+    int spikes_population_offset;
+    for (int i = 0; i< num_populations; i++) {
+        report_conf >> spikes_population_name >> spikes_population_offset;
+        spikes_population_name_offset.emplace_back(std::make_pair(spikes_population_name, spikes_population_offset));
+    }
 
-    report_conf >> spikes_population_name;
     return reports;
 }
 }  // namespace coreneuron

--- a/coreneuron/io/reports/report_configuration_parser.cpp
+++ b/coreneuron/io/reports/report_configuration_parser.cpp
@@ -158,12 +158,22 @@ std::vector<ReportConfiguration> create_report_configurations(
         }
         reports.push_back(report);
     }
-    int num_populations = 0;
-    report_conf >> num_populations;
+    // read population information for spike report
+    int num_populations;
     std::string spikes_population_name;
     int spikes_population_offset;
+    if (isdigit(report_conf.peek())) {
+        report_conf >> num_populations;
+    } else {
+        // support old format: one single line "All"
+        num_populations = 1;
+    }
     for (int i = 0; i < num_populations; i++) {
-        report_conf >> spikes_population_name >> spikes_population_offset;
+        if (!(report_conf >> spikes_population_name >> spikes_population_offset)) {
+            // support old format: one single line "All"
+            report_conf >> spikes_population_name;
+            spikes_population_offset = 0;
+        }
         spikes_population_name_offset.emplace_back(
             std::make_pair(spikes_population_name, spikes_population_offset));
     }


### PR DESCRIPTION
**Description**

Adapt to the new feature from libsonata-report for spike report writing, i.e. do create_file/write data/close_file in separate steps.  
The spike data also requires gid offset for each population, use default 0 at the moment.

Fixes # (issue)

**How to test this?**
The Simulation Stack CI

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:SPACK_BRANCH=spike_multipop,NEURODAMUS_CORE_BRANCH=sandbox/weji/report_multipop,PYNEURODAMUS_BRANCH=sandbox/weji/report_multipop,
