### PR TITLE
Re-enable ccache in GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,13 +16,13 @@ stages:
 
 # Set up Spack
 spack_setup:
-  extends: .spack_setup
+  extends: .spack_setup_ccache
   variables:
     # Enable fetching GitHub PR descriptions and parsing them to find out what
     # branches to build of other projects.
     PARSE_GITHUB_PR_DESCRIPTIONS: "true"
   script:
-    - !reference [.spack_setup, script]
+    - !reference [.spack_setup_ccache, script]
     # This allows us to use the CoreNEURON repository in regression tests of
     # the gitlab-pipelines repositories. The regression test pipeline triggers
     # *this* pipeline as a child, having pushed a modified branch to the GitLab


### PR DESCRIPTION
**Description**
https://github.com/BlueBrain/CoreNeuron/pull/631 disabled `ccache` in the GitLab CI because of an issue, which I could not reproduce later (https://github.com/BlueBrain/nmodl/issues/731).

This PR re-enables `ccache`, which should make the CI faster.

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
