### PR TITLE
Let all DEBUG being compiled

### DIFF
--- a/.github/workflows/coreneuron-ci.yml
+++ b/.github/workflows/coreneuron-ci.yml
@@ -35,7 +35,7 @@ jobs:
         os: [ ubuntu-18.04, macOS-10.15 ]
         config:
           # Defaults: CORENRN_ENABLE_MPI=ON
-          - {cmake_option: "-DCORENRN_ENABLE_MPI=ON", documentation: ON}
+          - {cmake_option: "-DCORENRN_ENABLE_MPI=ON -DCORENRN_ENABLE_DEBUG_CODE=ON", documentation: ON}
           - {cmake_option: "-DCORENRN_ENABLE_MPI_DYNAMIC=ON"}
           - {cmake_option: "-DCORENRN_ENABLE_MPI_DYNAMIC=ON -DCORENRN_ENABLE_SHARED=OFF"}
           - {cmake_option: "-DCORENRN_ENABLE_MPI=OFF"}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,7 +36,7 @@ jobs:
         working-directory: ${{runner.workspace}}/CoreNeuron
         run:  |
           mkdir build && cd build
-          cmake .. -DCORENRN_ENABLE_MPI=ON -DCMAKE_C_FLAGS="-coverage -O0" -DCMAKE_CXX_FLAGS="-coverage -O0";
+          cmake .. -DCORENRN_ENABLE_MPI=ON -DCORENRN_ENABLE_DEBUG_CODE=ON -DCMAKE_C_FLAGS="-coverage -O0" -DCMAKE_CXX_FLAGS="-coverage -O0";
           make -j2
           (cd ..;  lcov --capture  --initial --directory . --no-external --output-file build/coverage-base.info)
           make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,11 @@ if(CORENRN_ENABLE_LIKWID_PROFILING)
   add_definitions("-DLIKWID_PERFMON")
 endif()
 
+# enable debugging code with extra logs to stdout
+if(CORENRN_ENABLE_DEBUG_CODE)
+  add_definitions(-DCORENRN_DEBUG -DCHKPNTDEBUG -DCORENRN_DEBUG_QUEUE -DINTERLEAVE_DEBUG)
+endif()
+
 # =============================================================================
 # Common CXX flags : ignore unknown pragma warnings
 # =============================================================================

--- a/coreneuron/apps/corenrn_parameters.cpp
+++ b/coreneuron/apps/corenrn_parameters.cpp
@@ -55,7 +55,7 @@ corenrn_parameters::corenrn_parameters() {
                      "Cell permutation: 0 No permutation; 1 optimise node adjacency; 2 optimize "
                      "parent adjacency.",
                      true)
-        ->check(CLI::Range(0, 3));
+        ->check(CLI::Range(0, 2));
     sub_gpu->add_flag("--cuda-interface",
                       this->cuda_interface,
                       "Activate CUDA branch of the code.");

--- a/coreneuron/io/global_vars.cpp
+++ b/coreneuron/io/global_vars.cpp
@@ -161,7 +161,7 @@ void set_globals(const char* path, bool cli_global_seed, int cli_global_seed_val
         }
     }
 
-#if DEBUG
+#if CORENRN_DEBUG
     for (const auto& item: *n2v) {
         printf("%s %ld %p\n", item.first.c_str(), item.second.first, item.second.second);
     }

--- a/coreneuron/io/nrn2core_data_init.cpp
+++ b/coreneuron/io/nrn2core_data_init.cpp
@@ -170,7 +170,9 @@ static void nrn2core_tqueue() {
                     case 2: {  // NetCon
                         int ncindex = ncte->intdata[idat++];
                         NetCon* nc = nt.netcons + ncindex;
+#ifndef CORENRN_DEBUG_QUEUE
 #define CORENRN_DEBUG_QUEUE 0
+#endif
 #if CORENRN_DEBUG_QUEUE
                         printf("nrn2core_tqueue tid=%d i=%zd type=%d tdeliver=%g NetCon %d\n",
                                tid,

--- a/coreneuron/io/nrn_checkpoint.hpp
+++ b/coreneuron/io/nrn_checkpoint.hpp
@@ -76,7 +76,7 @@ extern int patstimtype;
 // nrn_setup.cpp and debugging only information which is retrievable from
 // NrnThread and Memb_list. Ideally, this should all go away
 
-struct Memb_list_ckpnt {
+struct Memb_list_chkpnt {
     // debug only
     double* data_not_permuted;
     Datum* pdata_not_permuted;

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -524,7 +524,10 @@ void nrn_setup(const char* filesdat,
         nrn_setup_cleanup();
 
 #if INTERLEAVE_DEBUG
-    mk_cell_indices();
+    // mk_cell_indices debug code is supposed to be used with cell-per-core permutations
+    if (corenrn_param.cell_interleave_permute == 1) {
+        mk_cell_indices();
+    }
 #endif
 
     /// Allocate memory for fast_imem calculation
@@ -614,7 +617,7 @@ void read_phasegap(NrnThread& nt, UserParams& userParams) {
         F.read_array<int>(si.tar_index.data(), ntar);
     }
 
-#if DEBUG
+#if CORENRN_DEBUG
     printf("%d read_phasegap tid=%d nsrc=%d ntar=%d\n", nrnmpi_myid, nt.id, nsrc, ntar);
     for (int i = 0; i < nsrc; ++i) {
         printf("src %z %d %d\n", size_t(si.src_sid[i]), si.src_type[i], si.src_index[i]);

--- a/coreneuron/io/phase2.cpp
+++ b/coreneuron/io/phase2.cpp
@@ -745,9 +745,10 @@ void Phase2::get_info_from_bbcore(NrnThread& nt,
     // BBCOREPOINTER information
 #if CHKPNTDEBUG
     ntc.nbcp = num_point_process;
-    ntc.bcpicnt = new int[num_point_process];
-    ntc.bcpdcnt = new int[num_point_process];
-    ntc.bcptype = new int[num_point_process];
+    ntc.bcpicnt = new int[n_mech];
+    ntc.bcpdcnt = new int[n_mech];
+    ntc.bcptype = new int[n_mech];
+    size_t point_proc_id = 0;
 #endif
     for (size_t i = 0; i < n_mech; ++i) {
         int type = mech_types[i];
@@ -756,9 +757,10 @@ void Phase2::get_info_from_bbcore(NrnThread& nt,
         }
         type = tmls[i].type;  // This is not an error, but it has to be fixed I think
 #if CHKPNTDEBUG
-        ntc.bcptype[i] = type;
-        ntc.bcpicnt[i] = tmls[i].iArray.size();
-        ntc.bcpdcnt[i] = tmls[i].dArray.size();
+        ntc.bcptype[point_proc_id] = type;
+        ntc.bcpicnt[point_proc_id] = tmls[i].iArray.size();
+        ntc.bcpdcnt[point_proc_id] = tmls[i].dArray.size();
+        point_proc_id++;
 #endif
         int ik = 0;
         int dk = 0;
@@ -1066,7 +1068,7 @@ void Phase2::populate(NrnThread& nt, const UserParams& userParams) {
         permute_ptr(nt._v_parent_index, nt.end, p);
         node_permute(nt._v_parent_index, nt.end, p);
 
-#if DEBUG
+#if CORENRN_DEBUG
         for (int i = 0; i < nt.end; ++i) {
             printf("parent[%d] = %d\n", i, nt._v_parent_index[i]);
         }

--- a/coreneuron/io/phase2.hpp
+++ b/coreneuron/io/phase2.hpp
@@ -19,6 +19,7 @@ struct NrnThread;
 struct NrnThreadMembList;
 struct Memb_func;
 struct Memb_list;
+class NrnThreadChkpnt;
 
 class Phase2 {
   public:
@@ -82,9 +83,11 @@ class Phase2 {
     void fill_before_after_lists(NrnThread& nt, const std::vector<Memb_func>& memb_func);
     void pdata_relocation(const NrnThread& nt, const std::vector<Memb_func>& memb_func);
     void set_dependencies(const NrnThread& nt, const std::vector<Memb_func>& memb_func);
-    void handle_weights(NrnThread& nt, int n_netcon);
-    void get_info_from_bbcore(NrnThread& nt, const std::vector<Memb_func>& memb_func);
-    void set_vec_play(NrnThread& nt);
+    void handle_weights(NrnThread& nt, int n_netcon, NrnThreadChkpnt& ntc);
+    void get_info_from_bbcore(NrnThread& nt,
+                              const std::vector<Memb_func>& memb_func,
+                              NrnThreadChkpnt& ntc);
+    void set_vec_play(NrnThread& nt, NrnThreadChkpnt& ntc);
 
     int n_output;
     int n_real_output;

--- a/coreneuron/mechanism/register_mech.cpp
+++ b/coreneuron/mechanism/register_mech.cpp
@@ -165,7 +165,7 @@ void nrn_writes_conc(int type, int /* unused */) {
     if (type == -1)
         return;
 
-#if DEBUG
+#if CORENRN_DEBUG
     printf("%s reordered from %d to %d\n", corenrn.get_memb_func(type).sym, type, lastion);
 #endif
     if (nrn_is_ion(type)) {
@@ -243,7 +243,7 @@ void hoc_register_dparam_semantics(int type, int ix, const char* name) {
             ion_write_depend(type, etype);
         }
     }
-#if DEBUG
+#if CORENRN_DEBUG
     printf("dparam semantics %s ix=%d %s %d\n",
            memb_func[type].sym,
            ix,

--- a/coreneuron/network/multisend_setup.cpp
+++ b/coreneuron/network/multisend_setup.cpp
@@ -10,7 +10,7 @@
 #include <cmath>
 #include <numeric>
 
-#if DEBUG
+#if CORENRN_DEBUG
 #include <fstream>
 #include <iomanip>
 #endif
@@ -37,7 +37,7 @@ namespace coreneuron {
 using Gid2IPS = std::map<int, InputPreSyn*>;
 using Gid2PS = std::map<int, PreSyn*>;
 
-#if DEBUG
+#if CORENRN_DEBUG
 template <typename T>
 static void celldebug(const char* p, T& map) {
     std::string fname = std::string("debug.") + std::to_string(nrnmpi_myid);
@@ -91,7 +91,7 @@ static void alltoalldebug(const char*,
                           const std::vector<int>&) {}
 #endif
 
-#if DEBUG
+#if CORENRN_DEBUG
 void phase1debug(int* targets_phase1) {
     std::string fname = std::string("debug.") + std::to_string(nrnmpi_myid);
     std::ofstream f(fname, std::ios::app);

--- a/coreneuron/network/multisend_setup.cpp
+++ b/coreneuron/network/multisend_setup.cpp
@@ -12,6 +12,7 @@
 
 #if DEBUG
 #include <fstream>
+#include <iomanip>
 #endif
 
 #include "coreneuron/utils/randoms/nrnran123.h"

--- a/coreneuron/network/partrans_setup.cpp
+++ b/coreneuron/network/partrans_setup.cpp
@@ -124,7 +124,7 @@ void nrn_partrans::gap_mpi_setup(int ngroup) {
         assert(tar2info.find(sgid) != tar2info.end());
     }
 
-#if DEBUG
+#if CORENRN_DEBUG
     printf("%d mpi outsrccnt_, outsrcdspl_, insrccnt, insrcdspl_\n", nrnmpi_myid);
     for (int i = 0; i < nrnmpi_numprocs; ++i) {
         printf("%d : %d %d %d %d\n",
@@ -203,7 +203,7 @@ void nrn_partrans::gap_mpi_setup(int ngroup) {
         }
     }
 
-#if DEBUG
+#if CORENRN_DEBUG
     // things look ok so far?
     for (int tid = 0; tid < ngroup; ++tid) {
         SetupTransferInfo& si = setup_info_[tid];

--- a/coreneuron/network/partrans_setup.cpp
+++ b/coreneuron/network/partrans_setup.cpp
@@ -206,7 +206,7 @@ void nrn_partrans::gap_mpi_setup(int ngroup) {
 #if DEBUG
     // things look ok so far?
     for (int tid = 0; tid < ngroup; ++tid) {
-        nrn_partrans::SetupTransferInfo& si = setup_info_[tid];
+        SetupTransferInfo& si = setup_info_[tid];
         nrn_partrans::TransferThreadData& ttd = transfer_thread_data_[tid];
         for (size_t i = 0; i < si.src_sid.size(); ++i) {
             printf("%d %d src sid=%d v_index=%d %g\n",
@@ -217,7 +217,7 @@ void nrn_partrans::gap_mpi_setup(int ngroup) {
                    nrn_threads[tid]._data[ttd.src_indices[i]]);
         }
         for (size_t i = 0; i < ttd.tar_indices.size(); ++i) {
-            printf("%d %d src sid=i%z tar_index=%d %g\n",
+            printf("%d %d src sid=i%zd tar_index=%d %g\n",
                    nrnmpi_myid,
                    tid,
                    i,

--- a/coreneuron/permute/cellorder.hpp
+++ b/coreneuron/permute/cellorder.hpp
@@ -121,7 +121,9 @@ void copy_align_array(T*& dest, T* src, size_t n) {
     std::copy(src, src + n, dest);
 }
 
+#ifndef INTERLEAVE_DEBUG
 #define INTERLEAVE_DEBUG 0
+#endif
 
 #if INTERLEAVE_DEBUG
 void mk_cell_indices();

--- a/coreneuron/permute/cellorder1.cpp
+++ b/coreneuron/permute/cellorder1.cpp
@@ -92,7 +92,7 @@ static void admin2(int ncell,
                    int*& nodebegin,
                    int*& ncycles);
 static void check(VecTNode&);
-#if DEBUG
+#if CORENRN_DEBUG
 static void prtree(VecTNode&);
 #endif
 
@@ -168,13 +168,13 @@ static void quality(VecTNode& nodevec, size_t max = 32) {
 
     // print result
     qcnt = 0;
-#if DEBUG
+#if CORENRN_DEBUG
     for (const auto& q: qual) {
         qcnt += q.second;
         printf("%6ld %6ld\n", q.first, q.second);
     }
 #endif
-#if DEBUG
+#if CORENRN_DEBUG
     printf("qual.size=%ld  qual total nodes=%ld  nodevec.size=%ld\n",
            qual.size(),
            qcnt,
@@ -209,7 +209,7 @@ static void quality(VecTNode& nodevec, size_t max = 32) {
             }
         }
     }
-#if DEBUG
+#if CORENRN_DEBUG
     printf("nrace = %ld (parent in same group of %ld nodes)\n", nrace1, max);
     printf("nrace = %ld (parent used more than once by same group of %ld nodes)\n", nrace2, max);
 #endif
@@ -342,7 +342,7 @@ int* node_order(int ncell,
     }
     check(nodevec);
 
-#if DEBUG
+#if CORENRN_DEBUG
     for (int i = 0; i < ncell; ++i) {
         TNode& nd = *nodevec[i];
         printf("%d size=%ld hash=%ld ix=%d\n", i, nd.treesize, nd.hash, nd.nodeindex);
@@ -411,7 +411,7 @@ void check(VecTNode& nodevec) {
     }
 }
 
-#if DEBUG
+#if CORENRN_DEBUG
 void prtree(VecTNode& nodevec) {
     size_t nnode = nodevec.size();
     for (size_t i = 0; i < nnode; ++i) {
@@ -501,7 +501,7 @@ void node_interleave_order(int ncell, VecTNode& nodevec) {
     // Traversal of nodevec: From root to leaves (this is why we compute the tree node order)
     std::sort(nodevec.begin() + ncell, nodevec.end(), interleave_comp);
 
-#if DEBUG
+#if CORENRN_DEBUG
     for (size_t i = 0; i < nodevec.size(); ++i) {
         TNode& nd = *nodevec[i];
         printf("%ld cell=%ld ix=%d\n", i, nd.cellindex, nd.nodeindex);
@@ -651,7 +651,7 @@ static void admin2(int ncell,
         }
     }
 
-#if DEBUG
+#if CORENRN_DEBUG
     printf("warp rootbegin nodebegin stridedispl\n");
     for (int i = 0; i <= nwarp; ++i) {
         printf("%4d %4d %4d %4d\n", i, rootbegin[i], nodebegin[i], stridedispl[i]);

--- a/coreneuron/permute/cellorder2.cpp
+++ b/coreneuron/permute/cellorder2.cpp
@@ -78,7 +78,7 @@ static void set_treenode_order(VVTN& levels) {
     }
 }
 
-#if DEBUG
+#if CORENRN_DEBUG
 // every level starts out with no race conditions involving both
 // parent and child in the same level. Can we arrange things so that
 // every level has at least 32 nodes?
@@ -108,7 +108,7 @@ static bool is_parent_race2(TNode* nd) {  // vitiating
     return false;
 }
 
-#if DEBUG
+#if CORENRN_DEBUG
 static bool is_child_race(TNode* nd) {  // potentially handleable by atomic
     if (nd->children.size() < 2) {
         return false;
@@ -196,7 +196,7 @@ static void move_nodes(size_t start, size_t length, size_t dst, VTN& nodes) {
     }
 }
 
-#if DEBUG
+#if CORENRN_DEBUG
 // least number of nodes to move after nd to eliminate prace
 static size_t need2move(TNode* nd) {
     size_t d = dist2child(nd);
@@ -426,7 +426,7 @@ static void analyze(VVTN& levels) {
 }
 
 void prgroupsize(VVVTN& groups) {
-#if DEBUG
+#if CORENRN_DEBUG
     for (size_t i = 0; i < groups[0].size(); ++i) {
         printf("%5ld\n", i);
         for (const auto& group: groups) {

--- a/coreneuron/permute/node_permute.cpp
+++ b/coreneuron/permute/node_permute.cpp
@@ -272,7 +272,7 @@ int nrn_index_permute(int ix, int type, Memb_list* ml) {
     }
 }
 
-#if DEBUG
+#if CORENRN_DEBUG
 static void pr(const char* s, int* x, int n) {
     printf("%s:", s);
     for (int i = 0; i < n; ++i) {

--- a/coreneuron/sim/scopmath/sparse_thread.cpp
+++ b/coreneuron/sim/scopmath/sparse_thread.cpp
@@ -545,7 +545,7 @@ static void get_next_pivot(SparseObj* so, unsigned i) {
         reduce_order(so, el->row);
     }
 
-#if DEBUG
+#if CORENRN_DEBUG
     {
         int j;
         Item* _or;

--- a/coreneuron/utils/nrntimeout.cpp
+++ b/coreneuron/utils/nrntimeout.cpp
@@ -34,7 +34,7 @@ static struct sigaction act, oact;
 
 static void timed_out(int sig) {
     (void) sig; /* unused */
-#if DEBUG
+#if CORENRN_DEBUG
     printf("timed_out told=%g t=%g\n", told, t);
 #endif
     if (nrn_threads->_t == told) { /* nothing has been accomplished since last signal*/
@@ -51,7 +51,7 @@ void nrn_timeout(int seconds) {
     if (nrnmpi_myid != 0) {
         return;
     }
-#if DEBUG
+#if CORENRN_DEBUG
     printf("nrn_timeout %d\n", seconds);
 #endif
     if (seconds) {


### PR DESCRIPTION
hines: I think CORENRN_DEBUG_QUEUE can be deleted. Those are easy to add back if needed. I think INTERLEAVE_DEBUG should be kept as it consists of a very elaborate test which would be tedious to add back. I'd be happy to make it work again. I expect CHKPNTDEBUG to also be useful again in the future. DEBUG is too generic to be much use but to the extent that they are just printf, I think they can be removed and if more than a dozen lines in one place, assessed in context.