### PR TITLE
Fix BB5-based CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,8 +48,6 @@ spack_setup:
     SPACK_PACKAGE_SPEC: +coreneuron+debug+tests~legacy-unit
 .gpu_node:
   variables:
-    # All GPU nodes are fair game
-    bb5_partition: prod_p2,prod_p1,interactive
     bb5_constraint: volta
 
 build:nmodl:intel:

--- a/tests/jenkins/install_coreneuron.sh
+++ b/tests/jenkins/install_coreneuron.sh
@@ -23,7 +23,7 @@ else
     mkdir build_${CORENRN_TYPE} build_intel_${CORENRN_TYPE}
 fi
 
-export SALLOC_PARTITION="prod,interactive";
+export SALLOC_PARTITION="prod";
 
 cd $WORKSPACE/build_${CORENRN_TYPE}
 


### PR DESCRIPTION
**Description**
After the Slurm upgrade we can no longer specify multiple partitions.

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
