### PR TITLE
fix: cmake options missing one '\'

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Note that if you are building on Cray system with the GNU toolchain, you have to
    -DNRN_ENABLE_CORENEURON=ON \
    -DNRN_ENABLE_INTERVIEWS=OFF \
    -DNRN_ENABLE_RX3D=OFF \
-   -DCMAKE_INSTALL_PREFIX=$HOME/install
+   -DCMAKE_INSTALL_PREFIX=$HOME/install \
    -DCMAKE_C_COMPILER=icc \
    -DCMAKE_CXX_COMPILER=icpc
   ```
@@ -258,7 +258,7 @@ cmake .. \
   -DNRN_ENABLE_CORENEURON=ON \
   -DNRN_ENABLE_INTERVIEWS=OFF \
   -DNRN_ENABLE_RX3D=OFF \
-  -DCMAKE_INSTALL_PREFIX=$HOME/install
+  -DCMAKE_INSTALL_PREFIX=$HOME/install \
   -DCMAKE_C_COMPILER=icc \
   -DCMAKE_CXX_COMPILER=icpc \
   -DNRN_ENABLE_TESTS=ON


### PR DESCRIPTION
- Did not raised an issue, but I was copy pasting the cmake configurations and noticed this minor typo: missing a `\`
- Hope It helps even if just a little
