### PR TITLE
Compile with -cuda

### DIFF
--- a/CMake/OpenAccHelper.cmake
+++ b/CMake/OpenAccHelper.cmake
@@ -58,7 +58,7 @@ if(CORENRN_ENABLE_GPU)
   # due to e.g. __CUDACC__ being defined. See https://github.com/BlueBrain/CoreNeuron/issues/607 for
   # more information about this. -gpu=cudaX.Y ensures that OpenACC code is compiled with the same
   # CUDA version as is used for the explicit CUDA code.
-  set(NVHPC_ACC_COMP_FLAGS "-Minfo=accel -gpu=cuda${CORENRN_CUDA_VERSION_SHORT},lineinfo")
+  set(NVHPC_ACC_COMP_FLAGS "-cuda -Minfo=accel -gpu=cuda${CORENRN_CUDA_VERSION_SHORT},lineinfo")
   set(NVHPC_ACC_LINK_FLAGS "-cuda")
   # Make sure that OpenACC code is generated for the same compute capabilities as the explicit CUDA
   # code. Otherwise there may be confusing linker errors. We cannot rely on nvcc and nvc++ using the


### PR DESCRIPTION
**Description**
Pass the `-cuda` option to the NVIDIA HPC compilers when OpenACC/OpenMP are enabled.
See https://forums.developer.nvidia.com/t/enabling-openmp-offload-breaks-openacc-code/196643, and this also seems to help with Random123.

TODO:
- [x] Merge https://github.com/BlueBrain/eigen/pull/1
- [x] Update https://github.com/BlueBrain/nmodl/pull/787
- [x] Merge https://github.com/BlueBrain/nmodl/pull/787
- [x] Merge Merge https://github.com/BlueBrain/eigen/pull/2
- [x] Update https://github.com/BlueBrain/nmodl/pull/789
- [x] Merge https://github.com/BlueBrain/nmodl/pull/789
- [x] Update NMODL submodule commit.

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=hackathon_main,
