### PR TITLE
Sync t and dt changes to device.

### DIFF
--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -389,6 +389,7 @@ void handle_forward_skip(double forwardskip, int prcellgid) {
 
     dt = forwardskip * 0.1;
     t = -1e9;
+    dt2thread(-1.);
 
     for (int step = 0; step < 10; ++step) {
         nrn_fixed_step_minimal();

--- a/coreneuron/sim/fadvance_core.cpp
+++ b/coreneuron/sim/fadvance_core.cpp
@@ -78,6 +78,11 @@ void dt2thread(double adt) { /* copied from nrnoc/fadvance.c */
             } else {
                 nt->cj = 1.0 / dt;
             }
+            // clang-format off
+
+            #pragma acc update device(nt->_t, nt->_dt, nt->cj) \
+                    async(nt->stream_id) if(nt->compute_gpu)
+            // clang-format on
         }
     }
 }


### PR DESCRIPTION
**Description**
This makes the `dt2thread` method sync updates of `NrnThread::t`, `NrnThread::dt` (and `NrnThread::cj`) values from the host-side global `t` and `dt` onto the device.

Also call `dt2thread` when handing `--forwardskip`, otherwise in GPU mode the forward skip is performed with the wrong timestep. This was needed to get matching CPU/GPU results with the Hippocampus model.

**How to test this?**
Compare CoreNEURON execution on CPU and GPU when using a nonzero `--forwardskip` value.

**Test System**
 - OS: BB5
 - Compiler: NVHPC 21.2
 - Version: master ish
 - Backend: GPU

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
