### PR TITLE
Allow GPU test jobs to run on all GPU nodes.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,6 +46,12 @@ spack_setup:
     SPACK_PACKAGE: neuron
     SPACK_PACKAGE_REF: ''
     SPACK_PACKAGE_SPEC: +coreneuron+debug+tests~legacy-unit
+.gpu_node:
+  variables:
+    # All GPU nodes are fair game
+    bb5_partition: uc2_all
+    # This is *probably* not needed given the partition above.
+    bb5_constraint: volta
 
 build:nmodl:intel:
   stage: build_nmodl
@@ -115,19 +121,11 @@ test:coreneuron:intel:
   needs: ["build:coreneuron:intel"]
 
 test:coreneuron+nmodl:gpu:
-  extends:
-    - .ctest
-  variables:
-    # GPU tests need to run on nodes with GPUs.
-    bb5_constraint: volta
+  extends: [.ctest, .gpu_node]
   needs: ["build:coreneuron+nmodl:gpu"]
 
 test:coreneuron:gpu:
-  extends:
-    - .ctest
-  variables:
-    # GPU tests need to run on nodes with GPUs.
-    bb5_constraint: volta
+  extends: [.ctest, .gpu_node]
   needs: ["build:coreneuron:gpu"]
 
 build:neuron+nmodl:intel:
@@ -182,16 +180,10 @@ test:neuron:intel:
 
 test:neuron+nmodl:gpu:
   stage: test_neuron
-  extends: [.ctest]
-  variables:
-    # GPU tests need to run on nodes with GPUs.
-    bb5_constraint: volta
+  extends: [.ctest, .gpu_node]
   needs: ["build:neuron+nmodl:gpu"]
 
 test:neuron:gpu:
   stage: test_neuron
-  extends: [.ctest]
-  variables:
-    # GPU tests need to run on nodes with GPUs.
-    bb5_constraint: volta
+  extends: [.ctest, .gpu_node]
   needs: ["build:neuron:gpu"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,8 +49,7 @@ spack_setup:
 .gpu_node:
   variables:
     # All GPU nodes are fair game
-    bb5_partition: uc2_all
-    # This is *probably* not needed given the partition above.
+    bb5_partition: prod_p2,prod_p1,interactive
     bb5_constraint: volta
 
 build:nmodl:intel:


### PR DESCRIPTION
**Description**
Allow GPU CI jobs to run on nodes not in the `prod` partition. Tests the resolution of HELP-14481.

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
