### PR TITLE
Drop a couple of redundant CI builds.

### DIFF
--- a/.github/workflows/coreneuron-ci.yml
+++ b/.github/workflows/coreneuron-ci.yml
@@ -34,9 +34,9 @@ jobs:
       matrix:
         os: [ ubuntu-18.04, macOS-10.15 ]
         config:
-          - {cmake_option: "-DCORENRN_ENABLE_MPI=ON", documentation: ON }
+          # Defaults: CORENRN_ENABLE_SOA=ON CORENRN_ENABLE_MPI=ON
+          - {cmake_option: "-DCORENRN_ENABLE_MPI=ON", documentation: ON}
           - {cmake_option: "-DCORENRN_ENABLE_MPI=OFF"}
-          - {cmake_option: "-DCORENRN_ENABLE_SOA=ON"}
           - {cmake_option: "-DCORENRN_ENABLE_SOA=OFF"}
           - {use_nmodl: ON, py_version: 3.6.7}
           - {use_nmodl: ON}


### PR DESCRIPTION
**Description**
Two CI builds (one Ubuntu, one macOS) were doing essentially identical things to other builds. This drops them.
