### PR TITLE
Refactor/re-organising MPI related code

### DIFF
--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -5,9 +5,8 @@
 # =============================================================================
 
 # commonly included directories
-include_directories(
-  utils/randoms ${MPI_INCLUDE_PATH} ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR}/coreneuron
-  ${CMAKE_BINARY_DIR}/coreneuron ${CMAKE_BINARY_DIR}/include)
+include_directories(utils/randoms ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR}/coreneuron
+                    ${CMAKE_BINARY_DIR}/coreneuron ${CMAKE_BINARY_DIR}/include)
 
 # put libraries (e.g. dll) in bin directory
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -26,7 +25,6 @@ file(
   "io/*.cpp"
   "io/reports/*.cpp"
   "mechanism/*.cpp"
-  "mpi/*.cpp"
   "network/*.cpp"
   "permute/*.cpp"
   "sim/*.cpp"
@@ -35,6 +33,7 @@ file(
   "utils/*/*.cpp")
 file(GLOB_RECURSE CORENEURON_CUDA_FILES "*.cu")
 file(GLOB SCOPMATH_CODE_FILES "sim/scopmath/*.cpp")
+file(GLOB MPI_CODE_FILES "mpi/*.cpp")
 file(COPY ${CORENEURON_PROJECT_SOURCE_DIR}/external/Random123/include/Random123
      DESTINATION ${CMAKE_BINARY_DIR}/include)
 list(APPEND CORENEURON_CODE_FILES ${PROJECT_BINARY_DIR}/coreneuron/config/config.cpp)
@@ -158,10 +157,20 @@ add_custom_target(kin_deriv_header DEPENDS "${KINDERIV_HEADER_FILE}")
 # create libraries
 # =============================================================================
 
+# mpi related target, this will be a separate library for dynamic MPI
+add_library(corenrn_mpi OBJECT ${MPI_CODE_FILES})
+target_include_directories(corenrn_mpi PRIVATE ${MPI_INCLUDE_PATH})
+
 # main coreneuron library
 add_library(
-  coreneuron ${COMPILE_LIBRARY_TYPE} ${CORENEURON_HEADER_FILES} ${CORENEURON_TEMPLATE_FILES}
-             ${CORENEURON_CODE_FILES} ${cudacorenrn_objs} ${NMODL_INBUILT_MOD_OUTPUTS})
+  coreneuron
+  ${COMPILE_LIBRARY_TYPE}
+  ${CORENEURON_HEADER_FILES}
+  ${CORENEURON_TEMPLATE_FILES}
+  ${CORENEURON_CODE_FILES}
+  ${cudacorenrn_objs}
+  $<TARGET_OBJECTS:corenrn_mpi>
+  ${NMODL_INBUILT_MOD_OUTPUTS})
 # Prevent CMake from running a device code link step when assembling libcoreneuron.a in GPU builds.
 # The device code linking needs to be deferred to the final step, where it is done by `nvc++ -cuda`.
 set_target_properties(coreneuron PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
@@ -170,7 +179,7 @@ target_compile_options(coreneuron
                        PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CORENEURON_CXX_WARNING_SUPPRESSIONS}>)
 
 # need to have _kinderiv.h for mod2c generated files and nrnivmodl-core and nmodl building
-add_dependencies(coreneuron kin_deriv_header nrnivmodl-core)
+add_dependencies(coreneuron kin_deriv_header corenrn_mpi nrnivmodl-core)
 
 # scopmath is created separately for nrnivmodl-core workflow
 add_library(scopmath STATIC ${CORENEURON_HEADER_FILES} ${SCOPMATH_CODE_FILES})

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -180,7 +180,7 @@ target_compile_options(coreneuron
                        PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CORENEURON_CXX_WARNING_SUPPRESSIONS}>)
 
 # need to have _kinderiv.h for mod2c generated files and nrnivmodl-core and nmodl building
-add_dependencies(coreneuron kin_deriv_header corenrn_mpi nrnivmodl-core)
+add_dependencies(coreneuron kin_deriv_header nrnivmodl-core)
 
 # scopmath is created separately for nrnivmodl-core workflow
 add_library(scopmath STATIC ${CORENEURON_HEADER_FILES} ${SCOPMATH_CODE_FILES})

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -160,6 +160,7 @@ add_custom_target(kin_deriv_header DEPENDS "${KINDERIV_HEADER_FILE}")
 # mpi related target, this will be a separate library for dynamic MPI
 add_library(corenrn_mpi OBJECT ${MPI_CODE_FILES})
 target_include_directories(corenrn_mpi PRIVATE ${MPI_INCLUDE_PATH})
+set_property(TARGET corenrn_mpi PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # main coreneuron library
 add_library(

--- a/coreneuron/io/mech_report.cpp
+++ b/coreneuron/io/mech_report.cpp
@@ -11,7 +11,6 @@
 
 #include "coreneuron/coreneuron.hpp"
 #include "coreneuron/mpi/nrnmpi.h"
-#include "coreneuron/mpi/nrnmpi_impl.h"
 
 namespace coreneuron {
 

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -23,7 +23,6 @@
 #include "coreneuron/utils/nrnmutdec.h"
 #include "coreneuron/utils/memory.h"
 #include "coreneuron/mpi/nrnmpi.h"
-#include "coreneuron/mpi/nrnmpi_impl.h"
 #include "coreneuron/io/nrn_setup.hpp"
 #include "coreneuron/network/partrans.hpp"
 #include "coreneuron/io/nrn_checkpoint.hpp"
@@ -34,8 +33,6 @@
 #include "coreneuron/io/phase1.hpp"
 #include "coreneuron/io/phase2.hpp"
 #include "coreneuron/io/mech_report.h"
-#include "coreneuron/apps/corenrn_parameters.hpp"
-#include "coreneuron/io/nrn_setup.hpp"
 #include "coreneuron/io/reports/nrnreport.hpp"
 
 // callbacks into nrn/src/nrniv/nrnbbcore_write.cpp

--- a/coreneuron/mpi/nrnmpi.h
+++ b/coreneuron/mpi/nrnmpi.h
@@ -8,6 +8,9 @@
 
 #ifndef nrnmpi_h
 #define nrnmpi_h
+
+#include <string>
+
 #include "coreneuron/mpi/nrnmpiuse.h"
 
 namespace coreneuron {
@@ -39,6 +42,9 @@ typedef struct {
 } NRNMPI_Spike;
 
 extern bool nrnmpi_use; /* NEURON does MPI init and terminate?*/
+
+// Write given buffer to a new file using MPI collective I/O
+extern void nrnmpi_write_file(const std::string& filename, const char* buffer, size_t length);
 
 }  // namespace coreneuron
 #include "coreneuron/mpi/nrnmpidec.h"


### PR DESCRIPTION
**Description**

  - All MPI related code is now under coreneuron/mpi
  - Separate cmake target for mpi related code and
    include MPI headers for only these files
  - Remove unnecessary headers (and MPI include)
  - Spike output function is factored into a separate file

Preparation for #600

**How to test this?**

No new options/instructions.

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
