### PR TITLE
Turn off printing of multisend setup space/time info

### DIFF
--- a/coreneuron/network/multisend_setup.cpp
+++ b/coreneuron/network/multisend_setup.cpp
@@ -150,7 +150,15 @@ static std::pair<std::vector<int>, std::vector<int>> all2allv_helper(const std::
     return std::make_pair(std::move(rcnt), std::move(rdispl));
 }
 
-#define all2allv_perf 1
+/*
+define following to 1 if desire space/performance information such as:
+all2allv_int gidin to intermediate space=1552 total=37345104 time=0.000495835
+all2allv_int gidout space=528 total=37379376 time=1.641e-05
+all2allv_int lists space=3088 total=37351312 time=4.4708e-05
+*/
+
+#define all2allv_perf 0
+
 // input: s, scnt, sdispl; output: r, rdispl
 static std::pair<std::vector<int>, std::vector<int>> all2allv_int(const std::vector<int>& s,
                                                                   const std::vector<int>& scnt,


### PR DESCRIPTION
**Description**

Turn off printing of multisend setup space/time info

**How to test this?**

See neuronsimulator/nrn#1537

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=hines/multisend-fix,
