### PR TITLE
Implementation of solve_interleaved2 using CUDA + Improvement of OpenACC counterpart (issue #603)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,8 @@ find_package(Perl REQUIRED)
 # =============================================================================
 # Common build options
 # =============================================================================
+add_definitions(-DENABLE_CUDA_)
+
 # build mod files for coreneuron
 add_definitions(-DCORENEURON_BUILD)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,8 +204,6 @@ find_package(Perl REQUIRED)
 # =============================================================================
 # Common build options
 # =============================================================================
-add_definitions(-DENABLE_CUDA_)
-
 # build mod files for coreneuron
 add_definitions(-DCORENEURON_BUILD)
 

--- a/coreneuron/apps/corenrn_parameters.cpp
+++ b/coreneuron/apps/corenrn_parameters.cpp
@@ -52,6 +52,9 @@ corenrn_parameters::corenrn_parameters() {
                      "parent adjacency.",
                      true)
         ->check(CLI::Range(0, 3));
+    sub_gpu->add_flag("--cuda-interface",
+                      this->cuda_interface,
+                      "Activate CUDA branch of the code.");
 
     auto sub_input = app.add_option_group("input", "Input dataset options.");
     sub_input->add_option("-d, --datpath", this->datpath, "Path containing CoreNeuron data files.")
@@ -190,6 +193,7 @@ std::ostream& operator<<(std::ostream& os, const corenrn_parameters& corenrn_par
        << "GPU" << std::endl
        << "--nwarp=" << corenrn_param.nwarp << std::endl
        << "--cell-permute=" << corenrn_param.cell_interleave_permute << std::endl
+       << "--cuda-interface=" << (corenrn_param.cuda_interface ? "true" : "false") << std::endl
        << std::endl
        << "INPUT PARAMETERS" << std::endl
        << "--voltage=" << corenrn_param.voltage << std::endl

--- a/coreneuron/apps/corenrn_parameters.hpp
+++ b/coreneuron/apps/corenrn_parameters.hpp
@@ -55,6 +55,7 @@ struct corenrn_parameters {
     bool multisend = false;          /// Use Multisend spike exchange instead of Allgather.
     bool threading = false;          /// Enable pthread/openmp
     bool gpu = false;                /// Enable GPU computation.
+    bool cuda_interface = false;     /// Enable CUDA interface. By default is the OpenACC interface.
     bool binqueue = false;           /// Use bin queue.
 
     bool show_version = false;  /// Print version and exit.

--- a/coreneuron/apps/corenrn_parameters.hpp
+++ b/coreneuron/apps/corenrn_parameters.hpp
@@ -55,8 +55,10 @@ struct corenrn_parameters {
     bool multisend = false;          /// Use Multisend spike exchange instead of Allgather.
     bool threading = false;          /// Enable pthread/openmp
     bool gpu = false;                /// Enable GPU computation.
-    bool cuda_interface = false;     /// Enable CUDA interface. By default is the OpenACC interface.
-    bool binqueue = false;           /// Use bin queue.
+    bool cuda_interface = false;     /// Enable CUDA interface (default is the OpenACC interface).
+                                  /// Branch of the code is executed through CUDA kernels instead of
+                                  /// OpenACC regions.
+    bool binqueue = false;  /// Use bin queue.
 
     bool show_version = false;  /// Print version and exit.
 

--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -151,6 +151,12 @@ void nrn_init_and_load_data(int argc,
                 "missing --gpu\n");
         exit(1);
     }
+    if (!corenrn_param.gpu && corenrn_param.cuda_interface) {
+        fprintf(stderr,
+                "compiled with OpenACC/CUDA does not allow the combination of --cuda-interface and "
+                "missing --gpu\n");
+        exit(1);
+    }
 #endif
 
 // if multi-threading enabled, make sure mpi library supports it

--- a/coreneuron/permute/cellorder.cpp
+++ b/coreneuron/permute/cellorder.cpp
@@ -568,10 +568,6 @@ static void bksub_interleaved2(NrnThread* nt,
     }
 }
 
-int temp1[1024] = {0};
-int temp2[1024] = {0};
-int temp3[1024] = {0};
-
 /**
  * \brief Solve Hines matrices/cells with compartment-based granularity.
  *
@@ -595,7 +591,6 @@ void solve_interleaved2(int ith) {
         solve_interleaved2_launcher(d_nt, d_info, ncore, acc_get_cuda_stream(nt->stream_id));
     } else {
 #endif
-        static int foo = 1;
         int* ncycles = ii.cellsize;         // nwarp of these
         int* stridedispl = ii.stridedispl;  // nwarp+1 of these
         int* strides = ii.stride;           // sum ncycles of these (bad since ncompart/warpsize)
@@ -625,9 +620,6 @@ void solve_interleaved2(int ith) {
             int lastroot = rootbegin[iwarp + 1];
             int firstnode = nodebegin[iwarp];
             int lastnode = nodebegin[iwarp + 1];
-// temp1[icore] = ic;
-// temp2[icore] = ncycle;
-// temp3[icore] = stride - strides;
 #if !defined(_OPENACC)
             if (ic == 0) {  // serial test mode. triang and bksub do all cores in warp
 #endif
@@ -640,13 +632,6 @@ void solve_interleaved2(int ith) {
 #ifdef _OPENACC
 #pragma acc wait(nt->stream_id)
 #endif
-        if (foo == 1) {
-            return;
-        }
-        foo = 0;
-        for (int i = 0; i < ncore; ++i) {
-            printf("%d => %d %d %d\n", i, temp1[i], temp2[i], temp3[i]);
-        }
 #ifdef _OPENACC
     }
 #endif

--- a/coreneuron/permute/cellorder.cpp
+++ b/coreneuron/permute/cellorder.cpp
@@ -588,11 +588,13 @@ void solve_interleaved2(int ith) {
 
     int ncore = nwarp * warpsize;
 
+#ifdef _OPENACC
     if (corenrn_param.gpu && corenrn_param.cuda_interface) {
         auto* d_nt = static_cast<NrnThread*>(acc_deviceptr(nt));
         auto* d_info = static_cast<InterleaveInfo*>(acc_deviceptr(interleave_info + ith));
         solve_interleaved2_launcher(d_nt, d_info, ncore, acc_get_cuda_stream(nt->stream_id));
     } else {
+#endif
         static int foo = 1;
         int* ncycles = ii.cellsize;         // nwarp of these
         int* stridedispl = ii.stridedispl;  // nwarp+1 of these
@@ -645,7 +647,9 @@ void solve_interleaved2(int ith) {
         for (int i = 0; i < ncore; ++i) {
             printf("%d => %d %d %d\n", i, temp1[i], temp2[i], temp3[i]);
         }
+#ifdef _OPENACC
     }
+#endif
 }
 
 /**

--- a/coreneuron/permute/cellorder.cpp
+++ b/coreneuron/permute/cellorder.cpp
@@ -15,6 +15,7 @@
 #include "coreneuron/network/tnode.hpp"
 #include "coreneuron/utils/lpt.hpp"
 #include "coreneuron/utils/memory.h"
+#include "coreneuron/apps/corenrn_parameters.hpp"
 
 #include "coreneuron/permute/node_permute.h"  // for print_quality
 
@@ -567,10 +568,6 @@ static void bksub_interleaved2(NrnThread* nt,
     }
 }
 
-#ifdef ENABLE_CUDA_INTERFACE
-void solve_interleaved_launcher(NrnThread* nt, InterleaveInfo* info, int ncell);
-#endif
-
 int temp1[1024] = {0};
 int temp2[1024] = {0};
 int temp3[1024] = {0};
@@ -583,72 +580,72 @@ int temp3[1024] = {0};
  * warp deals with a group of cells, therefore multiple compartments (finer level of parallelism).
  */
 void solve_interleaved2(int ith) {
-    static int foo = 1;
     NrnThread* nt = nrn_threads + ith;
     InterleaveInfo& ii = interleave_info[ith];
     int nwarp = ii.nwarp;
-    if (nwarp == 0) {
+    if (nwarp == 0)
         return;
-    }
-    int* ncycles = ii.cellsize;         // nwarp of these
-    int* stridedispl = ii.stridedispl;  // nwarp+1 of these
-    int* strides = ii.stride;           // sum ncycles of these (bad since ncompart/warpsize)
-    int* rootbegin = ii.firstnode;      // nwarp+1 of these
-    int* nodebegin = ii.lastnode;       // nwarp+1 of these
-#ifdef _OPENACC
-    int nstride = stridedispl[nwarp];
-    int stream_id = nt->stream_id;
-#endif
 
     int ncore = nwarp * warpsize;
 
-#ifdef ENABLE_CUDA_INTERFACE
-    NrnThread* d_nt = (NrnThread*) acc_deviceptr(nt);
-    InterleaveInfo* d_info = (InterleaveInfo*) acc_deviceptr(interleave_info + ith);
-    solve_interleaved2_launcher(d_nt, d_info, ncore);
-#else
+    if (corenrn_param.gpu && corenrn_param.cuda_interface) {
+        auto* d_nt = static_cast<NrnThread*>(acc_deviceptr(nt));
+        auto* d_info = static_cast<InterleaveInfo*>(acc_deviceptr(interleave_info + ith));
+        solve_interleaved2_launcher(d_nt, d_info, ncore, acc_get_cuda_stream(nt->stream_id));
+    } else {
+        static int foo = 1;
+        int* ncycles = ii.cellsize;         // nwarp of these
+        int* stridedispl = ii.stridedispl;  // nwarp+1 of these
+        int* strides = ii.stride;           // sum ncycles of these (bad since ncompart/warpsize)
+        int* rootbegin = ii.firstnode;      // nwarp+1 of these
+        int* nodebegin = ii.lastnode;       // nwarp+1 of these
 #ifdef _OPENACC
-    // clang-format off
-    
-    #pragma acc parallel loop gang vector vector_length(warpsize) \
-        present(nt[0:1], strides[0:nstride],                      \
-        ncycles[0:nwarp], stridedispl[0:nwarp+1],                 \
-        rootbegin[0:nwarp+1], nodebegin[0:nwarp+1])               \
-        if (nt->compute_gpu) async(stream_id)
+        int nstride = stridedispl[nwarp];
+        int stream_id = nt->stream_id;
+#endif
+
+#ifdef _OPENACC
+        // clang-format off
+        
+        #pragma acc parallel loop gang vector vector_length(warpsize) \
+            present(nt[0:1], strides[0:nstride],                      \
+            ncycles[0:nwarp], stridedispl[0:nwarp+1],                 \
+            rootbegin[0:nwarp+1], nodebegin[0:nwarp+1])               \
+            if (nt->compute_gpu) async(stream_id)
 // clang-format on
 #endif
-    for (int icore = 0; icore < ncore; ++icore) {
-        int iwarp = icore / warpsize;     // figure out the >> value
-        int ic = icore & (warpsize - 1);  // figure out the & mask
-        int ncycle = ncycles[iwarp];
-        int* stride = strides + stridedispl[iwarp];
-        int root = rootbegin[iwarp];
-        int lastroot = rootbegin[iwarp + 1];
-        int firstnode = nodebegin[iwarp];
-        int lastnode = nodebegin[iwarp + 1];
+        for (int icore = 0; icore < ncore; ++icore) {
+            int iwarp = icore / warpsize;     // figure out the >> value
+            int ic = icore & (warpsize - 1);  // figure out the & mask
+            int ncycle = ncycles[iwarp];
+            int* stride = strides + stridedispl[iwarp];
+            int root = rootbegin[iwarp];
+            int lastroot = rootbegin[iwarp + 1];
+            int firstnode = nodebegin[iwarp];
+            int lastnode = nodebegin[iwarp + 1];
 // temp1[icore] = ic;
 // temp2[icore] = ncycle;
 // temp3[icore] = stride - strides;
 #if !defined(_OPENACC)
-        if (ic == 0) {  // serial test mode. triang and bksub do all cores in warp
+            if (ic == 0) {  // serial test mode. triang and bksub do all cores in warp
 #endif
-            triang_interleaved2(nt, ic, ncycle, stride, lastnode);
-            bksub_interleaved2(nt, root + ic, lastroot, ic, ncycle, stride, firstnode);
+                triang_interleaved2(nt, ic, ncycle, stride, lastnode);
+                bksub_interleaved2(nt, root + ic, lastroot, ic, ncycle, stride, firstnode);
 #if !defined(_OPENACC)
-        }  // serial test mode
+            }  // serial test mode
 #endif
-    }
+        }
 #ifdef _OPENACC
 #pragma acc wait(nt->stream_id)
 #endif
-    if (foo == 1) {
-        return;
+        if (foo == 1) {
+            return;
+        }
+        foo = 0;
+        for (int i = 0; i < ncore; ++i) {
+            printf("%d => %d %d %d\n", i, temp1[i], temp2[i], temp3[i]);
+        }
     }
-    foo = 0;
-    for (int i = 0; i < ncore; ++i) {
-        printf("%d => %d %d %d\n", i, temp1[i], temp2[i], temp3[i]);
-    }
-#endif
 }
 
 /**
@@ -674,11 +671,6 @@ void solve_interleaved1(int ith) {
     int stream_id = nt->stream_id;
 #endif
 
-#ifdef ENABLE_CUDA_INTERFACE
-    NrnThread* d_nt = (NrnThread*) acc_deviceptr(nt);
-    InterleaveInfo* d_info = (InterleaveInfo*) acc_deviceptr(interleave_info + ith);
-    solve_interleaved_launcher(d_nt, d_info, ncell);
-#else
 #ifdef _OPENACC
     // clang-format off
 
@@ -696,7 +688,6 @@ void solve_interleaved1(int ith) {
     }
 #ifdef _OPENACC
 #pragma acc wait(stream_id)
-#endif
 #endif
 }
 

--- a/coreneuron/permute/cellorder.cpp
+++ b/coreneuron/permute/cellorder.cpp
@@ -602,9 +602,9 @@ void solve_interleaved2(int ith) {
 
     int ncore = nwarp * warpsize;
 
-#ifdef ENABLE_CUDA_
-    NrnThread* d_nt = (NrnThread*)acc_deviceptr(nt);
-    InterleaveInfo* d_info = (InterleaveInfo*)acc_deviceptr(interleave_info + ith);
+#ifdef ENABLE_CUDA_INTERFACE
+    NrnThread* d_nt = (NrnThread*) acc_deviceptr(nt);
+    InterleaveInfo* d_info = (InterleaveInfo*) acc_deviceptr(interleave_info + ith);
     solve_interleaved2_launcher(d_nt, d_info, ncore);
 #else
 #ifdef _OPENACC

--- a/coreneuron/permute/cellorder.cu
+++ b/coreneuron/permute/cellorder.cu
@@ -6,24 +6,10 @@
 # =============================================================================
 */
 
+#include "coreneuron/utils/utils_cuda.h"
 #include "coreneuron/permute/cellorder.hpp"
 #include "coreneuron/network/tnode.hpp"
 #include "coreneuron/sim/multicore.hpp"
-
-#include <stdio.h>
-#define CHECKLAST(MSG)                             \
-    do {                                           \
-        cudaError_t e = cudaGetLastError();        \
-        if (e != cudaSuccess) {                    \
-            fprintf(stderr,                        \
-                    "%s:%d: CUDA Error: %s: %s\n", \
-                    __FILE__,                      \
-                    __LINE__,                      \
-                    (MSG),                         \
-                    cudaGetErrorString(e));        \
-            exit(1);                               \
-        }                                          \
-    } while (0)
 
 namespace coreneuron {
 

--- a/coreneuron/permute/cellorder.cu
+++ b/coreneuron/permute/cellorder.cu
@@ -10,6 +10,21 @@
 #include "coreneuron/network/tnode.hpp"
 #include "coreneuron/sim/multicore.hpp"
 
+#include <stdio.h>
+#define CHECKLAST(MSG)                             \
+    do {                                           \
+        cudaError_t e = cudaGetLastError();        \
+        if (e != cudaSuccess) {                    \
+            fprintf(stderr,                        \
+                    "%s:%d: CUDA Error: %s: %s\n", \
+                    __FILE__,                      \
+                    __LINE__,                      \
+                    (MSG),                         \
+                    cudaGetErrorString(e));        \
+            exit(1);                               \
+        }                                          \
+    } while (0)
+
 namespace coreneuron {
 
 __device__ void triang_interleaved2_device(NrnThread* nt,
@@ -94,6 +109,8 @@ void solve_interleaved2_launcher(NrnThread* nt, InterleaveInfo* info, int ncore,
     solve_interleaved2_kernel<<<blocksPerGrid, threadsPerBlock, 0, cuda_stream>>>(nt, info, ncore);
 
     cudaStreamSynchronize(cuda_stream);
+
+    CHECKLAST("solve_interleaved2_launcher");
 }
 
 }  // namespace coreneuron

--- a/coreneuron/permute/cellorder.cu
+++ b/coreneuron/permute/cellorder.cu
@@ -1,0 +1,114 @@
+#ifdef ENABLE_CUDA_
+
+#include <iostream>
+#include <stdio.h>
+
+#include "coreneuron/permute/cellorder.hpp"
+#include "coreneuron/network/tnode.hpp"
+#include "coreneuron/sim/multicore.hpp"
+
+namespace coreneuron {
+
+#define GPU_V(i)      nt->_actual_v[i]
+#define GPU_A(i)      nt->_actual_a[i]
+#define GPU_B(i)      nt->_actual_b[i]
+#define GPU_D(i)      nt->_actual_d[i]
+#define GPU_RHS(i)    nt->_actual_rhs[i]
+#define GPU_PARENT(i) nt->_v_parent_index[i]
+
+__device__
+void triang_interleaved2_device(NrnThread* nt, int icore, int ncycle, int* stride, int lastnode)
+{
+    int icycle = ncycle - 1;
+    int istride = stride[icycle];
+    int i = lastnode - istride + icore;
+
+    // execute until all tree depths are executed
+    bool has_subtrees_to_compute = true;
+
+    for (; has_subtrees_to_compute; ) {  // ncycle loop
+        if (icore < istride) {  // most efficient if istride equal  warpsize
+            // what is the index
+            int ip = GPU_PARENT(i);
+            double p = GPU_A(i) / GPU_D(i);
+            atomicAdd(&GPU_D(ip), - p * GPU_B(i));
+            atomicAdd(&GPU_RHS(ip), - p * GPU_RHS(i));
+        }
+        // if finished with all tree depths then ready to break
+        if (icycle == 0) {
+            has_subtrees_to_compute = false;
+            continue;
+        }
+        --icycle;
+        istride = stride[icycle];
+        i -= istride;
+    }
+}
+
+__device__
+void bksub_interleaved2_device(NrnThread* nt,
+                               int root,
+                               int lastroot,
+                               int icore,
+                               int ncycle,
+                               int* stride,
+                               int firstnode)
+{
+    for (int i = root; i < lastroot; i += warpsize) {
+        GPU_RHS(i) /= GPU_D(i);  // the root
+    }
+
+    int i = firstnode + icore;
+
+    for (int icycle = 0; icycle < ncycle; ++icycle) {
+        int istride = stride[icycle];
+        if (icore < istride) {
+            int ip = GPU_PARENT(i);
+            GPU_RHS(i) -= GPU_B(i) * GPU_RHS(ip);
+            GPU_RHS(i) /= GPU_D(i);
+        }
+        i += istride;
+    }
+}
+
+__global__
+void solve_interleaved2_kernel(NrnThread* nt, InterleaveInfo* ii, int ncore)
+{
+    int icore = blockDim.x * blockIdx.x + threadIdx.x;
+    
+    int* ncycles = ii->cellsize;         // nwarp of these
+    int* stridedispl = ii->stridedispl;  // nwarp+1 of these
+    int* strides = ii->stride;           // sum ncycles of these (bad since ncompart/warpsize)
+    int* rootbegin = ii->firstnode;      // nwarp+1 of these
+    int* nodebegin = ii->lastnode;       // nwarp+1 of these
+
+    int iwarp = icore / warpsize;     // figure out the >> value
+    int ic = icore & (warpsize - 1);  // figure out the & mask
+    int ncycle = ncycles[iwarp];
+    int* stride = strides + stridedispl[iwarp];
+    int root = rootbegin[iwarp];
+    int lastroot = rootbegin[iwarp + 1];
+    int firstnode = nodebegin[iwarp];
+    int lastnode = nodebegin[iwarp + 1];
+
+    for (int i = root; i < lastroot; i += warpsize) {
+        GPU_RHS(i) /= GPU_D(i);  // the root
+    }
+
+    triang_interleaved2_device(nt, ic, ncycle, stride, lastnode);
+    bksub_interleaved2_device(nt, root + ic, lastroot, ic, ncycle, stride, firstnode);
+}
+
+void solve_interleaved2_launcher(NrnThread* nt, InterleaveInfo* info, int ncore)
+{
+    cudaDeviceSynchronize();
+    int threadsPerBlock = warpsize;
+    int blocksPerGrid = (ncore + threadsPerBlock - 1) / threadsPerBlock;
+
+    solve_interleaved2_kernel<<<blocksPerGrid,threadsPerBlock>>>(nt, info, ncore);
+    cudaDeviceSynchronize();
+}
+
+} // namespace coreneuron
+
+#endif // ENABLE_CUDA_

--- a/coreneuron/permute/cellorder.cu
+++ b/coreneuron/permute/cellorder.cu
@@ -88,6 +88,7 @@ void solve_interleaved2_launcher(NrnThread* nt, InterleaveInfo* info, int ncore,
     auto cuda_stream = static_cast<cudaStream_t>(stream);
 
     int threadsPerBlock = warpsize;
+    // Should blocksPerGrid be a fixed number and have a while block inside the kernel?
     int blocksPerGrid = (ncore + threadsPerBlock - 1) / threadsPerBlock;
 
     solve_interleaved2_kernel<<<blocksPerGrid, threadsPerBlock, 0, cuda_stream>>>(nt, info, ncore);

--- a/coreneuron/permute/cellorder.cu
+++ b/coreneuron/permute/cellorder.cu
@@ -88,7 +88,7 @@ void solve_interleaved2_launcher(NrnThread* nt, InterleaveInfo* info, int ncore,
     auto cuda_stream = static_cast<cudaStream_t>(stream);
 
     int threadsPerBlock = warpsize;
-    // Should blocksPerGrid be a fixed number and have a while block inside the kernel?
+    // TODO: Should blocksPerGrid be a fixed number and have a while block inside the kernel?
     int blocksPerGrid = (ncore + threadsPerBlock - 1) / threadsPerBlock;
 
     solve_interleaved2_kernel<<<blocksPerGrid, threadsPerBlock, 0, cuda_stream>>>(nt, info, ncore);

--- a/coreneuron/permute/cellorder.cu
+++ b/coreneuron/permute/cellorder.cu
@@ -1,7 +1,7 @@
 #ifdef ENABLE_CUDA_
 
-#include <iostream>
-#include <stdio.h>
+//#include <iostream>
+//#include <stdio.h>
 
 #include "coreneuron/permute/cellorder.hpp"
 #include "coreneuron/network/tnode.hpp"
@@ -25,8 +25,8 @@ void triang_interleaved2_device(NrnThread* nt, int icore, int ncycle, int* strid
     int ip;
     double p;
     while(icycle >= 0) {
-        if (icore < istride) {  // most efficient if istride equal  warpsize
-            // what is the index
+        // most efficient if istride equal warpsize, else branch divergence!
+        if (icore < istride) {
             ip = GPU_PARENT(i);
             p = GPU_A(i) / GPU_D(i);
             atomicAdd(&GPU_D(ip), - p * GPU_B(i));

--- a/coreneuron/permute/cellorder.cu
+++ b/coreneuron/permute/cellorder.cu
@@ -9,7 +9,6 @@
 
 namespace coreneuron {
 
-#define GPU_V(i)      nt->_actual_v[i]
 #define GPU_A(i)      nt->_actual_a[i]
 #define GPU_B(i)      nt->_actual_b[i]
 #define GPU_D(i)      nt->_actual_d[i]
@@ -90,10 +89,6 @@ void solve_interleaved2_kernel(NrnThread* nt, InterleaveInfo* ii, int ncore)
     int lastroot = rootbegin[iwarp + 1];
     int firstnode = nodebegin[iwarp];
     int lastnode = nodebegin[iwarp + 1];
-
-    for (int i = root; i < lastroot; i += warpsize) {
-        GPU_RHS(i) /= GPU_D(i);  // the root
-    }
 
     triang_interleaved2_device(nt, ic, ncycle, stride, lastnode);
     bksub_interleaved2_device(nt, root + ic, lastroot, ic, ncycle, stride, firstnode);

--- a/coreneuron/permute/cellorder.hpp
+++ b/coreneuron/permute/cellorder.hpp
@@ -48,7 +48,7 @@ class InterleaveInfo;  // forward declaration
  */
 void solve_interleaved2_launcher(NrnThread* nt, InterleaveInfo* info, int ncore, void* stream);
 
-class InterleaveInfo {
+class InterleaveInfo: public MemoryManaged {
   public:
     InterleaveInfo() = default;
     InterleaveInfo(const InterleaveInfo&);

--- a/coreneuron/permute/cellorder.hpp
+++ b/coreneuron/permute/cellorder.hpp
@@ -12,6 +12,12 @@
 #include "coreneuron/utils/memory.h"
 #include <algorithm>
 namespace coreneuron {
+
+#ifdef ENABLE_CUDA_
+class InterleaveInfo; // forward declaration
+void solve_interleaved2_launcher(NrnThread* nt, InterleaveInfo* info, int ncore);
+#endif
+
 /**
  * \brief Function that performs the permutation of the cells such that the
  *        execution threads access coalesced memory.

--- a/coreneuron/permute/cellorder.hpp
+++ b/coreneuron/permute/cellorder.hpp
@@ -13,11 +13,6 @@
 #include <algorithm>
 namespace coreneuron {
 
-#ifdef ENABLE_CUDA_INTERFACE
-class InterleaveInfo;  // forward declaration
-void solve_interleaved2_launcher(NrnThread* nt, InterleaveInfo* info, int ncore);
-#endif
-
 /**
  * \brief Function that performs the permutation of the cells such that the
  *        execution threads access coalesced memory.
@@ -43,6 +38,15 @@ void destroy_interleave_info();
  * is solved by multiple execution threads (with coalesced memory access as well)
  */
 extern void solve_interleaved(int ith);
+
+class InterleaveInfo;  // forward declaration
+/**
+ *
+ * \brief CUDA branch of the solve_interleaved with interleave_permute_type == 2.
+ *
+ * This branch is activated in runtime with the --cuda-interface CLI flag
+ */
+void solve_interleaved2_launcher(NrnThread* nt, InterleaveInfo* info, int ncore, void* stream);
 
 class InterleaveInfo {
   public:

--- a/coreneuron/permute/cellorder.hpp
+++ b/coreneuron/permute/cellorder.hpp
@@ -13,8 +13,8 @@
 #include <algorithm>
 namespace coreneuron {
 
-#ifdef ENABLE_CUDA_
-class InterleaveInfo; // forward declaration
+#ifdef ENABLE_CUDA_INTERFACE
+class InterleaveInfo;  // forward declaration
 void solve_interleaved2_launcher(NrnThread* nt, InterleaveInfo* info, int ncore);
 #endif
 

--- a/coreneuron/utils/utils_cuda.h
+++ b/coreneuron/utils/utils_cuda.h
@@ -1,0 +1,16 @@
+/*
+# =============================================================================
+# Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
+#
+# See top-level LICENSE file for details.
+# =============================================================================.
+*/
+
+#pragma once
+
+#include <stdio.h>
+#include <cuda_runtime_api.h>
+
+// From Random123 lib
+#define CHECKLAST(MSG) 	do { cudaError_t e = cudaGetLastError(); if (e != cudaSuccess) {fprintf(stderr, "%s:%d: CUDA Error: %s: %s\n", __FILE__, __LINE__, (MSG), cudaGetErrorString(e)); exit(1); }} while(0)
+#define CHECKCALL(RET)	do { cudaError_t e = (RET); if (e != cudaSuccess) { fprintf(stderr, "%s:%d: CUDA Error: %s\n", __FILE__, __LINE__, cudaGetErrorString(e)); exit(1); } } while(0)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -24,14 +24,21 @@ set(TEST_CASES_WITH_ARGS
     "ring_spike_buffer!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_spike_buffer --spikebuf 1"
     "ring_permute1!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute1 ${PERMUTE1_ARGS}"
     "ring_permute2!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute2 ${PERMUTE2_ARGS}"
-    "ring_permute2_cudaInterface!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute2_cudaInterface ${PERMUTE2_ARGS} ${CUDA_INTERFACE}"
     "ring_gap!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap"
     "ring_gap_binqueue!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_binqueue --binqueue"
     "ring_gap_multisend!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_multisend --multisend"
     "ring_gap_permute1!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute1 ${PERMUTE1_ARGS}"
     "ring_gap_permute2!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute2 ${PERMUTE2_ARGS}"
-    "ring_gap_permute2_cudaInterface!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute2_cudaInterface ${PERMUTE2_ARGS} ${CUDA_INTERFACE}"
 )
+
+if(CORENRN_ENABLE_GPU)
+  list(
+    APPEND
+    TEST_CASES_WITH_ARGS
+    "ring_permute2_cudaInterface!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute2_cudaInterface ${PERMUTE2_ARGS} ${CUDA_INTERFACE}"
+    "ring_gap_permute2_cudaInterface!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute2_cudaInterface ${PERMUTE2_ARGS} ${CUDA_INTERFACE}"
+  )
+endif()
 
 # ~~~
 # As reports require MPI, do not add test if report is enabled.

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -24,13 +24,13 @@ set(TEST_CASES_WITH_ARGS
     "ring_spike_buffer!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_spike_buffer --spikebuf 1"
     "ring_permute1!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute1 ${PERMUTE1_ARGS}"
     "ring_permute2!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute2 ${PERMUTE2_ARGS}"
-    "ring_permute2_cudaInterface!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute2 ${PERMUTE2_ARGS} ${CUDA_INTERFACE}"
+    "ring_permute2_cudaInterface!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute2_cudaInterface ${PERMUTE2_ARGS} ${CUDA_INTERFACE}"
     "ring_gap!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap"
     "ring_gap_binqueue!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_binqueue --binqueue"
     "ring_gap_multisend!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_multisend --multisend"
     "ring_gap_permute1!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute1 ${PERMUTE1_ARGS}"
     "ring_gap_permute2!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute2 ${PERMUTE2_ARGS}"
-    "ring_gap_permute2_cudaInterface!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute2 ${PERMUTE2_ARGS} ${CUDA_INTERFACE}"
+    "ring_gap_permute2_cudaInterface!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute2_cudaInterface ${PERMUTE2_ARGS} ${CUDA_INTERFACE}"
 )
 
 # ~~~
@@ -63,7 +63,8 @@ foreach(data_dir "ring" "ring_gap")
     "savestate_permute1"
     "savestate_permute2"
     "permute1"
-    "permute2")
+    "permute2"
+    "permute2_cudaInterface")
     file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/${data_dir}/out.dat.ref"
          DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/${data_dir}_${test_suffix}/")
   endforeach()

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -11,6 +11,7 @@ set(RING_COMMON_ARGS "--datpath ${RING_DATASET_DIR} ${COMMON_ARGS}")
 set(RING_GAP_COMMON_ARGS "--datpath ${CMAKE_CURRENT_SOURCE_DIR}/ring_gap ${COMMON_ARGS}")
 set(PERMUTE1_ARGS "--cell-permute 1")
 set(PERMUTE2_ARGS "--cell-permute 2")
+set(CUDA_INTERFACE "--cuda-interface")
 if(CORENRN_ENABLE_GPU)
   set(GPU_ARGS "--gpu")
 endif()
@@ -23,11 +24,13 @@ set(TEST_CASES_WITH_ARGS
     "ring_spike_buffer!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_spike_buffer --spikebuf 1"
     "ring_permute1!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute1 ${PERMUTE1_ARGS}"
     "ring_permute2!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute2 ${PERMUTE2_ARGS}"
+    "ring_permute2!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute2 ${PERMUTE2_ARGS} ${CUDA_INTERFACE}"
     "ring_gap!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap"
     "ring_gap_binqueue!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_binqueue --binqueue"
     "ring_gap_multisend!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_multisend --multisend"
     "ring_gap_permute1!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute1 ${PERMUTE1_ARGS}"
     "ring_gap_permute2!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute2 ${PERMUTE2_ARGS}"
+    "ring_gap_permute2!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute2 ${PERMUTE2_ARGS} ${CUDA_INTERFACE}"
 )
 
 # ~~~

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -24,13 +24,13 @@ set(TEST_CASES_WITH_ARGS
     "ring_spike_buffer!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_spike_buffer --spikebuf 1"
     "ring_permute1!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute1 ${PERMUTE1_ARGS}"
     "ring_permute2!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute2 ${PERMUTE2_ARGS}"
-    "ring_permute2!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute2 ${PERMUTE2_ARGS} ${CUDA_INTERFACE}"
+    "ring_permute2_cudaInterface!${RING_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_permute2 ${PERMUTE2_ARGS} ${CUDA_INTERFACE}"
     "ring_gap!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap"
     "ring_gap_binqueue!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_binqueue --binqueue"
     "ring_gap_multisend!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_multisend --multisend"
     "ring_gap_permute1!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute1 ${PERMUTE1_ARGS}"
     "ring_gap_permute2!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute2 ${PERMUTE2_ARGS}"
-    "ring_gap_permute2!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute2 ${PERMUTE2_ARGS} ${CUDA_INTERFACE}"
+    "ring_gap_permute2_cudaInterface!${RING_GAP_COMMON_ARGS} ${GPU_ARGS} --outpath ${CMAKE_CURRENT_BINARY_DIR}/ring_gap_permute2 ${PERMUTE2_ARGS} ${CUDA_INTERFACE}"
 )
 
 # ~~~


### PR DESCRIPTION
**Description**

Implementation of solve_interleaved2 using CUDA + Improvement of OpenACC counterpart (issue #603)

The solve_interleaved1 should not be used since the algorithm is not optimized for GPUs. On the other hand, solve_interleaved2 is constructed with GPU-architecture in mind, i.e. the computations (forward/backward substitution on Hines matrices) are done in batches of warpsize(=32). This guarantees coalesced memory access and minimal branch divergence.

Regarding the openACC version of solve_interleaved2, I have forced the vector_length to be warpsize(=32) given the structure of the implementation. _This change resulted in 15-20% increase in performance._

Regarding the CUDA version of solve_interleaved2, I have tried many alternatives using shared/constant memory but because the algorithm is based on strided accesses of various matrices, these types of memories do not help. As is, the CUDA version has exactly the same performance as the OpenACC one. This branch is activated through the **--cuda-interface** cli argument.

**How to test this?**

```bash
cmake .. \
-DCMAKE_INSTALL_PREFIX=./install \
-DCORENRN_ENABLE_OPENMP=OFF \
-DCORENRN_ENABLE_GPU=ON \
-DCORENRN_ENABLE_NMODL=OFF \
-DCMAKE_C_COMPILER=nvc \
-DCMAKE_CXX_COMPILER=nvc++ \
-DCMAKE_CUDA_COMPILER=nvcc

make -j && make install

./bin/nrnivmodl-core **channel-benchmark/benchmark/channels/lib/modlib**
```

**Test System**
 - BB5

