### PR TITLE
Add instrumentation phases in multiple places

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,7 @@ if(CORENRN_ENABLE_CALIPER_PROFILING)
   include_directories(${caliper_INCLUDE_DIR})
   add_definitions("-DCORENEURON_CALIPER")
   set(CALIPER_LIB "caliper")
+  set_property(GLOBAL APPEND_STRING PROPERTY CORENEURON_LIB_LINK_FLAGS " -L${caliper_LIB_DIR} -l${CALIPER_LIB}")
 endif()
 
 if(CORENRN_ENABLE_LIKWID_PROFILING)

--- a/coreneuron/network/netpar.cpp
+++ b/coreneuron/network/netpar.cpp
@@ -25,6 +25,7 @@
 #include "coreneuron/network/multisend.hpp"
 #include "coreneuron/utils/nrn_assert.h"
 #include "coreneuron/utils/nrnoc_aux.hpp"
+#include "coreneuron/utils/profile/profiler_interface.h"
 
 #if NRNMPI
 #include "coreneuron/mpi/mpispike.hpp"
@@ -288,6 +289,7 @@ void nrn_spike_exchange_init() {
 
 #if NRNMPI
 void nrn_spike_exchange(NrnThread* nt) {
+    Instrumentor::phase p_nrn_spike_exchange("nrn_spike_exchange");
     if (!active_) {
         return;
     }
@@ -327,6 +329,7 @@ void nrn_spike_exchange(NrnThread* nt) {
     if (n == 0) {
         return;
     }
+    Instrumentor::phase_begin("presyn-transfer");
 #if nrn_spikebuf_size > 0
     for (int i = 0; i < nrnmpi_numprocs; ++i) {
         int nn = spbufin_[i].nspike;
@@ -351,6 +354,7 @@ void nrn_spike_exchange(NrnThread* nt) {
         }
     }
     wt1_ = nrn_wtime() - wt;
+    Instrumentor::phase_end("presyn-transfer");
 }
 
 void nrn_spike_exchange_compressed(NrnThread* nt) {

--- a/coreneuron/sim/fadvance_core.cpp
+++ b/coreneuron/sim/fadvance_core.cpp
@@ -93,7 +93,10 @@ void nrn_fixed_step_minimal() { /* not so minimal anymore with gap junctions */
     nrn_thread_table_check();
     nrn_multithread_job(nrn_fixed_step_thread);
     if (nrn_have_gaps) {
-        nrnmpi_v_transfer();
+        {
+            Instrumentor::phase p("gap-v-transfer");
+            nrnmpi_v_transfer();
+        }
         nrn_multithread_job(nrn_fixed_step_lastpart);
     }
 #if NRNMPI

--- a/coreneuron/sim/finitialize.cpp
+++ b/coreneuron/sim/finitialize.cpp
@@ -66,6 +66,7 @@ void nrn_finitialize(int setv, double v) {
     }
 
     if (nrn_have_gaps) {
+        Instrumentor::phase p("gap-v-transfer");
         nrnmpi_v_transfer();
         for (int i = 0; i < nrn_nthread; ++i) {
             nrnthread_v_transfer(nrn_threads + i);


### PR DESCRIPTION
**Description**
Overall improvements in CoreNEURON instrumentation towards avoid having non instrumented part of code in typical simulation

- [x] Add more places where `gap-v-transfer` phase is executed
- [x] Create new phase for `nrn_spike_exchange` since that also includes `presyn-transfer` which takes a ~2% of the total simulation time on `olfactory-bulb-3d` circuit
- [x] Add `caliper` link flags to `CORENEURON_LIB_LINK_FLAGS` so that when calling `nrnivmodl -coreneuron` the correct flags are passed to the linker of `special/special-core`

**Example output**
```
CALI_CONFIG=runtime-report,profile.mpi,nvtx
```
Output of instrumentation of `olfactory-bulb-3d` model in 2 Nodes with 4 GPUs each
```bash
Path                         Min time/rank Max time/rank Avg time/rank Time %
main                              0.105163      0.119554      0.112414  0.055909
  MPI_Comm_dup                    0.000062      0.000274      0.000141  0.000070
  MPI_Finalize                    0.011457      0.013245      0.012351  0.006143
  MPI_Comm_free                   0.000018      0.004641      0.001670  0.000830
  MPI_Initialized                 0.000006      0.000018      0.000010  0.000005
  checkpoint                      0.000005      0.000010      0.000006  0.000003
  output-spike                    0.129579      1.375350      0.280763  0.139637
    MPI_File_close                0.005551      4.568384      2.643880  1.314927
    MPI_File_write_at_all         6.361088     10.927195      8.287230  4.121632
    MPI_File_open                 0.023753      0.024067      0.023923  0.011898
      MPI_Type_create_struct      0.000004      0.000017      0.000006  0.000003
    MPI_Exscan                    0.000047      0.627964      0.537560  0.267354
    MPI_Barrier                   0.000033      0.606135      0.545727  0.271416
    MPI_Alltoallv                 0.012401      0.021559      0.020777  0.010334
    MPI_Alltoall                  0.000102      0.001691      0.001188  0.000591
    MPI_Allreduce                 0.000050      0.004447      0.003127  0.001555
    MPI_Initialized               0.000001      0.000004      0.000002  0.000001
  simulation                      0.652448      2.861560      0.949646  0.472304
    MPI_Barrier                   0.000005      0.000012      0.000009  0.000005
    nrn_spike_exchange            0.060686      0.069935      0.062627  0.031147
      presyn-transfer             4.196795      5.339580      4.833493  2.403925
      spike-exchange              0.041662      0.044851      0.042890  0.021331
        communication             0.057565      0.064124      0.059038  0.029363
          MPI_Allgatherv          7.324536      9.836337      8.547918  4.251285
          MPI_Allgather           0.365271      0.498247      0.426346  0.212042
        imbalance                 0.041311      0.044983      0.042606  0.021190
          MPI_Barrier             4.636944      7.229453      5.743663  2.856596
    deliver_events                9.695369     10.747885     10.208742  5.077291
    state-update                  0.221595      0.277321      0.226720  0.112759
      state-ThreshDetect          0.932009      1.121317      1.016154  0.505382
      state-orn                   4.409581      5.018572      4.750651  2.362724
      state-nax                   1.329547      1.514845      1.436332  0.714356
      state-ks                    1.127615      1.263871      1.209744  0.601663
      state-kdrmt                 1.182972      1.319590      1.270289  0.631775
      state-kamt                  1.292956      1.447153      1.375226  0.683965
      state-FastInhib             0.946224      1.088567      1.011929  0.503280
      state-AmpaNmda              0.968806      1.092718      1.038367  0.516429
    gap-v-transfer                2.738712      5.329488      4.275310  2.126314
      MPI_Alltoallv               0.494332      0.955419      0.728803  0.362468
      MPI_Barrier                 5.625101     23.517717     13.638204  6.782925
    timestep                      0.679523      0.826140      0.731481  0.363800
      update                      0.859005      1.003404      0.913406  0.454280
      second_order_cur            0.028060      0.032828      0.028635  0.014242
      matrix-solver              16.916651     30.996376     22.632428 11.256179
      setup_tree_matrix           2.919654      3.433282      3.145658  1.564485
        cur-orn                   0.764106      0.904616      0.831750  0.413669
        cur-nax                   1.118828      1.239365      1.181284  0.587508
        cur-ks                    0.871916      1.008325      0.935921  0.465478
        cur-kdrmt                 1.065231      1.192407      1.125298  0.559664
        cur-kamt                  1.128107      1.242074      1.192747  0.593209
        cur-Gap                   0.854302      0.988763      0.916434  0.455786
        cur-FastInhib             0.931932      1.077984      0.994520  0.494622
        cur-AmpaNmda              1.055292      1.167771      1.109395  0.551755
        cur-k_ion                 0.681080      0.805702      0.735606  0.365852
        cur-na_ion                0.720891      0.863513      0.770430  0.383172
        cur-pas                   0.963630      1.075062      1.012954  0.503790
      deliver_events             47.622102     57.781483     52.936712 26.327936
  finitialize                     2.134226      2.456597      2.321076  1.154381
    nrn_spike_exchange            0.000004      0.000010      0.000006  0.000003
      spike-exchange              0.000001      0.000005      0.000003  0.000001
        communication             0.000008      0.000308      0.000185  0.000092
          MPI_Allgather           0.000038      0.000356      0.000163  0.000081
        imbalance                 0.000003      0.000011      0.000005  0.000003
          MPI_Barrier             0.000015      0.320665      0.134404  0.066845
    cur-orn                       0.000027      0.000102      0.000032  0.000016
    cur-nax                       0.000036      0.000147      0.000043  0.000021
    cur-ks                        0.000030      0.000073      0.000036  0.000018
    cur-kdrmt                     0.000033      0.000135      0.000039  0.000019
    cur-kamt                      0.000036      0.000167      0.000046  0.000023
    cur-Gap                       0.000027      0.000178      0.000033  0.000016
    cur-FastInhib                 0.000030      0.000127      0.000036  0.000018
    cur-AmpaNmda                  0.000031      0.000108      0.000039  0.000019
    cur-k_ion                     0.000017      0.000101      0.000024  0.000012
    cur-na_ion                    0.000022      0.000144      0.000030  0.000015
    cur-pas                       0.000037      0.000238      0.000068  0.000034
    gap-v-transfer                0.000120      0.000825      0.000243  0.000121
      MPI_Alltoallv               0.000043      0.000080      0.000070  0.000035
      MPI_Barrier                 0.000015      0.002859      0.001811  0.000901
  MPI_Barrier                     0.000101      0.022446      0.006772  0.003368
  load-model                      0.520480     31.535297      5.436917  2.704036
    MPI_Alltoallv                 0.000116      0.000361      0.000245  0.000122
    MPI_Alltoall                  0.000595     31.018368     26.108494 12.984991
    MPI_Allreduce                 0.003532      0.018366      0.011300  0.005620
  MPI_Allreduce                   0.009558      1.028329      0.484032  0.240732
```

**Test System**
 - OS: RedHat
 - Compiler: NVHPC 21.2
 - Version: master branch
 - Backend: GPU