### PR TITLE
Add corenrn_parameters::reset() method.

### DIFF
--- a/coreneuron/apps/corenrn_parameters.cpp
+++ b/coreneuron/apps/corenrn_parameters.cpp
@@ -160,7 +160,12 @@ corenrn_parameters::corenrn_parameters() {
     app.add_flag("-v, --version", this->show_version, "Show version information and quit.");
 
     CLI::retire_option(app, "--show");
-};
+}
+
+void corenrn_parameters::reset() {
+    static_cast<corenrn_parameters_data&>(*this) = corenrn_parameters_data{};
+    app.clear();
+}
 
 void corenrn_parameters::parse(int argc, char** argv) {
     try {

--- a/coreneuron/apps/corenrn_parameters.hpp
+++ b/coreneuron/apps/corenrn_parameters.hpp
@@ -35,10 +35,10 @@
 
 namespace coreneuron {
 
-struct corenrn_parameters {
+struct corenrn_parameters_data {
     enum verbose_level : std::uint32_t { NONE = 0, ERROR = 1, INFO = 2, DEBUG = 3, DEFAULT = INFO };
 
-    const int report_buff_size_default = 4;
+    static constexpr int report_buff_size_default = 4;
 
     unsigned spikebuf = 100'000;           /// Internal buffer used on every rank for spikes
     int prcellgid = -1;                    /// Gid of cell for prcellstate
@@ -86,13 +86,22 @@ struct corenrn_parameters {
     std::string checkpointpath;  /// Enable checkpoint and specify directory to store related files.
     std::string writeParametersFilepath;  /// Write parameters to this file
     std::string mpi_lib;                  /// Name of CoreNEURON MPI library to load dynamically.
+};
 
+struct corenrn_parameters: corenrn_parameters_data {
     CLI::App app{"CoreNeuron - Optimised Simulator Engine for NEURON."};  /// CLI app that performs
                                                                           /// CLI parsing
 
     corenrn_parameters();  /// Constructor that initializes the CLI11 app.
 
     void parse(int argc, char* argv[]);  /// Runs the CLI11_PARSE macro.
+
+    /** @brief Reset all parameters to their default values.
+     *
+     *  Unfortunately it is awkward to support `x = corenrn_parameters{}`
+     *  because `app` holds pointers to members of `corenrn_parameters`.
+     */
+    void reset();
 
     inline bool is_quiet() {
         return verbose == verbose_level::NONE;

--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -467,6 +467,8 @@ static void* load_dynamic_mpi(const std::string& libname) {
 #endif
 
 extern "C" void mk_mech_init(int argc, char** argv) {
+    // reset all parameters to their default values
+    corenrn_param.reset();
     // read command line parameters and parameter config files
     corenrn_param.parse(argc, argv);
 

--- a/tests/unit/cmdline_interface/test_cmdline_interface.cpp
+++ b/tests/unit/cmdline_interface/test_cmdline_interface.cpp
@@ -5,13 +5,14 @@
 # See top-level LICENSE file for details.
 # =============================================================================.
 */
+#include "coreneuron/apps/corenrn_parameters.hpp"
 
 #define BOOST_TEST_MODULE cmdline_interface
 #define BOOST_TEST_MAIN
 
 #include <boost/test/unit_test.hpp>
+
 #include <cfloat>
-#include "coreneuron/apps/corenrn_parameters.hpp"
 
 using namespace coreneuron;
 
@@ -74,13 +75,7 @@ BOOST_AUTO_TEST_CASE(cmdline_interface) {
 
         "--dt_io",
         "0.2"};
-
-    int argc = 0;
-
-    for (; strcmp(argv[argc], "0.2"); argc++)
-        ;
-
-    argc++;
+    constexpr int argc = sizeof argv / sizeof argv[0];
 
     corenrn_parameters corenrn_param_test;
 
@@ -126,4 +121,14 @@ BOOST_AUTO_TEST_CASE(cmdline_interface) {
     BOOST_CHECK(corenrn_param_test.spkcompress == 32);
 
     BOOST_CHECK(corenrn_param_test.multisend == true);
+
+    // Reset all parameters to their default values.
+    corenrn_param_test.reset();
+
+    // Should match a default-constructed set of parameters.
+    BOOST_CHECK_EQUAL(corenrn_param_test.voltage, corenrn_parameters{}.voltage);
+
+    // Everything has its default value, and the first `false` says not to
+    // include default values in the output, so this should be empty
+    BOOST_CHECK(corenrn_param_test.app.config_to_str(false, false).empty());
 }


### PR DESCRIPTION
**Description**
Adds a `reset()` method to the `corenrn_parameters` struct, which resets members to their default values.
This should help with https://github.com/BlueBrain/CoreNeuron/pull/701/files#r758813278.
It is challenging to support `corenrn_param = corenrn_parameters{}` as a way of doing the same thing because of the CLI11 struct embedded inside.

**Use certain branches for the SimulationStack CI**
CI_BRANCHES:NEURON_BRANCH=master,