### PR TITLE
Hines/rancompat

### DIFF
--- a/coreneuron/io/core2nrn_data_return.cpp
+++ b/coreneuron/io/core2nrn_data_return.cpp
@@ -410,7 +410,7 @@ std::map<int, int*> type2invperm;
 
 static void clear_inv_perm_for_selfevent_targets() {
     for (auto it: type2invperm) {
-        delete [] it.second;
+        delete[] it.second;
     }
     type2invperm.clear();
 }

--- a/coreneuron/io/core2nrn_data_return.cpp
+++ b/coreneuron/io/core2nrn_data_return.cpp
@@ -418,9 +418,11 @@ static void clear_inv_perm_for_selfevent_targets() {
 
 typedef std::map<int, std::vector<TQItem*>> SelfEventWeightMap;
 
-static void core2nrn_tqueue_item(TQItem* q, SelfEventWeightMap& sewm, NrnThread& nt) {
+// return false unless q is pushed to sewm
+static bool core2nrn_tqueue_item(TQItem* q, SelfEventWeightMap& sewm, NrnThread& nt) {
     DiscreteEvent* d = (DiscreteEvent*) q->data_;
     double td = q->t_;
+    bool in_sewm = false;
 
     switch (d->type()) {
         case NetConType: {
@@ -457,6 +459,8 @@ static void core2nrn_tqueue_item(TQItem* q, SelfEventWeightMap& sewm, NrnThread&
                 // same weight index. More importantly, collect them all
                 // so that we only need to iterate over the nt.netcons once
                 sewm[weight_index].push_back(q);
+                in_sewm = true;
+
             } else {
                 int tar_index = pnt->_i_instance;  // correct for no permutation
                 if (ml->_permute) {
@@ -464,6 +468,7 @@ static void core2nrn_tqueue_item(TQItem* q, SelfEventWeightMap& sewm, NrnThread&
                 }
                 (*core2nrn_SelfEvent_event_noweight_)(
                     nt.id, td, tar_type, tar_index, flag, is_movable);
+                delete se;
             }
             break;
         }
@@ -490,6 +495,7 @@ static void core2nrn_tqueue_item(TQItem* q, SelfEventWeightMap& sewm, NrnThread&
             break;
         }
     }
+    return in_sewm;
 }
 
 void core2nrn_tqueue(NrnThread& nt) {
@@ -510,11 +516,13 @@ void core2nrn_tqueue(NrnThread& nt) {
     SelfEventWeightMap sewm;
     // TQItems from atomic_dq
     while ((q = tqe->atomic_dq(1e20)) != nullptr) {
-        core2nrn_tqueue_item(q, sewm, nt);
+        if (core2nrn_tqueue_item(q, sewm, nt) == false) {
+            delete q;
+        }
     }
     // TQitems from binq_
     for (q = tqe->binq_->first(); q; q = tqe->binq_->next(q)) {
-        core2nrn_tqueue_item(q, sewm, nt);
+        assert(core2nrn_tqueue_item(q, sewm, nt) == false);
     }
 
     // For self events with weight, find the NetCon index and send that
@@ -545,6 +553,8 @@ void core2nrn_tqueue(NrnThread& nt) {
                     int is_movable = (movable && *movable == q) ? 1 : 0;
                     (*core2nrn_SelfEvent_event_)(
                         nt.id, td, tar_type, tar_index, flag, nc_index, is_movable);
+                    delete q;
+                    delete se;
                 }
             }
         }

--- a/coreneuron/io/core2nrn_data_return.cpp
+++ b/coreneuron/io/core2nrn_data_return.cpp
@@ -546,8 +546,16 @@ void core2nrn_tqueue(NrnThread& nt) {
                     assert(d->type() == SelfEventType);
                     SelfEvent* se = (SelfEvent*) d;
                     int tar_type = se->target_->_type;
-                    int tar_index = se->target_ - nt.pntprocs;
-                    // Note: nt.pntprocs is not permuted.
+                    // Note that instead of getting tar_index from the permuted
+                    // pnt->_i_instance here and for the noweight case above
+                    // which then needs the possibly large inverse permutation
+                    // vectors, it would save some space to use the unpermuted
+                    // nt.pntprocs array along with a much shorter vector
+                    // of type offsets.
+                    int tar_index = se->target_->_i_instance;
+                    if (nt._ml_list[tar_type]->_permute) {
+                        tar_index = type2invperm[tar_type][tar_index];
+                    }
                     double flag = se->flag_;
                     TQItem** movable = (TQItem**) (se->movable_);
                     int is_movable = (movable && *movable == q) ? 1 : 0;

--- a/coreneuron/io/core2nrn_data_return.cpp
+++ b/coreneuron/io/core2nrn_data_return.cpp
@@ -410,7 +410,7 @@ std::map<int, int*> type2invperm;
 
 static void clear_inv_perm_for_selfevent_targets() {
     for (auto it: type2invperm) {
-        delete it.second;
+        delete [] it.second;
     }
     type2invperm.clear();
 }

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -759,11 +759,13 @@ void nrn_cleanup() {
                     free_memory(nrb->_nrb_index);
                 }
                 free_memory(nrb);
+                ml->_net_receive_buffer = nullptr;
             }
 
             NetSendBuffer_t* nsb = ml->_net_send_buffer;
             if (nsb) {
                 delete nsb;
+                ml->_net_send_buffer = nullptr;
             }
 
             if (tml->dependencies)

--- a/coreneuron/io/phase2.cpp
+++ b/coreneuron/io/phase2.cpp
@@ -458,6 +458,7 @@ void Phase2::set_net_send_buffer(Memb_list** ml_list, const std::vector<int>& pn
         if (ml) {  // needs a NetReceiveBuffer
             NetReceiveBuffer_t* nrb =
                 (NetReceiveBuffer_t*) ecalloc_align(1, sizeof(NetReceiveBuffer_t));
+            assert(ml->_net_receive_buffer == nullptr);
             ml->_net_receive_buffer = nrb;
             nrb->_pnt_offset = pnt_offset[type];
 
@@ -467,7 +468,6 @@ void Phase2::set_net_send_buffer(Memb_list** ml_list, const std::vector<int>& pn
             nrb->_size = std::max(8, nrb->_size);
             // but not more than nodecount
             nrb->_size = std::min(ml->nodecount, nrb->_size);
-
             nrb->_pnt_index = (int*) ecalloc_align(nrb->_size, sizeof(int));
             nrb->_displ = (int*) ecalloc_align(nrb->_size + 1, sizeof(int));
             nrb->_nrb_index = (int*) ecalloc_align(nrb->_size, sizeof(int));
@@ -482,6 +482,7 @@ void Phase2::set_net_send_buffer(Memb_list** ml_list, const std::vector<int>& pn
         // Does this thread have this type.
         Memb_list* ml = ml_list[type];
         if (ml) {  // needs a NetSendBuffer
+            assert(ml->_net_send_buffer == nullptr);
             // begin with a size equal to twice number of instances
             NetSendBuffer_t* nsb = new NetSendBuffer_t(ml->nodecount * 2);
             ml->_net_send_buffer = nsb;

--- a/coreneuron/mechanism/mech/cfile/cabvars.h
+++ b/coreneuron/mechanism/mech/cfile/cabvars.h
@@ -22,12 +22,6 @@ static void (*mechanism[])(void) = {/* type will start at 3 */
                                     /* extracellular requires special handling and must be type 5 */
                                     extracell_reg_,
 #endif
-                                    _stim_reg,
-                                    _hh_reg,
-                                    _expsyn_reg,
-                                    _netstim_reg,
-                                    _exp2syn_reg,
-                                    _svclmp_reg,
                                     0};
 
 }  // namespace coreneuron

--- a/coreneuron/mechanism/membfunc.hpp
+++ b/coreneuron/mechanism/membfunc.hpp
@@ -41,6 +41,7 @@ struct Memb_func {
     int is_point;
     void (*setdata_)(double*, Datum*);
     int* dparam_semantics; /* for nrncore writing. */
+    ~Memb_func();
 };
 
 #define VINDEX       -1

--- a/coreneuron/mechanism/register_mech.cpp
+++ b/coreneuron/mechanism/register_mech.cpp
@@ -426,4 +426,14 @@ void _nrn_setdata_reg(int i, void (*call)(double*, Datum*)) {
 
     corenrn.get_memb_func(i).setdata_ = call;
 }
+
+Memb_func::~Memb_func() {
+    if (sym != nullptr) {
+        free(sym);
+    }
+    if (dparam_semantics != nullptr) {
+        free(dparam_semantics);
+    }
+}
+
 }  // namespace coreneuron

--- a/coreneuron/network/tqueue.ipp
+++ b/coreneuron/network/tqueue.ipp
@@ -45,7 +45,8 @@ TQueue<C>::~TQueue() {
     /// Clear the binq
     for (q = binq_->first(); q; q = q2) {
         q2 = binq_->next(q);
-        remove(q);  /// Potentially dereferences freed pointer this->sptree_
+        binq_->remove(q);
+        delete q;
     }
     delete binq_;
 


### PR DESCRIPTION
**Description**
Fix some memory leaks.
Fixes #644
Fix random123 memory leak in NetStim
Fix SelfEvent and TQItem leak on return to NEURON from psolve.
Fix memory leak due to dual registration of some mechanisms.



**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=hines/rancompat,SPACK_BRANCH=spike_multipop,NEURODAMUS_CORE_BRANCH=sandbox/weji/report_multipop,PYNEURODAMUS_BRANCH=sandbox/weji/report_multipop,