### PR TITLE
Modernise CMake/CUDA and fix link issues

### DIFF
--- a/CMake/OpenAccHelper.cmake
+++ b/CMake/OpenAccHelper.cmake
@@ -8,51 +8,40 @@
 # Prepare compiler flags for GPU target
 # =============================================================================
 if(CORENRN_ENABLE_GPU)
-
   # cuda unified memory support
   if(CORENRN_ENABLE_CUDA_UNIFIED_MEMORY)
     set(UNIFIED_MEMORY_DEF -DUNIFIED_MEMORY)
   endif()
-
-  # if user don't specify host compiler, use gcc from $PATH
-  if(NOT CUDA_HOST_COMPILER)
-    find_program(GCC_BIN gcc)
-    set(CUDA_HOST_COMPILER
-        ${GCC_BIN}
-        CACHE FILEPATH "" FORCE)
-  endif()
-
-  # various flags for PGI compiler with GPU build
-  if(${CMAKE_C_COMPILER_ID} STREQUAL "PGI" OR ${CMAKE_C_COMPILER_ID} STREQUAL "NVHPC")
-    # find_cuda produce verbose messages : use new behavior to use _ROOT variables
-    if(POLICY CMP0074)
-      cmake_policy(SET CMP0074 NEW)
-    endif()
-    find_package(CUDA 9.0 REQUIRED)
-    set(CUDA_SEPARABLE_COMPILATION ON)
-    set(CUDA_PROPAGATE_HOST_FLAGS OFF)
-    set(CUDA_PROFILING_DEF -DCUDA_PROFILING)
-    set(PGI_ACC_FLAGS "-acc -gpu=cuda${CUDA_VERSION}")
-    # ${CORENRN_GPU_CUDA_COMPUTE_CAPABILITY} is {60, 70[, ...]} then generate
-    # -gpu=cudaX.Y,cc60,cc70[,...]. It is important that the architectures used to compile OpenACC
-    # C++ code are compatible with those used to compile the CUDA code that is linked in, otherwise
-    # there will be unhelpful linker errors. This also goes for the CUDA version itself, which may
-    # not be correctly detected if the build system does not itself have a GPU.
-    foreach(compute_capability ${CORENRN_GPU_CUDA_COMPUTE_CAPABILITY})
-      string(APPEND PGI_ACC_FLAGS ",cc${compute_capability}")
-    endforeach()
-    # disable very verbose diagnosis messages and obvious warnings for mod2c
-    set(PGI_DIAG_FLAGS "--diag_suppress 161,177,550")
-    # avoid PGI adding standard compliant "-A" flags
-    set(CMAKE_CXX11_STANDARD_COMPILE_OPTION --c++11)
-    set(CMAKE_CXX14_STANDARD_COMPILE_OPTION --c++14)
-
-  else()
+  # This is a lazy way of getting the major/minor versions separately without parsing
+  # ${CMAKE_CUDA_COMPILER_VERSION}
+  find_package(CUDAToolkit 9.0 REQUIRED)
+  # Be a bit paranoid
+  if(NOT ${CMAKE_CUDA_COMPILER_VERSION} STREQUAL ${CUDAToolkit_VERSION})
     message(
-      FATAL_ERROR "GPU support is available via OpenACC using PGI/NVIDIA compilers."
-                  " Use NVIDIA HPC SDK with -DCMAKE_C_COMPILER=nvc -DCMAKE_CXX_COMPILER=nvc++")
+      FATAL_ERROR
+        "CUDA compiler (${CMAKE_CUDA_COMPILER_VERSION}) and toolkit (${CUDAToolkit_VERSION}) versions are not the same!"
+    )
   endif()
-
+  set(CUDA_PROFILING_DEF -DCUDA_PROFILING)
+  # -acc enables OpenACC support, -cuda links CUDA libraries and (very importantly!) seems to be
+  # required so make the NVHPC compiler do the device code linking. Otherwise the explicit CUDA
+  # device code (.cu files in libcudacoreneuron) has to be linked in a separate, earlier, step,
+  # which causes problems with interoperability with OpenACC. See
+  # https://github.com/BlueBrain/CoreNeuron/issues/607 for more information about this. -gpu=cudaX.Y
+  # ensures that OpenACC code is compiled with the same CUDA version as is used for the explicit
+  # CUDA code.
+  set(PGI_ACC_FLAGS "-acc -cuda -gpu=cuda${CUDAToolkit_VERSION_MAJOR}.${CUDAToolkit_VERSION_MINOR}")
+  # Make sure that OpenACC code is generated for the same compute capabilities as the explicit CUDA
+  # code. Otherwise there may be confusing linker errors. We cannot rely on nvcc and nvc++ using the
+  # same default compute capabilities as each other, particularly on GPU-less build machines.
+  foreach(compute_capability ${CMAKE_CUDA_ARCHITECTURES})
+    string(APPEND PGI_ACC_FLAGS ",cc${compute_capability}")
+  endforeach()
+  # disable very verbose diagnosis messages and obvious warnings for mod2c
+  set(PGI_DIAG_FLAGS "--diag_suppress 161,177,550")
+  # avoid PGI adding standard compliant "-A" flags
+  set(CMAKE_CXX11_STANDARD_COMPILE_OPTION --c++11)
+  set(CMAKE_CXX14_STANDARD_COMPILE_OPTION --c++14)
   set(CORENRN_ACC_GPU_DEFS "${UNIFIED_MEMORY_DEF} ${CUDA_PROFILING_DEF}")
   set(CORENRN_ACC_GPU_FLAGS "${PGI_ACC_FLAGS} ${PGI_DIAG_FLAGS}")
 
@@ -68,7 +57,7 @@ if(CORENRN_ENABLE_GPU)
     GLOBAL
     PROPERTY
       CORENEURON_LIB_LINK_FLAGS
-      "${PGI_ACC_FLAGS} -rdynamic -lrt -Wl,--whole-archive -L${CMAKE_HOST_SYSTEM_PROCESSOR} -lcorenrnmech -L${CMAKE_INSTALL_PREFIX}/lib -lcoreneuron -lcudacoreneuron -Wl,--no-whole-archive ${CUDA_cudart_static_LIBRARY}"
+      "${PGI_ACC_FLAGS} -rdynamic -lrt -Wl,--whole-archive -L${CMAKE_HOST_SYSTEM_PROCESSOR} -lcorenrnmech -L${CMAKE_INSTALL_PREFIX}/lib -lcoreneuron -lcudacoreneuron -Wl,--no-whole-archive"
   )
 else()
   set_property(GLOBAL PROPERTY CORENEURON_LIB_LINK_FLAGS

--- a/CMake/OpenAccHelper.cmake
+++ b/CMake/OpenAccHelper.cmake
@@ -14,15 +14,38 @@ if(CORENRN_ENABLE_GPU)
   if(CORENRN_ENABLE_CUDA_UNIFIED_MEMORY)
     add_compile_definitions(CORENEURON_UNIFIED_MEMORY)
   endif()
-  # This is a lazy way of getting the major/minor versions separately without parsing
-  # ${CMAKE_CUDA_COMPILER_VERSION}
-  find_package(CUDAToolkit 9.0 REQUIRED)
-  # Be a bit paranoid
-  if(NOT ${CMAKE_CUDA_COMPILER_VERSION} STREQUAL ${CUDAToolkit_VERSION})
-    message(
-      FATAL_ERROR
-        "CUDA compiler (${CMAKE_CUDA_COMPILER_VERSION}) and toolkit (${CUDAToolkit_VERSION}) versions are not the same!"
-    )
+  if(${CMAKE_VERSION} VERSION_LESS 3.17)
+    # Hopefully we can drop this soon. Parse ${CMAKE_CUDA_COMPILER_VERSION} into a shorter X.Y
+    # version without any patch version.
+    if(NOT ${CMAKE_CUDA_COMPILER_ID} STREQUAL "NVIDIA")
+      message(FATAL_ERROR "Unsupported CUDA compiler ${CMAKE_CUDA_COMPILER_ID}")
+    endif()
+    # Parse CMAKE_CUDA_COMPILER_VERSION=x.y.z into CUDA_VERSION=x.y
+    string(FIND ${CMAKE_CUDA_COMPILER_VERSION} . first_dot)
+    math(EXPR first_dot_plus_one "${first_dot}+1")
+    string(SUBSTRING ${CMAKE_CUDA_COMPILER_VERSION} ${first_dot_plus_one} -1 minor_and_later)
+    string(FIND ${minor_and_later} . second_dot_relative)
+    if(${first_dot} EQUAL -1 OR ${second_dot_relative} EQUAL -1)
+      message(
+        FATAL_ERROR
+          "Failed to parse a CUDA_VERSION from CMAKE_CUDA_COMPILER_VERSION=${CMAKE_CUDA_COMPILER_VERSION}"
+      )
+    endif()
+    math(EXPR second_dot_plus_one "${first_dot}+${second_dot_relative}+1")
+    string(SUBSTRING ${CMAKE_CUDA_COMPILER_VERSION} 0 ${second_dot_plus_one}
+                     CORENRN_CUDA_VERSION_SHORT)
+  else()
+    # This is a lazy way of getting the major/minor versions separately without parsing
+    # ${CMAKE_CUDA_COMPILER_VERSION}
+    find_package(CUDAToolkit 9.0 REQUIRED)
+    # Be a bit paranoid
+    if(NOT ${CMAKE_CUDA_COMPILER_VERSION} STREQUAL ${CUDAToolkit_VERSION})
+      message(
+        FATAL_ERROR
+          "CUDA compiler (${CMAKE_CUDA_COMPILER_VERSION}) and toolkit (${CUDAToolkit_VERSION}) versions are not the same!"
+      )
+    endif()
+    set(CORENRN_CUDA_VERSION_SHORT "${CUDAToolkit_VERSION_MAJOR}.${CUDAToolkit_VERSION_MINOR}")
   endif()
   # -acc enables OpenACC support, -cuda links CUDA libraries and (very importantly!) seems to be
   # required to make the NVHPC compiler do the device code linking. Otherwise the explicit CUDA
@@ -32,8 +55,7 @@ if(CORENRN_ENABLE_GPU)
   # due to e.g. __CUDACC__ being defined. See https://github.com/BlueBrain/CoreNeuron/issues/607 for
   # more information about this. -gpu=cudaX.Y ensures that OpenACC code is compiled with the same
   # CUDA version as is used for the explicit CUDA code.
-  set(NVHPC_ACC_COMP_FLAGS
-      "-acc -gpu=cuda${CUDAToolkit_VERSION_MAJOR}.${CUDAToolkit_VERSION_MINOR}")
+  set(NVHPC_ACC_COMP_FLAGS "-acc -gpu=cuda${CORENRN_CUDA_VERSION_SHORT}")
   set(NVHPC_ACC_LINK_FLAGS "-cuda")
   # Make sure that OpenACC code is generated for the same compute capabilities as the explicit CUDA
   # code. Otherwise there may be confusing linker errors. We cannot rely on nvcc and nvc++ using the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,11 @@
 #
 # See top-level LICENSE file for details.
 # =============================================================================
-
 cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
-project(coreneuron VERSION 0.21.0)
+project(
+  coreneuron
+  VERSION 1.0
+  LANGUAGES C CXX)
 
 # ~~~
 # It is a bad idea having floating point versions, since macros cant handle them
@@ -96,15 +98,38 @@ option(CORENRN_ENABLE_SHARED "Enable shared library build" ON)
 option(CORENRN_ENABLE_LEGACY_UNITS "Enable legacy FARADAY, R, etc" OFF)
 option(CORENRN_ENABLE_PRCELLSTATE "Enable NRN_PRCELLSTATE debug feature" OFF)
 
-set(CORENRN_GPU_CUDA_COMPUTE_CAPABILITY
-    "60" "70"
-    CACHE STRING "List of CUDA compute capabilities to compile CUDA/OpenACC for")
 set(CORENRN_NMODL_DIR
     ""
     CACHE PATH "Path to nmodl source-to-source compiler installation")
 set(LIKWID_DIR
     ""
     CACHE PATH "Path to likwid performance analysis suite")
+
+# Older CMake versions label NVHPC as PGI, newer ones label it as NVHPC.
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "PGI" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "NVHPC")
+  set(CORENRN_HAVE_NVHPC_COMPILER ON)
+else()
+  set(CORENRN_HAVE_NVHPC_COMPILER OFF)
+endif()
+if(CORENRN_ENABLE_GPU)
+  # find_package(CUDAToolkit), for example
+  if(${CMAKE_VERSION} VERSION_LESS 3.17)
+    message(FATAL_ERROR "GPU support requires at least CMake v3.17!")
+  endif()
+  # Fail hard and early if we don't have the PGI/NVHPC compiler.
+  if(NOT CORENRN_HAVE_NVHPC_COMPILER)
+    message(
+      FATAL_ERROR "GPU support is available via OpenACC using PGI/NVIDIA compilers."
+                  " Use NVIDIA HPC SDK with -DCMAKE_C_COMPILER=nvc -DCMAKE_CXX_COMPILER=nvc++")
+  endif()
+  # Set some sensible default CUDA architectures.
+  if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(CMAKE_CUDA_ARCHITECTURES 60 70)
+    message(STATUS "Setting default CUDA architectures to ${CMAKE_CUDA_ARCHITECTURES}")
+  endif()
+  # Enable CUDA language support.
+  enable_language(CUDA)
+endif()
 
 # =============================================================================
 # Project version from git and project directories
@@ -141,7 +166,7 @@ endif()
 # =============================================================================
 # Build option specific compiler flags
 # =============================================================================
-if(${CMAKE_CXX_COMPILER_ID} STREQUAL "PGI" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "NVHPC")
+if(CORENRN_HAVE_NVHPC_COMPILER)
   # PGI with llvm code generation doesn't have necessary assembly intrinsic headers
   add_definitions(-DEIGEN_DONT_VECTORIZE=1)
 endif()
@@ -390,57 +415,58 @@ endif()
 message(STATUS "")
 message(STATUS "Configured CoreNEURON ${PROJECT_VERSION}")
 message(STATUS "")
-string(TOLOWER "${CMAKE_GENERATOR}" cmake_generator_tolower)
-if(cmake_generator_tolower MATCHES "makefile")
-  message(STATUS "Some things you can do now:")
-  message(STATUS "--------------------+--------------------------------------------------------")
-  message(STATUS "Command             |   Description")
-  message(STATUS "--------------------+--------------------------------------------------------")
-  message(STATUS "make install        | Will install CoreNEURON to: ${CMAKE_INSTALL_PREFIX}")
-  message(STATUS "make docs           | Build full docs. Calls targets: doxygen, sphinx")
-  message(STATUS "--------------------+--------------------------------------------------------")
-  message(STATUS " Build option       | Status")
-  message(STATUS "--------------------+--------------------------------------------------------")
-
-  message(STATUS "C COMPILER          | ${CMAKE_C_COMPILER}")
-  message(STATUS "CXX COMPILER        | ${CMAKE_CXX_COMPILER}")
-  message(STATUS "COMPILE FLAGS       | ${CORENRN_CXX_FLAGS}")
-  message(STATUS "Build Type          | ${COMPILE_LIBRARY_TYPE}")
-  message(STATUS "MPI                 | ${CORENRN_ENABLE_MPI}")
-  if(CORENRN_ENABLE_MPI)
-    message(STATUS "  INC               | ${MPI_C_INCLUDE_PATH}")
-  endif()
-  message(STATUS "OpenMP              | ${CORENRN_ENABLE_OPENMP}")
-  message(STATUS "Use legacy units    | ${CORENRN_ENABLE_LEGACY_UNITS}")
-  message(STATUS "NMODL               | ${CORENRN_ENABLE_NMODL}")
-  if(CORENRN_ENABLE_NMODL)
-    message(STATUS "  ISPC              | ${CORENRN_ENABLE_ISPC}")
-    message(STATUS "  FLAGS             | ${CORENRN_NMODL_FLAGS}")
-  endif()
-  message(STATUS "MOD2CPP PATH        | ${CORENRN_MOD2CPP_BINARY}")
-  message(STATUS "GPU Support         | ${CORENRN_ENABLE_GPU}")
-  if(CORENRN_ENABLE_GPU)
-    message(STATUS "  CUDA              | ${CUDA_TOOLKIT_ROOT_DIR}")
-    message(STATUS "  Unified Memory    | ${CORENRN_ENABLE_CUDA_UNIFIED_MEMORY}")
-    message(STATUS "  HOST COMPILER     | ${CUDA_HOST_COMPILER}")
-  endif()
-  message(STATUS "Auto Timeout        | ${CORENRN_ENABLE_TIMEOUT}")
-  message(STATUS "Wrap exp()          | ${CORENRN_ENABLE_HOC_EXP}")
-  message(STATUS "SplayTree Queue     | ${CORENRN_ENABLE_SPLAYTREE_QUEUING}")
-  message(STATUS "NetReceive Buffer   | ${CORENRN_ENABLE_NET_RECEIVE_BUFFER}")
-  message(STATUS "Caliper             | ${CORENRN_ENABLE_CALIPER_PROFILING}")
-  message(STATUS "Likwid              | ${CORENRN_ENABLE_LIKWID_PROFILING}")
-  message(STATUS "Unit Tests          | ${CORENRN_ENABLE_UNIT_TESTS}")
-  message(STATUS "Reporting           | ${CORENRN_ENABLE_REPORTING}")
-  if(CORENRN_ENABLE_REPORTING)
-    message(STATUS "  sonatareport_INC  | ${sonatareport_INCLUDE_DIR}")
-    message(STATUS "  sonatareport_LIB  | ${sonatareport_LIBRARY}")
-    message(STATUS "  reportinglib_INC  | ${reportinglib_INCLUDE_DIR}")
-    message(STATUS "  reportinglib_LIB  | ${reportinglib_LIBRARY}")
-  endif()
-
-  message(STATUS "--------------+--------------------------------------------------------------")
-  message(STATUS " See documentation : https://github.com/BlueBrain/CoreNeuron/")
-  message(STATUS "--------------+--------------------------------------------------------------")
+message(STATUS "You can now build CoreNEURON using:")
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  message(STATUS "  cmake --build . [--target TARGET] -- -j 8")
+else()
+  message(STATUS "  cmake --build . --parallel 8 [--target TARGET]")
 endif()
+message(STATUS "You might want to adjust the number of parallel build jobs for your system.")
+message(STATUS "Some non-default targets you might want to build:")
+message(STATUS "--------------------+--------------------------------------------------------")
+message(STATUS " Target             |   Description")
+message(STATUS "--------------------+--------------------------------------------------------")
+message(STATUS "install             | Will install CoreNEURON to: ${CMAKE_INSTALL_PREFIX}")
+message(STATUS "docs                | Build full docs. Calls targets: doxygen, sphinx")
+message(STATUS "--------------------+--------------------------------------------------------")
+message(STATUS " Build option       | Status")
+message(STATUS "--------------------+--------------------------------------------------------")
+message(STATUS "C COMPILER          | ${CMAKE_C_COMPILER}")
+message(STATUS "CXX COMPILER        | ${CMAKE_CXX_COMPILER}")
+message(STATUS "COMPILE FLAGS       | ${CORENRN_CXX_FLAGS}")
+message(STATUS "Build Type          | ${COMPILE_LIBRARY_TYPE}")
+message(STATUS "MPI                 | ${CORENRN_ENABLE_MPI}")
+if(CORENRN_ENABLE_MPI)
+  message(STATUS "  INC               | ${MPI_C_INCLUDE_PATH}")
+endif()
+message(STATUS "OpenMP              | ${CORENRN_ENABLE_OPENMP}")
+message(STATUS "Use legacy units    | ${CORENRN_ENABLE_LEGACY_UNITS}")
+message(STATUS "NMODL               | ${CORENRN_ENABLE_NMODL}")
+if(CORENRN_ENABLE_NMODL)
+  message(STATUS "  ISPC              | ${CORENRN_ENABLE_ISPC}")
+  message(STATUS "  FLAGS             | ${CORENRN_NMODL_FLAGS}")
+endif()
+message(STATUS "MOD2CPP PATH        | ${CORENRN_MOD2CPP_BINARY}")
+message(STATUS "GPU Support         | ${CORENRN_ENABLE_GPU}")
+if(CORENRN_ENABLE_GPU)
+  message(STATUS "  CUDA              | ${CUDAToolkit_LIBRARY_DIR}")
+  message(STATUS "  Unified Memory    | ${CORENRN_ENABLE_CUDA_UNIFIED_MEMORY}")
+endif()
+message(STATUS "Auto Timeout        | ${CORENRN_ENABLE_TIMEOUT}")
+message(STATUS "Wrap exp()          | ${CORENRN_ENABLE_HOC_EXP}")
+message(STATUS "SplayTree Queue     | ${CORENRN_ENABLE_SPLAYTREE_QUEUING}")
+message(STATUS "NetReceive Buffer   | ${CORENRN_ENABLE_NET_RECEIVE_BUFFER}")
+message(STATUS "Caliper             | ${CORENRN_ENABLE_CALIPER_PROFILING}")
+message(STATUS "Likwid              | ${CORENRN_ENABLE_LIKWID_PROFILING}")
+message(STATUS "Unit Tests          | ${CORENRN_ENABLE_UNIT_TESTS}")
+message(STATUS "Reporting           | ${CORENRN_ENABLE_REPORTING}")
+if(CORENRN_ENABLE_REPORTING)
+  message(STATUS "  sonatareport_INC  | ${sonatareport_INCLUDE_DIR}")
+  message(STATUS "  sonatareport_LIB  | ${sonatareport_LIBRARY}")
+  message(STATUS "  reportinglib_INC  | ${reportinglib_INCLUDE_DIR}")
+  message(STATUS "  reportinglib_LIB  | ${reportinglib_LIBRARY}")
+endif()
+message(STATUS "--------------+--------------------------------------------------------------")
+message(STATUS " See documentation : https://github.com/BlueBrain/CoreNeuron/")
+message(STATUS "--------------+--------------------------------------------------------------")
 message(STATUS "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,8 +119,10 @@ if(CORENRN_ENABLE_GPU)
   # Fail hard and early if we don't have the PGI/NVHPC compiler.
   if(NOT CORENRN_HAVE_NVHPC_COMPILER)
     message(
-      FATAL_ERROR "GPU support is available via OpenACC using PGI/NVIDIA compilers."
-                  " Use NVIDIA HPC SDK with -DCMAKE_C_COMPILER=nvc -DCMAKE_CXX_COMPILER=nvc++")
+      FATAL_ERROR
+        "GPU support is available via OpenACC using PGI/NVIDIA compilers."
+        " Use NVIDIA HPC SDK with -DCMAKE_C_COMPILER=nvc -DCMAKE_CUDA_COMPILER=nvcc -DCMAKE_CXX_COMPILER=nvc++"
+    )
   endif()
   # Set some sensible default CUDA architectures.
   if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,11 +111,17 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "PGI" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL 
 else()
   set(CORENRN_HAVE_NVHPC_COMPILER OFF)
 endif()
+
 if(CORENRN_ENABLE_GPU)
-  # find_package(CUDAToolkit), for example
-  if(${CMAKE_VERSION} VERSION_LESS 3.17)
-    message(FATAL_ERROR "GPU support requires at least CMake v3.17!")
+  # Older CMake versions have not been tested for GPU/CUDA/OpenACC support after
+  # https://github.com/BlueBrain/CoreNeuron/pull/609.
+  # https://cmake.org/cmake/help/latest/release/3.14.html#properties suggests there would be
+  # problems because of expressions like set_target_properties(lfp_test_bin PROPERTIES
+  # CUDA_RESOLVE_DEVICE_SYMBOLS OFF)
+  if(${CMAKE_VERSION} VERSION_LESS 3.15)
+    message(FATAL_ERROR "GPU support requires at least CMake v3.15!")
   endif()
+
   # Fail hard and early if we don't have the PGI/NVHPC compiler.
   if(NOT CORENRN_HAVE_NVHPC_COMPILER)
     message(
@@ -124,16 +130,44 @@ if(CORENRN_ENABLE_GPU)
         " Use NVIDIA HPC SDK with -DCMAKE_C_COMPILER=nvc -DCMAKE_CUDA_COMPILER=nvcc -DCMAKE_CXX_COMPILER=nvc++"
     )
   endif()
+
   # Set some sensible default CUDA architectures.
   if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     set(CMAKE_CUDA_ARCHITECTURES 60 70)
     message(STATUS "Setting default CUDA architectures to ${CMAKE_CUDA_ARCHITECTURES}")
   endif()
+
   # Enable CUDA language support.
   enable_language(CUDA)
-  # nvc++ -cuda implicitly links dynamically to libcudart.so. Setting this makes sure that CMake
-  # does not add -lcudart_static and trigger errors due to mixed dynamic/static linkage.
-  set(CMAKE_CUDA_RUNTIME_LIBRARY Shared)
+
+  # Prefer shared libcudart.so
+  if(${CMAKE_VERSION} VERSION_LESS 3.17)
+    # Ugly workaround from https://gitlab.kitware.com/cmake/cmake/-/issues/17559, remove when
+    # possible
+    if(CMAKE_CUDA_HOST_IMPLICIT_LINK_LIBRARIES)
+      list(REMOVE_ITEM CMAKE_CUDA_HOST_IMPLICIT_LINK_LIBRARIES "cudart_static")
+      list(REMOVE_ITEM CMAKE_CUDA_HOST_IMPLICIT_LINK_LIBRARIES "cudadevrt")
+      list(APPEND CMAKE_CUDA_HOST_IMPLICIT_LINK_LIBRARIES "cudart")
+    endif()
+    if(CMAKE_CUDA_IMPLICIT_LINK_LIBRARIES)
+      list(REMOVE_ITEM CMAKE_CUDA_IMPLICIT_LINK_LIBRARIES "cudart_static")
+      list(REMOVE_ITEM CMAKE_CUDA_IMPLICIT_LINK_LIBRARIES "cudadevrt")
+      list(APPEND CMAKE_CUDA_IMPLICIT_LINK_LIBRARIES "cudart")
+    endif()
+  else()
+    # nvc++ -cuda implicitly links dynamically to libcudart.so. Setting this makes sure that CMake
+    # does not add -lcudart_static and trigger errors due to mixed dynamic/static linkage.
+    set(CMAKE_CUDA_RUNTIME_LIBRARY Shared)
+  endif()
+
+  # Patch CUDA_ARCHITECTURES support into older CMake versions
+  if(${CMAKE_VERSION} VERSION_LESS 3.18)
+    foreach(cuda_arch ${CMAKE_CUDA_ARCHITECTURES})
+      string(
+        APPEND CMAKE_CUDA_FLAGS
+        "--generate-code=arch=compute_${cuda_arch},code=[compute_${cuda_arch},sm_${cuda_arch}]")
+    endforeach()
+  endif()
 endif()
 
 # =============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,9 @@ if(CORENRN_ENABLE_GPU)
   endif()
   # Enable CUDA language support.
   enable_language(CUDA)
+  # nvc++ -cuda implicitly links dynamically to libcudart.so. Setting this makes sure that CMake
+  # does not add -lcudart_static and trigger errors due to mixed dynamic/static linkage.
+  set(CMAKE_CUDA_RUNTIME_LIBRARY Shared)
 endif()
 
 # =============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,12 @@ if(CORENRN_ENABLE_GPU)
     message(STATUS "Setting default CUDA architectures to ${CMAKE_CUDA_ARCHITECTURES}")
   endif()
 
+  if(${CMAKE_VERSION} VERSION_LESS 3.16)
+    if(DEFINED CMAKE_CUDA_HOST_COMPILER)
+      unset(ENV{CUDAHOSTCXX})
+    endif()
+  endif()
+
   # Enable CUDA language support.
   enable_language(CUDA)
 
@@ -165,7 +171,7 @@ if(CORENRN_ENABLE_GPU)
     foreach(cuda_arch ${CMAKE_CUDA_ARCHITECTURES})
       string(
         APPEND CMAKE_CUDA_FLAGS
-        "--generate-code=arch=compute_${cuda_arch},code=[compute_${cuda_arch},sm_${cuda_arch}]")
+        " --generate-code=arch=compute_${cuda_arch},code=[compute_${cuda_arch},sm_${cuda_arch}]")
     endforeach()
   endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Note that if you are building on Cray system with the GNU toolchain, you have to
    -DNRN_ENABLE_RX3D=OFF \
    -DCMAKE_INSTALL_PREFIX=$HOME/install
    -DCMAKE_C_COMPILER=nvc \
-   -DCMAKE_CXX_COMPILER=nvc++
+   -DCMAKE_CXX_COMPILER=nvc++ \
+   -DCMAKE_CUDA_COMPILER=nvcc
   ```
 
   By default the GPU code will be compiled for NVIDIA devices with compute

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Note that if you are building on Cray system with the GNU toolchain, you have to
 
   By default the GPU code will be compiled for NVIDIA devices with compute
   capability 6.0 or 7.0. This can be steered by passing, for example,
-  `-DCORENRN_GPU_CUDA_COMPUTE_CAPABILITY:STRING=50;60;70` to CMake.
+  `-DCMAKE_CUDA_ARCHITECTURES=50;60;70` to CMake.
 
 NOTE : If the CMake command fails, please make sure to delete temporary CMake cache files (`CMakeCache.txt`) before rerunning CMake.
 

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -29,9 +29,10 @@ file(
   "mpi/*.cpp"
   "network/*.cpp"
   "permute/*.cpp"
-  "sim/*.cpp")
-file(GLOB_RECURSE CORENEURON_UTILS_FILES "utils/*.c*")
-list(APPEND CORENEURON_CODE_FILES ${CORENEURON_UTILS_FILES})
+  "sim/*.cpp"
+  "utils/*.cpp"
+  "utils/*/*.c"
+  "utils/*/*.cpp")
 file(GLOB_RECURSE CORENEURON_CUDA_FILES "*.cu")
 file(GLOB SCOPMATH_CODE_FILES "sim/scopmath/*.cpp")
 file(COPY ${CORENEURON_PROJECT_SOURCE_DIR}/external/Random123/include/Random123
@@ -124,32 +125,17 @@ if(CORENRN_ENABLE_GPU)
   set_source_files_properties(${OPENACC_EXCLUDED_FILES} PROPERTIES COMPILE_FLAGS
                                                                    "-DDISABLE_OPENACC")
 
-  # if ${CORENRN_GPU_CUDA_COMPUTE_CAPABILITY} is {60[, ...]} then generate
-  # --generate-code=arch=compute_60,code=sm_60 --generate-code=arch=compute_60,code=compute_60, this
-  # is modelled after
-  # https://github.com/spack/spack/blob/a586fa6dd342ec39f2044f9dc035dd61b58f197d/lib/spack/spack/build_systems/cuda.py#L41-L47
-  # and the links therein.
-  foreach(compute_capability ${CORENRN_GPU_CUDA_COMPUTE_CAPABILITY})
-    list(APPEND cuda_arch_flags
-         "--generate-code=arch=compute_${compute_capability},code=sm_${compute_capability}")
-    list(APPEND cuda_arch_flags
-         "--generate-code=arch=compute_${compute_capability},code=compute_${compute_capability}")
-  endforeach()
-  cuda_add_library("cudacoreneuron" ${CORENEURON_CUDA_FILES} OPTIONS ${cuda_arch_flags} -Xcompiler
-                                                                     -fPIC)
+  add_library(cudacoreneuron STATIC ${CORENEURON_CUDA_FILES})
+  set_target_properties(cudacoreneuron PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
   set(link_cudacoreneuron cudacoreneuron)
   # nrnran123.cpp is a symlink to nrnran123.cu, in GPU builds we compile this as CUDA code (so we
-  # want to remove the .cpp here), while in non-GPU builds we compile it as plain C++ (so we want to
-  # remove the .cu below). Unfortunately CMake <v3.20 does not pass explicit -x <lang> options based
-  # on the LANGUAGE property (https://cmake.org/cmake/help/latest/policy/CMP0119.html), so using a
-  # single .cu file and setting LANGUAGE=CXX in non-GPU builds does not work.
+  # want to remove the .cpp here), while in non-GPU builds we compile it as plain C++. Unfortunately
+  # CMake <v3.20 does not pass explicit -x <lang> options based on the LANGUAGE property
+  # (https://cmake.org/cmake/help/latest/policy/CMP0119.html), so using a single .cu file and
+  # setting LANGUAGE=CXX in non-GPU builds does not work.
   list(REMOVE_ITEM CORENEURON_CODE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/utils/randoms/nrnran123.cpp")
-  list(REMOVE_ITEM CORENEURON_UTILS_FILES "${CMAKE_CURRENT_SOURCE_DIR}/utils/randoms/nrnran123.cpp")
 else()
   set(link_cudacoreneuron "")
-  # See above regarding CMake policy CMP0119.
-  list(REMOVE_ITEM CORENEURON_CODE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/utils/randoms/nrnran123.cu")
-  list(REMOVE_ITEM CORENEURON_UTILS_FILES "${CMAKE_CURRENT_SOURCE_DIR}/utils/randoms/nrnran123.cu")
 endif()
 
 # =============================================================================
@@ -183,6 +169,11 @@ add_custom_target(kin_deriv_header DEPENDS "${KINDERIV_HEADER_FILE}")
 add_library(
   coreneuron ${COMPILE_LIBRARY_TYPE} ${CORENEURON_HEADER_FILES} ${CORENEURON_TEMPLATE_FILES}
              ${CORENEURON_CODE_FILES} ${cudacorenrn_objs} ${NMODL_INBUILT_MOD_OUTPUTS})
+# Prevent CMake from running a device code link step when assembling libcoreneuron.a in GPU builds.
+# The device code linking needs to be deferred to the final step, where it is done by `nvc++ -cuda`.
+# OL210811: it's not clear why this is needed, given that coreneuron is a static library in GPU
+# builds.
+set_target_properties(coreneuron PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS OFF)
 
 # need to have _kinderiv.h for mod2c generated files and nrnivmodl-core and nmodl building
 add_dependencies(coreneuron kin_deriv_header nrnivmodl-core)
@@ -195,7 +186,6 @@ target_link_libraries(
   ${reportinglib_LIBRARY}
   ${sonatareport_LIBRARY}
   ${link_cudacoreneuron}
-  ${CUDA_LIBRARIES}
   ${CALIPER_LIB}
   ${likwid_LIBRARIES}
   ${MPI_C_LIBRARIES})

--- a/coreneuron/gpu/nrn_acc_manager.cpp
+++ b/coreneuron/gpu/nrn_acc_manager.cpp
@@ -50,7 +50,7 @@ void setup_nrnthreads_on_device(NrnThread* threads, int nthreads) {
 
     nrn_ion_global_map_copyto_device();
 
-#ifdef UNIFIED_MEMORY
+#ifdef CORENEURON_UNIFIED_MEMORY
     for (int i = 0; i < nthreads; i++) {
         NrnThread* nt = threads + i;  // NrnThread on host
 

--- a/coreneuron/utils/memory.h
+++ b/coreneuron/utils/memory.h
@@ -22,7 +22,8 @@
 #endif
 
 /// for gpu builds with unified memory support
-#if (defined(__CUDACC__) || defined(UNIFIED_MEMORY))
+/// OL210812: why do we include __CUDACC__ here?
+#if (defined(__CUDACC__) || defined(CORENEURON_UNIFIED_MEMORY))
 
 #include <cuda_runtime_api.h>
 

--- a/coreneuron/utils/profile/profiler_interface.h
+++ b/coreneuron/utils/profile/profiler_interface.h
@@ -15,7 +15,7 @@
 #include <caliper/cali.h>
 #endif
 
-#if defined(CUDA_PROFILING)
+#if defined(CORENEURON_CUDA_PROFILING)
 #include <cuda_profiler_api.h>
 #endif
 
@@ -163,7 +163,7 @@ struct Caliper {
 
 #endif
 
-#if defined(CUDA_PROFILING)
+#if defined(CORENEURON_CUDA_PROFILING)
 
 struct CudaProfiling {
     inline static void phase_begin(const char* name){};
@@ -270,7 +270,7 @@ using InstrumentorImpl = detail::Instrumentor<
 #if defined CORENEURON_CALIPER
     detail::Caliper,
 #endif
-#if defined(CUDA_PROFILING)
+#if defined(CORENEURON_CUDA_PROFILING)
     detail::CudaProfiling,
 #endif
 #if defined(CRAYPAT)

--- a/coreneuron/utils/randoms/nrnran123.cu
+++ b/coreneuron/utils/randoms/nrnran123.cu
@@ -137,8 +137,14 @@ nrnran123_State* nrnran123_newstream3(uint32_t id1,
     nrnran123_State* s{nullptr};
     if (use_unified_memory) {
 #ifdef __CUDACC__
-        assert(cudaMallocManaged(&s, sizeof(nrnran123_State)) == cudaSuccess);
-        assert(cudaMemset(s, 0, sizeof(nrnran123_State)) == cudaSuccess);
+        {
+            auto const code = cudaMallocManaged(&s, sizeof(nrnran123_State));
+            assert(code == cudaSuccess);
+        }
+        {
+            auto const code = cudaMemset(s, 0, sizeof(nrnran123_State));
+            assert(code == cudaSuccess);
+        }
 #else
         throw std::runtime_error("Tried to use CUDA unified memory in a non-GPU build.");
 #endif

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -31,24 +31,24 @@ echo "${CORENRN_TYPE} build"
 if [ "${CORENRN_TYPE}" = "GPU-non-unified" ]; then
     cmake \
         -DCORENRN_ENABLE_GPU=ON \
+        -DCMAKE_CUDA_COMPILER=nvcc \
         -DCORENRN_ENABLE_CUDA_UNIFIED_MEMORY=OFF \
         -DCMAKE_INSTALL_PREFIX=$WORKSPACE/install_${CORENRN_TYPE}/ \
         -DTEST_MPI_EXEC_BIN="srun;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta;--gres=gpu:2;--mem;0;-t;00:05:00" \
         -DTEST_EXEC_PREFIX="srun;-n;6;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta;--gres=gpu:2;--mem;0;-t;00:05:00" \
         -DAUTO_TEST_WITH_SLURM=OFF \
         -DAUTO_TEST_WITH_MPIEXEC=OFF \
-        -DCMAKE_CXX_FLAGS="-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1" \
         $WORKSPACE/
 elif [ "${CORENRN_TYPE}" = "GPU-unified" ]; then
     cmake \
         -DCORENRN_ENABLE_GPU=ON \
+        -DCMAKE_CUDA_COMPILER=nvcc \
         -DCORENRN_ENABLE_CUDA_UNIFIED_MEMORY=ON \
         -DCMAKE_INSTALL_PREFIX=$WORKSPACE/install_${CORENRN_TYPE}/ \
         -DTEST_MPI_EXEC_BIN="srun;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta;--gres=gpu:2;--mem;0;-t;00:05:00" \
         -DTEST_EXEC_PREFIX="srun;-n;6;--account=proj16;--partition=$SALLOC_PARTITION;--constraint=volta;--gres=gpu:2;--mem;0;-t;00:05:00" \
         -DAUTO_TEST_WITH_SLURM=OFF \
         -DAUTO_TEST_WITH_MPIEXEC=OFF \
-        -DCMAKE_CXX_FLAGS="-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1" \
         $WORKSPACE/
 elif [ "${CORENRN_TYPE}" = "AoS" ] || [ "${CORENRN_TYPE}" = "SoA" ]; then
     CORENRN_ENABLE_SOA=ON

--- a/tests/unit/alignment/CMakeLists.txt
+++ b/tests/unit/alignment/CMakeLists.txt
@@ -7,9 +7,4 @@ include_directories(${CMAKE_SOURCE_DIR}/coreneuron ${Boost_INCLUDE_DIRS})
 
 add_executable(alignment_test_bin alignment.cpp)
 target_link_libraries(alignment_test_bin ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-
-if(CORENRN_ENABLE_GPU)
-  target_link_libraries(alignment_test_bin ${link_cudacoreneuron} ${CUDA_LIBRARIES})
-endif()
-
 add_test(NAME alignment_test COMMAND ${TEST_EXEC_PREFIX} $<TARGET_FILE:alignment_test_bin>)

--- a/tests/unit/cmdline_interface/CMakeLists.txt
+++ b/tests/unit/cmdline_interface/CMakeLists.txt
@@ -15,5 +15,7 @@ target_link_libraries(
 target_include_directories(cmd_interface_test_bin SYSTEM
                            PRIVATE ${CORENEURON_PROJECT_SOURCE_DIR}/external/CLI11/include)
 add_dependencies(cmd_interface_test_bin nrniv-core)
-
+# Tell CMake *not* to run an explicit device code linker step (which will produce errors); let the
+# NVHPC C++ compiler handle this implicitly.
+set_target_properties(cmd_interface_test_bin PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS OFF)
 add_test(NAME cmd_interface_test COMMAND ${TEST_EXEC_PREFIX} $<TARGET_FILE:cmd_interface_test_bin>)

--- a/tests/unit/interleave_info/CMakeLists.txt
+++ b/tests/unit/interleave_info/CMakeLists.txt
@@ -13,6 +13,8 @@ target_link_libraries(
   ${reportinglib_LIBRARY}
   ${sonatareport_LIBRARY})
 add_dependencies(interleave_info_bin nrniv-core)
-
+# Tell CMake *not* to run an explicit device code linker step (which will produce errors); let the
+# NVHPC C++ compiler handle this implicitly.
+set_target_properties(interleave_info_bin PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS OFF)
 add_test(NAME interleave_info_constructor_test COMMAND ${TEST_EXEC_PREFIX}
                                                        $<TARGET_FILE:interleave_info_bin>)

--- a/tests/unit/lfp/CMakeLists.txt
+++ b/tests/unit/lfp/CMakeLists.txt
@@ -16,11 +16,8 @@ target_link_libraries(
   ${corenrn_mech_lib}
   ${reportinglib_LIBRARY}
   ${sonatareport_LIBRARY})
-
-if(CORENRN_ENABLE_GPU)
-  target_link_libraries(lfp_test_bin ${link_cudacoreneuron} ${CUDA_LIBRARIES})
-endif()
-
+# Tell CMake *not* to run an explicit device code linker step (which will produce errors); let the
+# NVHPC C++ compiler handle this implicitly.
+set_target_properties(lfp_test_bin PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS OFF)
 add_dependencies(lfp_test_bin nrniv-core)
-
 add_test(NAME lfp_test COMMAND ${TEST_EXEC_PREFIX} $<TARGET_FILE:lfp_test_bin>)

--- a/tests/unit/queueing/CMakeLists.txt
+++ b/tests/unit/queueing/CMakeLists.txt
@@ -13,5 +13,7 @@ target_link_libraries(
   ${reportinglib_LIBRARY}
   ${sonatareport_LIBRARY})
 add_dependencies(queuing_test_bin nrniv-core)
-
+# Tell CMake *not* to run an explicit device code linker step (which will produce errors); let the
+# NVHPC C++ compiler handle this implicitly.
+set_target_properties(queuing_test_bin PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS OFF)
 add_test(NAME queuing_test COMMAND ${TEST_EXEC_PREFIX} $<TARGET_FILE:queuing_test_bin>)


### PR DESCRIPTION
**Description**
This changeset changes the CMake configuration of GPU builds to:
- [x] Use CMake's language support for CUDA, instead of the deprecated `find_package(CUDA ...)`, `cuda_add_library(...)`, etc.
- [x] Increase the minimum CMake version for GPU builds to v3.15, with an explicit error message if this is not respected. 
- [x] Retire the custom `CORENRN_GPU_CUDA_COMPUTE_CAPABILITY` option; we now use the standard `CMAKE_CUDA_ARCHITECTURES` variable
- [x] Avoid multiple device code linking steps, which apparently caused problems (https://github.com/BlueBrain/CoreNeuron/issues/607) with global state.
- [x] Prefix more preprocessor macro names (https://github.com/BlueBrain/CoreNeuron/issues/153)
- [x] Bump the https://github.com/BlueBrain/hpc-coding-conventions submodule commit to support `clang-format-12`.
- [x] Fix a silly error in https://github.com/BlueBrain/CoreNeuron/pull/595 affecting builds with asserts disabled.

These changes force compilation to proceed slightly differently to a standard mixed CUDA/C++ project. Instead of allowing CMake to generate an explicit device linker step, i.e.
```
nvcc -dc -o foo.cu.o foo.cu ...
nvcc -dlink -o dlink.o *.cu.o ...
ar qc libcudastuff.a *.cu.o dlink.o
```
before compiling OpenACC/GPU-enabled C++ code (which emits additional device code):
```
nvc++ -acc -gpu=cuda11.0,cc70 -o main main.cpp -lcudastuff ...
```
we instead let `nvc++` do the device code linking itself, i.e. something more like
```
nvc++ -acc -gpu=cuda11.0,cc70 -o main.cpp.o -c main.cpp
nvc++ -acc -gpu=cuda11.0,cc70 -cuda -o main main.cpp.o *.cu.o # -cuda but no dlink.o!
```
which seems to give correct results. This is a bit tortuous in CMake presumably because the same pattern would fail with a GPU-unaware C++ compiler, e.g. GCC or Clang. The hypothesis is that the old way of doing things fell foul of
> It is possible to do multiple device links within a single host executable, as long as each device link is independent of the other. This requirement of independence means that they cannot share code across device executables, nor can they share addresses (e.g., a device function address can be passed from host to device for a callback only if the device link sees both the caller and potential callback callee; you cannot pass an address from one device executable to another, as those are separate address spaces). 

from [the CUDA documentation](https://docs.nvidia.com/cuda/archive/11.0/cuda-compiler-driver-nvcc/index.html#examples), while the new way ensures there is a single device link step including both the code generated from `.cu` files and that from OpenACC regions.

We now also prefer to dynamically link the CUDA runtime, `libcudart.so`. `nvc++ -cuda` seems to prefer this and only allows it to be steered by the `-static-nvidia` option, which would also statically link the OpenACC runtime (which has always been dynamically linked). Setting `CMAKE_CUDA_RUNTIME_LIBRARY=Shared` stops CMake from emitting `-lcudart_static`, which causes segfaults at teardown in combination with `-cuda`'s dynamic linking. 

cc: @kotsaloscv 

Closes https://github.com/BlueBrain/CoreNeuron/issues/520. Closes https://github.com/BlueBrain/CoreNeuron/issues/607.

**How to test this?**
Follow instructions in https://github.com/BlueBrain/CoreNeuron/issues/607 to test the link/global state issue.

**Test System**
 - OS: BB5
 - Compiler: NVHPC 21.7 / CUDA 11.0
 - Version: master
 - Backend: GPU

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
