### PR TITLE
All interthread events on queue before transfer.

### DIFF
--- a/coreneuron/io/core2nrn_data_return.cpp
+++ b/coreneuron/io/core2nrn_data_return.cpp
@@ -511,6 +511,9 @@ void core2nrn_tqueue(NrnThread& nt) {
 
     // The items on the queue
     NetCvodeThreadData& ntd = net_cvode_instance->p[nt.id];
+    // make sure all buffered interthread events are on the queue
+    ntd.enqueue(net_cvode_instance, &nt);
+
     TQueue<QTYPE>* tqe = ntd.tqe_;
     TQItem* q;
     SelfEventWeightMap sewm;


### PR DESCRIPTION
**Description**

Related to neuronsimulator/nrn#1534
This is part of the fix for issue neuronsimulator/nrn#1531

**How to test this?**
Build the NEURON version for neuronsimulator/nrn#1534
```bash
cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=install -DPYTHON_EXECUTABLE=`pyenv which python` -DNRN_ENABLE_RX3D=OFF -DCMAKE_BUILD_TYPE=Debug -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_TESTS=ON
ninja install
ninja test
# the relevant test is nrn/test/coreneuron/test_datarun.py and can be executed manually by
cd ../test/coreneuron
nrnivmodl -coreneuron mod
python test_datareturn.py
```

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=hines/nrn2core-tq-bug,
