### PR TITLE
Fix assertion in nrn2core_transfer_watch_condition

### DIFF
--- a/coreneuron/io/core2nrn_data_return.cpp
+++ b/coreneuron/io/core2nrn_data_return.cpp
@@ -287,9 +287,9 @@ static void core2nrn_watch() {
                 int watch_begin = first;
                 for (int iml = 0; iml < nodecount; ++iml) {
                     int iml_permute = permute ? permute[iml] : iml;
-                    Core2NrnWatchInfoItem& wiv = watch_info[iml_permute];
+                    Core2NrnWatchInfoItem& wiv = watch_info[iml];
                     for (int ix = first; ix <= last; ++ix) {
-                        int datum = pdata[nrn_i_layout(iml, nodecount, ix, dparam_size, layout)];
+                        int datum = pdata[nrn_i_layout(iml_permute, nodecount, ix, dparam_size, layout)];
                         if (datum & 2) {  // activated
                             bool above_thresh = bool(datum & 1);
                             wiv.push_back(std::pair<int, bool>(ix, above_thresh));

--- a/coreneuron/io/core2nrn_data_return.cpp
+++ b/coreneuron/io/core2nrn_data_return.cpp
@@ -289,7 +289,8 @@ static void core2nrn_watch() {
                     int iml_permute = permute ? permute[iml] : iml;
                     Core2NrnWatchInfoItem& wiv = watch_info[iml];
                     for (int ix = first; ix <= last; ++ix) {
-                        int datum = pdata[nrn_i_layout(iml_permute, nodecount, ix, dparam_size, layout)];
+                        int datum =
+                            pdata[nrn_i_layout(iml_permute, nodecount, ix, dparam_size, layout)];
                         if (datum & 2) {  // activated
                             bool above_thresh = bool(datum & 1);
                             wiv.push_back(std::pair<int, bool>(ix, above_thresh));
@@ -409,7 +410,7 @@ std::map<int, int*> type2invperm;
 
 static void clear_inv_perm_for_selfevent_targets() {
     for (auto it: type2invperm) {
-      delete it.second;
+        delete it.second;
     }
     type2invperm.clear();
 }
@@ -435,7 +436,7 @@ static void core2nrn_tqueue_item(TQItem* q, SelfEventWeightMap& sewm, NrnThread&
             assert(pnt->_tid == nt.id);
             int tar_type = (int) pnt->_type;
             Memb_list* ml = nt._ml_list[tar_type];
-            if (ml->_permute) { // if permutation, then make inverse available
+            if (ml->_permute) {  // if permutation, then make inverse available
                 // Doing this here because we don't know, in general, which
                 // mechanisms use SelfEvent
                 if (type2invperm.count(tar_type) == 0) {
@@ -457,7 +458,7 @@ static void core2nrn_tqueue_item(TQItem* q, SelfEventWeightMap& sewm, NrnThread&
                 // so that we only need to iterate over the nt.netcons once
                 sewm[weight_index].push_back(q);
             } else {
-                int tar_index = pnt->_i_instance; // correct for no permutation
+                int tar_index = pnt->_i_instance;  // correct for no permutation
                 if (ml->_permute) {
                     tar_index = type2invperm[tar_type][tar_index];
                 }

--- a/coreneuron/io/nrn2core_data_init.cpp
+++ b/coreneuron/io/nrn2core_data_init.cpp
@@ -188,6 +188,10 @@ static void nrn2core_tqueue() {
                         int offset = nt._pnt_offset[target_type];
                         Point_process* pnt = nt.pntprocs + offset + target_instance;
                         assert(pnt->_type == target_type);
+                        Memb_list* ml = nt._ml_list[target_type];
+                        if (ml->_permute) {
+                            target_instance = ml->_permute[target_instance];
+                        }
                         assert(pnt->_i_instance == target_instance);
                         assert(pnt->_tid == tid);
 
@@ -204,7 +208,6 @@ static void nrn2core_tqueue() {
                         // stored in the mechanism instance movable slot by net_send.
                         // And don't overwrite if not movable. Only one SelfEvent
                         // for a given target instance is movable.
-                        Memb_list* ml = nt._ml_list[target_type];
                         int movable_index =
                             nrn_i_layout(target_instance,
                                          ml->nodecount,

--- a/coreneuron/io/nrn2core_data_init.cpp
+++ b/coreneuron/io/nrn2core_data_init.cpp
@@ -347,7 +347,11 @@ void nrn2core_transfer_watch_condition(int tid,
     int pntoffset = nt._pnt_offset[pnttype];
     Point_process* pnt = nt.pntprocs + (pntoffset + pntindex);
     assert(pnt->_type == pnttype);
-    assert(pnt->_i_instance == pntindex);  // is this true for permutation?
+    Memb_list* ml = nt._ml_list[pnttype];
+    if (ml->_permute) {
+        pntindex = ml->_permute[pntindex];
+    }
+    assert(pnt->_i_instance == pntindex);
     assert(pnt->_tid == tid);
 
     // perhaps all this should be more closely associated with phase2 since
@@ -359,7 +363,6 @@ void nrn2core_transfer_watch_condition(int tid,
     // from where everything was done in nrn_setup.cpp. Here, I'm guessing
     // nrn_i_layout is the relevant index transformation after finding the
     // beginning of the mechanism pdata.
-    Memb_list* ml = nt._ml_list[pnttype];
     int* pdata = ml->pdata;
     int iml = pntindex;
     int nodecount = ml->nodecount;


### PR DESCRIPTION
**Description**

`assert(pnt->_i_instance == pntindex);` was not working properly for permute type different than 0.
Apply fix by @nrnhines mentioned in https://github.com/BlueBrain/CoreNeuron/issues/619#issuecomment-906377376 

Please include a summary of the change and which issue is fixed or which feature is added.

- [x] Fixes #619 together with https://github.com/HumanBrainProject/olfactory-bulb-3d/pull/13

**How to test this?**

Follow instructions in https://github.com/BlueBrain/CoreNeuron/issues/619#issue-979334600

**Test System**
 - OS: RedHat
 - Compiler: Intel
 - Version: master branch
 - Backend: CPU

CI_BRANCHES:NEURON_BRANCH=hines/psolve-permute-test,