### PR TITLE
Make CoreNEURON C++ only.

### DIFF
--- a/CMake/config/CompilerFlagsHelpers.cmake
+++ b/CMake/config/CompilerFlagsHelpers.cmake
@@ -9,7 +9,7 @@
 # set of Convenience functions for portable compiler flags
 # ~~~
 
-set(SUPPORTED_COMPILER_LANGUAGE_LIST "C;CXX")
+set(SUPPORTED_COMPILER_LANGUAGE_LIST "CXX")
 
 # detect compiler
 foreach(COMPILER_LANGUAGE ${SUPPORTED_COMPILER_LANGUAGE_LIST})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(
   coreneuron
   VERSION 1.0
-  LANGUAGES C CXX)
+  LANGUAGES CXX)
 
 # ~~~
 # It is a bad idea having floating point versions, since macros cant handle them
@@ -54,9 +54,9 @@ list(APPEND CMAKE_MODULE_PATH ${CORENEURON_PROJECT_SOURCE_DIR}/CMake
 set(CODING_CONV_PREFIX "CORENRN")
 set(CORENRN_3RDPARTY_DIR "external")
 # Adds .cu with respect to the current default in hpc-coding-conventions, and drops various patterns
-# that don't match anything in CoreNEURON. Note there's only one .c file left!
+# that don't match anything in CoreNEURON.
 set(CORENRN_ClangFormat_FILES_RE
-    "^.*\\\\.cu?$$" "^.*\\\\.[chi]pp$$"
+    "^.*\\\\.cu$$" "^.*\\\\.[chi]pp$$"
     CACHE STRING "List of regular expressions matching C/C++ filenames" FORCE)
 set(CORENRN_ClangFormat_EXCLUDES_RE
     "${CORENRN_PROJECT_SOURCE_DIR}/external/.*$$"
@@ -474,13 +474,12 @@ message(STATUS "docs                | Build full docs. Calls targets: doxygen, s
 message(STATUS "--------------------+--------------------------------------------------------")
 message(STATUS " Build option       | Status")
 message(STATUS "--------------------+--------------------------------------------------------")
-message(STATUS "C COMPILER          | ${CMAKE_C_COMPILER}")
 message(STATUS "CXX COMPILER        | ${CMAKE_CXX_COMPILER}")
 message(STATUS "COMPILE FLAGS       | ${CORENRN_CXX_FLAGS}")
 message(STATUS "Build Type          | ${COMPILE_LIBRARY_TYPE}")
 message(STATUS "MPI                 | ${CORENRN_ENABLE_MPI}")
 if(CORENRN_ENABLE_MPI)
-  message(STATUS "  INC               | ${MPI_C_INCLUDE_PATH}")
+  message(STATUS "  INC               | ${MPI_CXX_INCLUDE_PATH}")
 endif()
 message(STATUS "OpenMP              | ${CORENRN_ENABLE_OPENMP}")
 message(STATUS "Use legacy units    | ${CORENRN_ENABLE_LEGACY_UNITS}")

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -176,7 +176,7 @@ add_dependencies(coreneuron kin_deriv_header nrnivmodl-core)
 add_library(scopmath STATIC ${CORENEURON_HEADER_FILES} ${SCOPMATH_CODE_FILES})
 
 target_link_libraries(coreneuron ${reportinglib_LIBRARY} ${sonatareport_LIBRARY} ${CALIPER_LIB}
-                      ${likwid_LIBRARIES} ${MPI_C_LIBRARIES})
+                      ${likwid_LIBRARIES} ${MPI_CXX_LIBRARIES})
 target_include_directories(coreneuron SYSTEM
                            PRIVATE ${CORENEURON_PROJECT_SOURCE_DIR}/external/Random123/include)
 target_include_directories(coreneuron SYSTEM

--- a/coreneuron/sim/fadvance_core.cpp
+++ b/coreneuron/sim/fadvance_core.cpp
@@ -20,7 +20,7 @@
 #include "coreneuron/network/netpar.hpp"
 #include "coreneuron/network/partrans.hpp"
 #include "coreneuron/utils/nrnoc_aux.hpp"
-#include "coreneuron/utils/progressbar/progressbar.h"
+#include "coreneuron/utils/progressbar/progressbar.hpp"
 #include "coreneuron/utils/profile/profiler_interface.h"
 #include "coreneuron/io/nrn2core_direct.h"
 

--- a/coreneuron/utils/progressbar/progressbar.cpp
+++ b/coreneuron/utils/progressbar/progressbar.cpp
@@ -9,11 +9,11 @@
  * progressbar -- a C class (by convention) for displaying progress
  * on the command line (to stdout).
  */
+#include "coreneuron/utils/progressbar/progressbar.hpp"
 
 #include <assert.h>
 #include <limits.h>
 #include <unistd.h>
-#include "coreneuron/utils/progressbar/progressbar.h"
 
 ///  How wide we assume the screen is if termcap fails.
 enum { DEFAULT_SCREEN_WIDTH = 80 };
@@ -57,27 +57,28 @@ static int progressbar_remaining_seconds(const progressbar* bar);
  * bar like "<---------->". Returns NULL if there isn't enough memory to allocate a progressbar
  */
 progressbar* progressbar_new_with_format(const char* label, unsigned long max, const char* format) {
-    progressbar* new = malloc(sizeof(progressbar));
-    if (new == NULL) {
+    auto* new_bar = static_cast<progressbar*>(malloc(sizeof(progressbar)));
+    if (new_bar == NULL) {
         return NULL;
     }
 
-    new->max = max;
-    new->value = 0;
-    new->draw_time_interval = isatty(STDOUT_FILENO) ? BAR_DRAW_INTERVAL : BAR_DRAW_INTERVAL_NOTTY;
-    new->t = 0;
-    new->start = time(NULL);
+    new_bar->max = max;
+    new_bar->value = 0;
+    new_bar->draw_time_interval = isatty(STDOUT_FILENO) ? BAR_DRAW_INTERVAL
+                                                        : BAR_DRAW_INTERVAL_NOTTY;
+    new_bar->t = 0;
+    new_bar->start = time(NULL);
     assert(3 == strlen(format) && "format must be 3 characters in length");
-    new->format.begin = format[0];
-    new->format.fill = format[1];
-    new->format.end = format[2];
+    new_bar->format.begin = format[0];
+    new_bar->format.fill = format[1];
+    new_bar->format.end = format[2];
 
-    progressbar_update_label(new, label);
-    progressbar_draw(new);
-    new->prev_t = difftime(time(NULL), new->start);
-    new->drawn_count = 1;
+    progressbar_update_label(new_bar, label);
+    progressbar_draw(new_bar);
+    new_bar->prev_t = difftime(time(NULL), new_bar->start);
+    new_bar->drawn_count = 1;
 
-    return new;
+    return new_bar;
 }
 
 /**

--- a/coreneuron/utils/progressbar/progressbar.hpp
+++ b/coreneuron/utils/progressbar/progressbar.hpp
@@ -9,18 +9,11 @@
  * progressbar -- a C class (by convention) for displaying progress
  * on the command line (to stderr).
  */
-
-#ifndef PROGRESSBAR_H
-#define PROGRESSBAR_H
-
+#pragma once
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * Progressbar data structure (do not modify or create directly)
@@ -103,9 +96,3 @@ void progressbar_update_label(progressbar* bar, const char* label);
 /// Finalize (and free!) a progressbar. Call this when you're done, or if you break out
 /// partway through.
 void progressbar_finish(progressbar* bar);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif

--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -50,7 +50,7 @@ CORENRNLIB_FLAGS += $(if @caliper_LIB_DIR@,-L@caliper_LIB_DIR@,)
 
 # Includes paths gathered by CMake
 INCLUDES = $(INCFLAGS) -I$(CORENRN_INC_DIR) -I$(CORENRN_INC_DIR)/coreneuron/utils/randoms
-INCLUDES += $(if @MPI_C_INCLUDE_PATH@, -I$(subst ;, -I,@MPI_C_INCLUDE_PATH@),)
+INCLUDES += $(if @MPI_CXX_INCLUDE_PATH@, -I$(subst ;, -I,@MPI_CXX_INCLUDE_PATH@),)
 INCLUDES += $(if @reportinglib_INCLUDE_DIR@, -I$(subst ;, -I,@reportinglib_INCLUDE_DIR@),)
 
 # C++ compilation and link commands


### PR DESCRIPTION
**Description**
Drop C language code (1 file!) from CoreNEURON.
Also use this as an excuse to test https://github.com/BlueBrain/nmodl/pull/723.

**How to test this?**
Build CoreNEURON and note that it doesn't search for a C compiler (at all, if you build with NMODL).

**Test System**
 - OS: BB5
 - Compiler: NVHPC 21.7

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NMODL_BRANCH=olupton/ccache,
