### PR TITLE
make vector_capacity and vector_vec as routine seq

### DIFF
--- a/coreneuron/utils/ivocvect.cpp
+++ b/coreneuron/utils/ivocvect.cpp
@@ -26,9 +26,12 @@ void* vector_new1(int n) {
     return (void*) (new IvocVect(n));
 }
 
+#pragma acc routine seq
 int vector_capacity(void* v) {
     return ((IvocVect*) v)->size();
 }
+
+#pragma acc routine seq
 double* vector_vec(void* v) {
     return ((IvocVect*) v)->data();
 }

--- a/coreneuron/utils/ivocvect.hpp
+++ b/coreneuron/utils/ivocvect.hpp
@@ -53,13 +53,17 @@ class fixed_vector {
         return data_[i];
     }
 
+    #pragma acc routine seq
     const T* data(void) const {
         return data_;
     }
+
+    #pragma acc routine seq
     T* data(void) {
         return data_;
     }
 
+    #pragma acc routine seq
     size_t size() const {
         return n_;
     }
@@ -73,7 +77,9 @@ extern double* vector_vec(IvocVect* v);
 
 // retro-compatibility API
 extern void* vector_new1(int n);
+#pragma acc routine seq
 extern int vector_capacity(void* v);
+#pragma acc routine seq
 extern double* vector_vec(void* v);
 
 }  // namespace coreneuron

--- a/coreneuron/utils/ivocvect.hpp
+++ b/coreneuron/utils/ivocvect.hpp
@@ -53,17 +53,17 @@ class fixed_vector {
         return data_[i];
     }
 
-    #pragma acc routine seq
+#pragma acc routine seq
     const T* data(void) const {
         return data_;
     }
 
-    #pragma acc routine seq
+#pragma acc routine seq
     T* data(void) {
         return data_;
     }
 
-    #pragma acc routine seq
+#pragma acc routine seq
     size_t size() const {
         return n_;
     }


### PR DESCRIPTION
fixes #638 

- [x]  Still have build issue : below issue is solved by using neurodamus@develop (GluSynapse file is updated in develop and it builds fine with OpenACC)

```
/gpfs/bbp.cscs.ch/ssd/slurmTmpFS/kumbhar/2608407/spack-stage/spack-stage-neurodamus-hippocampus-1.5-3.3.2-4mxtb7v3n52yea62g3bp4axur5d66daz/spack-src/build_hippocampus
 => Binary creating x86_64/special-core
/gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/bbpv/softwares/sources/spack/opt/spack/linux-rhel7-x86_64/nvhpc-21.2/coreneuron-1.1a-jblyvn/share/coreneuron/coreneuron.cpp:
nvlink error   : Undefined reference to '_ZN57_INTERNAL_35_x86_64_corenrn_mod2c_GluSynapse_cpp_52e3392310coreneuron19_net_receive_kernelEdPNS0_13Point_processEid' in 'x86_64/libcorenrnmech_hippocampus.a:GluSynapse.o'
pgacclnk: child process exit status 2: /gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/externals/2021-01-06/linux-rhel7-x86_64/gcc-9.3.0/nvhpc-21.2-67d2qp/Linux_x86_64/21.2/compilers/bin/tools/nvdd
make: *** [x86_64/special-core] Error 2
==> Error: ProcessError: Command exited with status 2:
    '/gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/bbpv/softwares/sources/spack/opt/spack/linux-rhel7-x86_64/nvhpc-21.2/coreneuron-1.1a-jblyvn/bin/nrnivmodl-core' '-n' 'hippocampus' '-i' '' '-l' '' 'mod'
...
```

CI_BRANCHES:NEURON_BRANCH=master,
