### PR TITLE
[Hackathon] Add a temporary option for benchmark data.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,9 @@ option(CORENRN_ENABLE_SHARED "Enable shared library build" ON)
 option(CORENRN_ENABLE_LEGACY_UNITS "Enable legacy FARADAY, R, etc" OFF)
 option(CORENRN_ENABLE_PRCELLSTATE "Enable NRN_PRCELLSTATE debug feature" OFF)
 
+set(CORENRN_EXTERNAL_BENCHMARK_DATA
+    ""
+    CACHE PATH "Path to input data files and mechanisms for benchmarks")
 set(CORENRN_NMODL_DIR
     ""
     CACHE PATH "Path to nmodl source-to-source compiler installation")

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -310,10 +310,15 @@ if(NOT ${CORENRN_EXTERNAL_BENCHMARK_DATA} STREQUAL "")
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/benchmark
     COMMENT "Running nrnivmodl-core for channel-benchmark mechanisms")
   list(APPEND all_output_binaries ${output_binaries})
-  add_test(
-    NAME benchmark
-    COMMAND "${CMAKE_BINARY_DIR}/benchmark/${CMAKE_SYSTEM_PROCESSOR}/special-core" --datpath
-            "${CORENRN_EXTERNAL_BENCHMARK_DATA}/channel-benchmark-all-440-cells-2-ranks" --tstop 1)
+  string(
+    CONCAT
+      benchmark_command
+      "'${CMAKE_BINARY_DIR}/benchmark/${CMAKE_SYSTEM_PROCESSOR}/special-core'"
+      " --datpath '${CORENRN_EXTERNAL_BENCHMARK_DATA}/channel-benchmark-all-440-cells-2-ranks'"
+      " --tstop 1 &&"
+      "diff out.dat '${CORENRN_EXTERNAL_BENCHMARK_DATA}/channel-benchmark-all-440-cells-2-ranks.gpu.spikes'"
+  )
+  add_test(NAME benchmark COMMAND sh -c "${benchmark_command}")
 endif()
 set(modfile_directory "${CORENEURON_PROJECT_SOURCE_DIR}/tests/integration/ring_gap/mod")
 file(GLOB modfiles "${modfile_directory}/*.mod")

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -293,6 +293,28 @@ set_target_properties(
 # =============================================================================
 # create special-core with halfgap.mod for tests
 # =============================================================================
+set(all_output_binaries)
+if(NOT ${CORENRN_EXTERNAL_BENCHMARK_DATA} STREQUAL "")
+  # Hack for the december 2021 hackathon, build an extra special-core with channel-benchmark
+  # mechanisms.
+  set(modfile_directory
+      "${CORENRN_EXTERNAL_BENCHMARK_DATA}/channel-benchmark/benchmark/channels/lib/modlib")
+  file(GLOB modfiles "${modfile_directory}/*.mod")
+  set(output_binaries "${CMAKE_BINARY_DIR}/benchmark/${CMAKE_SYSTEM_PROCESSOR}/special-core"
+                      "${CMAKE_BINARY_DIR}/benchmark/${CMAKE_SYSTEM_PROCESSOR}/libcorenrnmech.a")
+  add_custom_command(
+    OUTPUT ${output_binaries}
+    DEPENDS scopmath coreneuron ${NMODL_TARGET_TO_DEPEND} ${modfiles} ${CORENEURON_BUILTIN_MODFILES}
+    COMMAND ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core -b STATIC -m ${CORENRN_MOD2CPP_BINARY} -p 1
+            "${modfile_directory}"
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/benchmark
+    COMMENT "Running nrnivmodl-core for channel-benchmark mechanisms")
+  list(APPEND all_output_binaries ${output_binaries})
+  add_test(
+    NAME benchmark
+    COMMAND "${CMAKE_BINARY_DIR}/benchmark/${CMAKE_SYSTEM_PROCESSOR}/special-core" --datpath
+            "${CORENRN_EXTERNAL_BENCHMARK_DATA}/channel-benchmark-all-440-cells-2-ranks" --tstop 1)
+endif()
 set(modfile_directory "${CORENEURON_PROJECT_SOURCE_DIR}/tests/integration/ring_gap/mod")
 file(GLOB modfiles "${modfile_directory}/*.mod")
 set(output_binaries "${CMAKE_BINARY_DIR}/bin/${CMAKE_SYSTEM_PROCESSOR}/special-core"
@@ -304,7 +326,8 @@ add_custom_command(
           "${modfile_directory}"
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   COMMENT "Running nrnivmodl-core with halfgap.mod")
-add_custom_target(nrniv-core ALL DEPENDS ${output_binaries})
+list(APPEND all_output_binaries ${output_binaries})
+add_custom_target(nrniv-core ALL DEPENDS ${all_output_binaries})
 
 include_directories(${CORENEURON_PROJECT_SOURCE_DIR})
 


### PR DESCRIPTION
**Description**
Adds an option `CORENRN_EXTERNAL_BENCHMARK_DATA` that we can point to a shared directory on Permutter/Ascent/BB5. A draft directory on BB5 is `/gpfs/bbp.cscs.ch/project/proj16/olupton/nersc-gpu-hackathon-dec-2021`, which exists (possibly out of date) at `$CFS/ntrain9/neuron/nersc-gpu-hackathon-dec-2021` on Perlmutter and `/ccsopen/proj/gen170/neuron/nersc-gpu-hackathon-dec-2021` on Ascent.

If this is available, building CoreNEURON will also create a `special-core` binary that can execute the `channel-benchmark` input data provided in `CORENRN_EXTERNAL_BENCHMARK_DATA`.