### PR TITLE
CoreNEURON offline (file) mode initializes fast i_membrane.

### DIFF
--- a/coreneuron/sim/fast_imem.cpp
+++ b/coreneuron/sim/fast_imem.cpp
@@ -59,4 +59,20 @@ void nrn_calc_fast_imem(NrnThread* nt) {
     }
 }
 
+void nrn_calc_fast_imem_init(NrnThread* nt) {
+    // See the corresponding NEURON nrn_calc_fast_imem_fixedstep_init
+    int i1 = 0;
+    int i3 = nt->end;
+
+    double* vec_rhs = nt->_actual_rhs;
+    double* vec_area = nt->_actual_area;
+
+    double* fast_imem_rhs = nt->nrn_fast_imem->nrn_sav_rhs;
+#pragma acc parallel loop present(vec_rhs, vec_area, fast_imem_rhs) if (nt->compute_gpu) \
+    async(nt->stream_id)
+    for (int i = i1; i < i3; ++i) {
+        fast_imem_rhs[i] = (vec_rhs[i] + fast_imem_rhs[i]) * vec_area[i] * 0.01;
+    }
+}
+
 }  // namespace coreneuron

--- a/coreneuron/sim/fast_imem.hpp
+++ b/coreneuron/sim/fast_imem.hpp
@@ -29,9 +29,14 @@ void fast_imem_free();
 void nrn_fast_imem_alloc();
 
 /* Calculate the new values of rhs array at every timestep.
- * Found in src/nrnoc/fadvance.c in NEURON.
+ * Found in src/nrnoc/fadvance.cpp in NEURON.
  */
+
 void nrn_calc_fast_imem(NrnThread* _nt);
+/* Initialization used only in offline (file) mode.
+ * See NEURON nrn_calc_fast_imem_fixedstep_init in src/nrnoc/fadvance.cpp
+ */
+void nrn_calc_fast_imem_init(NrnThread* _nt);
 
 }  // namespace coreneuron
 #endif  // fast_imem_h

--- a/coreneuron/sim/finitialize.cpp
+++ b/coreneuron/sim/finitialize.cpp
@@ -101,7 +101,7 @@ void nrn_finitialize(int setv, double v) {
     for (int i = 0; i < nrn_nthread; ++i) {
         setup_tree_matrix_minimal(nrn_threads + i);
         if (nrn_use_fast_imem) {
-            nrn_calc_fast_imem(nrn_threads + i);
+            nrn_calc_fast_imem_init(nrn_threads + i);
         }
     }
     for (int i = 0; i < nrn_nthread; ++i) {


### PR DESCRIPTION
The equation for initialization of i_membrane_ is slightly different than its per time step calculation after each integration step.
This follows NeuronSimulator/nrn#1237

As it is currently inconvenient to print certain kinds of information during an offline run,  this was tested using a patch which prints the values of node index and i_membrane for every node after nrn_finitialize is called. I.e:
```
hines@hines-T7500:~/neuron/fastimem/external/coreneuron/coreneuron$ git diff
diff --git a/coreneuron/apps/main1.cpp b/coreneuron/apps/main1.cpp
index cbca538..4adabcb 100644
--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -470,6 +470,24 @@ extern "C" void mk_mech_init(int argc, char** argv) {
     mk_mech((corenrn_param.datpath).c_str());
 }
 
+static void print_fast_imem(const char* suffix) {
+  if (nrn_use_fast_imem) {
+    for (int ith = 0; ith < nrn_nthread; ++ith) {
+      NrnThread& nt = nrn_threads[ith];
+      if (nt.end > 0) {
+        char fname[100];
+        sprintf(fname, "fastimem_%d.%s", ith, suffix);
+        FILE* f = fopen(fname, "w");
+        fprintf(f, "%d\n", nt.end);
+        for (int i=0; i < nt.end; ++i) {
+          double* x = stdindex2ptr(i_membrane_, i, nt);    
+          fprintf(f, "%d %.20g\n", i, *x);
+        }
+      }
+    }
+  }
+}
+
 extern "C" int run_solve_core(int argc, char** argv) {
     Instrumentor::phase_begin("main");
 
@@ -478,6 +496,7 @@ extern "C" int run_solve_core(int argc, char** argv) {
     std::string spikes_population_name;
     bool reports_needs_finalize = false;
 
+    nrn_use_fast_imem = true;
     if (!corenrn_param.is_quiet()) {
         report_mem_usage("After mk_mech");
     }
@@ -535,6 +554,7 @@ extern "C" int run_solve_core(int argc, char** argv) {
         // false in checkpoint_initialize
         if (!corenrn_embedded && !checkPoints.initialize()) {
             nrn_finitialize(v != 1000., v);
+            print_fast_imem(corenrn_embedded ? "nrn" : "cn");
         }
 
         if (!corenrn_param.is_quiet()) {
```
The printed file compares identically to the NEURON initialization of i_membrane and printed by:
```
def print_fast_imem():
    ix = h.Vector()
    imem = h.Vector()
    for sec in h.allsec():
        for seg in sec.allseg():
            if seg.x == 0.0 and sec.parentseg() is not None:
                continue  # don't count twice
            ix.append(seg.node_index())
            imem.append(seg.i_membrane_)
    si = ix.sortindex()
    ix.index(ix.c(), si)
    imem.index(imem.c(), si)
    f = open("fastimem.nrn", "w")
    f.write("%d\n" % int(ix.size()))
    for i, x in enumerate(imem):
        assert i == int(ix[i])  
        f.write("%d %.20g\n" % (i, x))
    f.close()
```

