### PR TITLE
If last symbol in NEURON is USERDOUBLE, was not processed as GLOBAL.

### DIFF
--- a/coreneuron/io/global_vars.cpp
+++ b/coreneuron/io/global_vars.cpp
@@ -55,7 +55,8 @@ void set_globals(const char* path, bool cli_global_seed, int cli_global_seed_val
         const char* name;
         int size;
         double* val = nullptr;
-        for (void* p = nullptr;;) {
+        void* p = nullptr;
+        while (1) {
             p = (*nrn2core_get_global_dbl_item_)(p, name, size, val);
             // If the last item in the NEURON symbol table is a USERDOUBLE
             // then p is NULL but val is not NULL and following fragment

--- a/coreneuron/io/global_vars.cpp
+++ b/coreneuron/io/global_vars.cpp
@@ -55,22 +55,31 @@ void set_globals(const char* path, bool cli_global_seed, int cli_global_seed_val
         const char* name;
         int size;
         double* val = nullptr;
-        for (void* p = nullptr;
-             (p = (*nrn2core_get_global_dbl_item_)(p, name, size, val)) != nullptr;) {
-            N2V::iterator it = n2v->find(name);
-            if (it != n2v->end()) {
-                if (size == 0) {
-                    nrn_assert(it->second.first == 0);
-                    *(it->second.second) = val[0];
-                } else {
-                    nrn_assert(it->second.first == (size_t) size);
-                    double* pval = it->second.second;
-                    for (int i = 0; i < size; ++i) {
-                        pval[i] = val[i];
+        for (void* p = nullptr;;) {
+            p = (*nrn2core_get_global_dbl_item_)(p, name, size, val);
+            // If the last item in the NEURON symbol table is a USERDOUBLE
+            // then p is NULL but val is not NULL and following fragment
+            // will be processed before exit from loop.
+            if (val) {
+                N2V::iterator it = n2v->find(name);
+                if (it != n2v->end()) {
+                    if (size == 0) {
+                        nrn_assert(it->second.first == 0);
+                        *(it->second.second) = val[0];
+                    } else {
+                        nrn_assert(it->second.first == (size_t) size);
+                        double* pval = it->second.second;
+                        for (int i = 0; i < size; ++i) {
+                            pval[i] = val[i];
+                        }
                     }
                 }
+                delete[] val;
+                val = nullptr;
             }
-            delete[] val;
+            if (!p) {
+                break;
+            }
         }
         secondorder = (*nrn2core_get_global_int_item_)("secondorder");
         nrnran123_set_globalindex((*nrn2core_get_global_int_item_)("Random123_global_index"));


### PR DESCRIPTION
**Description**
All USERDOUBLE are supposed to be transferred to CoreNEURON in online mode (In offline mode they all are supposed to appear in the globals.dat file). Although unlikely, it is possible for the last item in the NEURON symbol table to be a USERDOUBLE.  In that case that variable will not appear in the CoreNEURON list of globals. This error has been fixed for offline (file transfer) mode with NeuronSimulator/nrn#1437.  This PR fixes the issue for online (direct transfer) mode.

This bug revealed itself as a minor memory leak  in nrn/test/pynrn with:
```
valgrind --leak-check=full --show-leak-kinds=definite `pyenv which python` -m pytest .
```
It turned out that ```cao0_ca_ion``` ended up as the last symbol in the NEURON symbol table due to the test statement
```
expect_hocerr(h.ion_register, ("ca", 3))
```
in test_basic.py, and became a memory leak in test_partrans.py when the CoreNEURON data files were written.


CI_BRANCHES:NEURON_BRANCH=master,
