### PR TITLE
Set compilation flags for different build types with Clang

### DIFF
--- a/CMake/config/CompilerFlagsHelpers.cmake
+++ b/CMake/config/CompilerFlagsHelpers.cmake
@@ -99,6 +99,17 @@ foreach(COMPILER_LANGUAGE ${SUPPORTED_COMPILER_LANGUAGE_LIST})
 
     # CLANG
   elseif(CMAKE_${COMPILER_LANGUAGE}_COMPILER_IS_CLANG)
+    set(CMAKE_${COMPILER_LANGUAGE}_WARNING_ALL "-Wall")
+    set(CMAKE_${COMPILER_LANGUAGE}_DEBUGINFO_FLAGS "-g")
+
+    set(CMAKE_${COMPILER_LANGUAGE}_OPT_NONE "-O0")
+    set(CMAKE_${COMPILER_LANGUAGE}_OPT_NORMAL "-O2")
+    set(CMAKE_${COMPILER_LANGUAGE}_OPT_AGGRESSIVE "-O3")
+    set(CMAKE_${COMPILER_LANGUAGE}_OPT_FASTEST "-Ofast -march=native")
+
+    set(CMAKE_${COMPILER_LANGUAGE}_STACK_PROTECTION "-fstack-protector")
+    set(CMAKE_${COMPILER_LANGUAGE}_POSITION_INDEPENDENT "-fPIC")
+
     # Force same ld behavior as when called from gcc --as-needed forces the linker to check whether
     # a dynamic library mentioned in the command line is actually needed by the objects being
     # linked. Symbols needed in shared objects are already linked when building that library.

--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -139,7 +139,7 @@ pipeline {
                 stage('tqperf'){
                     steps{
                         dir('tqperf'){
-                            git url: 'https://github.com/nrnhines/tqperf.git'
+                            git url: 'https://github.com/neuronsimulator/tqperf'
                         }
                     }
                 }

--- a/tests/jenkins/nrnivmodl-core.sh
+++ b/tests/jenkins/nrnivmodl-core.sh
@@ -15,13 +15,18 @@ mkdir -p ${CORENRN_TYPE}
 pushd ${CORENRN_TYPE}
 
 set +x
+
+# tqperf has extra mod files under modx
+if [ "${TEST_DIR}" = "tqperf" ]; then
+    cp ../modx/*.mod ../mod/
+fi
+
 if [ "${TEST_DIR}" = "ringtest" ]; then
     echo "Running install_${CORENRN_TYPE}/bin/nrnivmodl-core ."
     $WORKSPACE/install_${CORENRN_TYPE}/bin/nrnivmodl-core .
 else
-    cp ../mod/*.mod ../modx
-    echo "Running install_${CORENRN_TYPE}/bin/nrnivmodl-core ../modx"
-    $WORKSPACE/install_${CORENRN_TYPE}/bin/nrnivmodl-core ../modx
+    echo "Running install_${CORENRN_TYPE}/bin/nrnivmodl-core ../mod"
+    $WORKSPACE/install_${CORENRN_TYPE}/bin/nrnivmodl-core ../mod
 fi
 set -x
 

--- a/tests/jenkins/nrnivmodl-core.sh
+++ b/tests/jenkins/nrnivmodl-core.sh
@@ -19,8 +19,9 @@ if [ "${TEST_DIR}" = "ringtest" ]; then
     echo "Running install_${CORENRN_TYPE}/bin/nrnivmodl-core ."
     $WORKSPACE/install_${CORENRN_TYPE}/bin/nrnivmodl-core .
 else
-    echo "Running install_${CORENRN_TYPE}/bin/nrnivmodl-core ../mod"
-    $WORKSPACE/install_${CORENRN_TYPE}/bin/nrnivmodl-core ../mod
+    cp ../mod/*.mod ../modx
+    echo "Running install_${CORENRN_TYPE}/bin/nrnivmodl-core ../modx"
+    $WORKSPACE/install_${CORENRN_TYPE}/bin/nrnivmodl-core ../modx
 fi
 set -x
 

--- a/tests/jenkins/nrnivmodl-core.sh
+++ b/tests/jenkins/nrnivmodl-core.sh
@@ -19,6 +19,7 @@ set +x
 # tqperf has extra mod files under modx
 if [ "${TEST_DIR}" = "tqperf" ]; then
     cp ../modx/*.mod ../mod/
+    extra_args="-l -lcrypto"
 fi
 
 if [ "${TEST_DIR}" = "ringtest" ]; then
@@ -26,7 +27,7 @@ if [ "${TEST_DIR}" = "ringtest" ]; then
     $WORKSPACE/install_${CORENRN_TYPE}/bin/nrnivmodl-core .
 else
     echo "Running install_${CORENRN_TYPE}/bin/nrnivmodl-core ../mod"
-    $WORKSPACE/install_${CORENRN_TYPE}/bin/nrnivmodl-core ../mod
+    $WORKSPACE/install_${CORENRN_TYPE}/bin/nrnivmodl-core ${extra_args} ../mod
 fi
 set -x
 

--- a/tests/jenkins/nrnivmodl.sh
+++ b/tests/jenkins/nrnivmodl.sh
@@ -7,6 +7,10 @@ module load neuron/develop
 set -x
 TEST_DIR="$1"
 
+# tqperf has extra mod files under modx
+if [ "${TEST_DIR}" = "tqperf" ]; then
+    cp modx/*.mod mod/
+fi
+
 cd $WORKSPACE/${TEST_DIR}
-cp mod/*.mod modx/
-nrnivmodl modx
+nrnivmodl mod

--- a/tests/jenkins/nrnivmodl.sh
+++ b/tests/jenkins/nrnivmodl.sh
@@ -14,4 +14,4 @@ if [ "${TEST_DIR}" = "tqperf" ]; then
     cp modx/*.mod mod/
 fi
 
-nrnivmodl mod
+nrnivmodl -loadflags -lcrypto mod

--- a/tests/jenkins/nrnivmodl.sh
+++ b/tests/jenkins/nrnivmodl.sh
@@ -7,10 +7,11 @@ module load neuron/develop
 set -x
 TEST_DIR="$1"
 
+cd $WORKSPACE/${TEST_DIR}
+
 # tqperf has extra mod files under modx
 if [ "${TEST_DIR}" = "tqperf" ]; then
     cp modx/*.mod mod/
 fi
 
-cd $WORKSPACE/${TEST_DIR}
 nrnivmodl mod

--- a/tests/jenkins/nrnivmodl.sh
+++ b/tests/jenkins/nrnivmodl.sh
@@ -8,4 +8,5 @@ set -x
 TEST_DIR="$1"
 
 cd $WORKSPACE/${TEST_DIR}
-nrnivmodl mod
+cp mod/*.mod modx/
+nrnivmodl modx


### PR DESCRIPTION
**Description**

 - Clang compiler flags were not added
 - Because of this, no flags were set for RelWithDebInfo or
   any other build types
 - Update tqperf test script for Jenkins CI
   - update tqperf GitHub URL
   - mod files are now into two directories, need to use mod + modx 

**How to test this?**


```bash
module load unstable gcc llvm cmake python 
cmake ..

-- Configured CoreNEURON 1.0
--
-- You can now build CoreNEURON using:
--   cmake --build . --parallel 8 [--target TARGET]
-- You might want to adjust the number of parallel build jobs for your system.
-- Some non-default targets you might want to build:
-- --------------------+--------------------------------------------------------
--  Target             |   Description
-- --------------------+--------------------------------------------------------
-- install             | Will install CoreNEURON to: /usr/local
-- docs                | Build full docs. Calls targets: doxygen, sphinx
-- --------------------+--------------------------------------------------------
--  Build option       | Status
-- --------------------+--------------------------------------------------------
-- CXX COMPILER        | /gpfs/bbp.cscs.ch/ssd/apps/bsd/2021-11/stage_externals/install_gcc-11.2.0-skylake/llvm-13.0.0-lvcrm6/bin/clang++
-- COMPILE FLAGS       |  -fopenmp=libomp   -g  -O2 -std=c++14
```

Previously `-g  -O2 ` were not added.

**Test System**
 - System: BB5
 - Compiler: LLVM
 - Backend: CPU
