### PR TITLE
Fix Boost-free compilation.

### DIFF
--- a/coreneuron/utils/randoms/nrnran123.cu
+++ b/coreneuron/utils/randoms/nrnran123.cu
@@ -69,7 +69,7 @@ std::unordered_map<void*, std::size_t> random123_allocate_unified::m_block_sizes
 using random123_allocator =
     boost::fast_pool_allocator<coreneuron::nrnran123_State, random123_allocate_unified>;
 #else
-using random123_allocator = coreneuron::unified_allocator<nrnran123_State>;
+using random123_allocator = coreneuron::unified_allocator<coreneuron::nrnran123_State>;
 #endif
 /* Global data structure per process. Using a unique_ptr here causes [minor]
  * problems because its destructor can be called very late during application


### PR DESCRIPTION
**Description**
Fix a silly bug in the branch of https://github.com/BlueBrain/CoreNeuron/pull/702 taken when Boost is not found.

**Use certain branches for the SimulationStack CI**
CI_BRANCHES:NEURON_BRANCH=master,
