### PR TITLE
[CI] CoreNEURON no longer depends on Eigen.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -94,9 +94,6 @@ build:coreneuron+nmodl:gpu:
   extends:
     - .spack_build
     - .spack_nvhpc
-  before_script:
-    - SPACK_PACKAGE_DEPENDENCIES="${SPACK_PACKAGE_DEPENDENCIES}^eigen%gcc"
-    - !reference [.spack_build, before_script]
   needs: ["build:nmodl:gpu"]
 
 build:coreneuron:gpu:


### PR DESCRIPTION
After https://github.com/BlueBrain/spack/pull/1285 `coreneuron+nmodl` no longer depends on `eigen` in BlueBrain's Spack.
The CoreNEURON CI plan previously specified that the `eigen` dependency be built with GCC, which now causes an error because that dependency no longer exists.
Without this change, new CI runs (which take `develop` of `BlueBrain/spack`) will fail.

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
