### PR TITLE
Respect __cpp_sized_deallocation macro.

### DIFF
--- a/coreneuron/utils/memory.cpp
+++ b/coreneuron/utils/memory.cpp
@@ -50,6 +50,10 @@ void deallocate_unified(void* ptr, std::size_t num_bytes) {
         return;
     }
 #endif
+#ifdef __cpp_sized_deallocation
     ::operator delete(ptr, num_bytes);
+#else
+    ::operator delete(ptr);
+#endif
 }
 }  // namespace coreneuron


### PR DESCRIPTION
**Description**

Only call `::operator delete(void*, std::size_t)` if it is defined,
otherwise fall back to `::operator delete(void*)`. Despite the
two-argument version being in the C++14 standard, Clang only enables it
if `-fsized-deallocation` is passed. [[link]](https://clang.llvm.org/cxx_status.html#n3778).
This fixes compilation of this file with Clang 12.



Language Feature | C++14 Proposal | Available in Clang?
-- | -- | --
C++ Sized Deallocation | N3778 | Clang 3.4 (7)

(7): In Clang 3.7 and later, sized deallocation is only enabled
if the user passes the <code>-fsized-deallocation</code> flag. The user must
supply definitions of the sized deallocation functions, either by providing them
explicitly or by using a C++ standard library that does. <code>libstdc++</code>
added these functions in version 5.0, and <code>libc++</code> added them in
version 3.7.

**Test System**
 - OS: RHEL7
 - Compiler: Clang 12
 - Version: master
 - Backend: CPU

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
