### PR TITLE
Fix GPU/OpenACC build issues with CMake build_type=Debug

### DIFF
--- a/CMake/MakefileBuildOptions.cmake
+++ b/CMake/MakefileBuildOptions.cmake
@@ -72,7 +72,9 @@ endforeach()
 # PGI compiler adds --c++14;-A option for C++14, remove ";"
 string(REPLACE ";" " " CXX14_STD_FLAGS "${CMAKE_CXX14_STANDARD_COMPILE_OPTION}")
 string(TOUPPER "${CMAKE_BUILD_TYPE}" _BUILD_TYPE)
-set(CORENRN_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${_BUILD_TYPE}} ${CXX14_STD_FLAGS} ${NVHPC_CXX_INLINE_FLAGS}")
+set(CORENRN_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${_BUILD_TYPE}} ${CXX14_STD_FLAGS} ${NVHPC_CXX_INLINE_FLAGS}"
+)
 
 # =============================================================================
 # nmodl/mod2c related options : TODO

--- a/CMake/MakefileBuildOptions.cmake
+++ b/CMake/MakefileBuildOptions.cmake
@@ -72,7 +72,7 @@ endforeach()
 # PGI compiler adds --c++14;-A option for C++14, remove ";"
 string(REPLACE ";" " " CXX14_STD_FLAGS "${CMAKE_CXX14_STANDARD_COMPILE_OPTION}")
 string(TOUPPER "${CMAKE_BUILD_TYPE}" _BUILD_TYPE)
-set(CORENRN_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${_BUILD_TYPE}} ${CXX14_STD_FLAGS}")
+set(CORENRN_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${_BUILD_TYPE}} ${CXX14_STD_FLAGS} ${NVHPC_CXX_INLINE_FLAGS}")
 
 # =============================================================================
 # nmodl/mod2c related options : TODO

--- a/CMake/OpenAccHelper.cmake
+++ b/CMake/OpenAccHelper.cmake
@@ -68,10 +68,10 @@ if(CORENRN_ENABLE_GPU)
   set(CMAKE_CXX14_STANDARD_COMPILE_OPTION --c++14)
   string(APPEND CMAKE_CXX_FLAGS " ${NVHPC_ACC_COMP_FLAGS} ${PGI_DIAG_FLAGS}")
   string(APPEND CMAKE_EXE_LINKER_FLAGS " ${NVHPC_ACC_LINK_FLAGS}")
-  # Use `-Mautoinline` option to compile .cpp files generated from .mod files only.
-  # This is especially needed when we compile with -O0 or -O1 optimisation
-  # level where we get link errors. Use of `-Mautoinline` ensure that the necessary
-  # functions like `net_receive_kernel` are inlined for OpenACC code generation.
+  # Use `-Mautoinline` option to compile .cpp files generated from .mod files only. This is
+  # especially needed when we compile with -O0 or -O1 optimisation level where we get link errors.
+  # Use of `-Mautoinline` ensure that the necessary functions like `net_receive_kernel` are inlined
+  # for OpenACC code generation.
   set(NVHPC_CXX_INLINE_FLAGS "-Mautoinline")
 endif()
 

--- a/CMake/OpenAccHelper.cmake
+++ b/CMake/OpenAccHelper.cmake
@@ -68,6 +68,11 @@ if(CORENRN_ENABLE_GPU)
   set(CMAKE_CXX14_STANDARD_COMPILE_OPTION --c++14)
   string(APPEND CMAKE_CXX_FLAGS " ${NVHPC_ACC_COMP_FLAGS} ${PGI_DIAG_FLAGS}")
   string(APPEND CMAKE_EXE_LINKER_FLAGS " ${NVHPC_ACC_LINK_FLAGS}")
+  # Use `-Mautoinline` option to compile .cpp files generated from .mod files only.
+  # This is especially needed when we compile with -O0 or -O1 optimisation
+  # level where we get link errors. Use of `-Mautoinline` ensure that the necessary
+  # functions like `net_receive_kernel` are inlined for OpenACC code generation.
+  set(NVHPC_CXX_INLINE_FLAGS "-Mautoinline")
 endif()
 
 # =============================================================================


### PR DESCRIPTION
* Need to explitly use -Mautoinline to make sure functions
  like `net_receieve_kernel` are inlined by NVHPC compiler.
* Note that `-Mautoinline` is not added to `CMAKE_CXX_FLAGS`
  because it's not default with NVHPC compiler. We are
  adding this flag only for `.mod` related `.cpp` files.
* See also #573

fixes #518


**How to test this?**
Run the standard CTest test suite in a GPU build.

**Test System**
 - OS: BB5
 - Compiler: NVHPC 21.7
 - Version: olupton/gpu-trajectories branch
 - Backend: GPU

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,