### PR TITLE
Set by default the number of warps

### DIFF
--- a/coreneuron/apps/corenrn_parameters.cpp
+++ b/coreneuron/apps/corenrn_parameters.cpp
@@ -47,7 +47,12 @@ corenrn_parameters::corenrn_parameters() {
                  "Print number of instances of each mechanism and detailed memory stats.");
 
     auto sub_gpu = app.add_option_group("GPU", "Commands relative to GPU.");
-    sub_gpu->add_option("-W, --nwarp", this->nwarp, "Number of warps to balance.", true)
+    sub_gpu
+        ->add_option("-W, --nwarp",
+                     this->nwarp,
+                     "Number of warps to execute in parallel the Hines solver. Each warp solves a "
+                     "group of cells. (Only used with cell permute 2)",
+                     true)
         ->check(CLI::Range(0, 1'000'000));
     sub_gpu
         ->add_option("-R, --cell-permute",

--- a/coreneuron/apps/corenrn_parameters.hpp
+++ b/coreneuron/apps/corenrn_parameters.hpp
@@ -46,7 +46,7 @@ struct corenrn_parameters {
     unsigned ms_subint = 2;                /// Number of multisend interval. 1 or 2
     unsigned spkcompress = 0;              /// Spike Compression
     unsigned cell_interleave_permute = 0;  /// Cell interleaving permutation
-    unsigned nwarp = 0;     /// Number of warps to balance for cell_interleave_permute == 2
+    unsigned nwarp = 1024;  /// Number of warps to balance for cell_interleave_permute == 2
     unsigned num_gpus = 0;  /// Number of gpus to use per node
     unsigned report_buff_size = report_buff_size_default;  /// Size in MB of the report buffer.
     int seed = -1;  /// Initialization seed for random number generator (int)


### PR DESCRIPTION
Set by default the number of warps to execute in a large reasonable number and update the related documentation

**Description**

Cell permute 2 algorithm is distributing the cells in groups based on the `nwarp` option based to the CLI. Since it used to be 0 as default all the cells were executed using one warp on GPU with the `--cell-permute 2` option and there was no interleaving of the cells in the way they are sorted in memory.
This generated suboptimal performance.
A quick solution provided is setting the `nwarp` to a reasonable large number that might not generate the best load balancing but should be enough to hide large latencies introduced by memory accesses.

TODO:
- Find a better and dynamic way to set it