### PR TITLE
OpenMP target offloading for random123

### DIFF
--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -133,7 +133,8 @@ if(CORENRN_ENABLE_GPU)
   if(CORENRN_ENABLE_OPENMP_OFFLOAD)
     list(REMOVE_ITEM CORENEURON_CODE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/utils/randoms/nrnran123.cu")
   else()
-    list(REMOVE_ITEM CORENEURON_CODE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/utils/randoms/nrnran123.cpp")
+    list(REMOVE_ITEM CORENEURON_CODE_FILES
+         "${CMAKE_CURRENT_SOURCE_DIR}/utils/randoms/nrnran123.cpp")
   endif()
 
   # Eigen-3.5+ provides better GPU support. However, some functions cannot be called directly from

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -129,8 +129,12 @@ if(CORENRN_ENABLE_GPU)
   # CMake <v3.20 does not pass explicit -x <lang> options based on the LANGUAGE property
   # (https://cmake.org/cmake/help/latest/policy/CMP0119.html), so using a single .cu file and
   # setting LANGUAGE=CXX in non-GPU builds does not work.
-  list(REMOVE_ITEM CORENEURON_CODE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/utils/randoms/nrnran123.cpp")
   list(APPEND CORENEURON_CODE_FILES ${CORENEURON_CUDA_FILES})
+  if(CORENRN_ENABLE_OPENMP_OFFLOAD)
+    list(REMOVE_ITEM CORENEURON_CODE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/utils/randoms/nrnran123.cu")
+  else()
+    list(REMOVE_ITEM CORENEURON_CODE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/utils/randoms/nrnran123.cpp")
+  endif()
 
   # Eigen-3.5+ provides better GPU support. However, some functions cannot be called directly from
   # within an OpenACC region. Therefore, we need to wrap them in a special API (decorate them with

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -130,11 +130,16 @@ if(CORENRN_ENABLE_GPU)
   # (https://cmake.org/cmake/help/latest/policy/CMP0119.html), so using a single .cu file and
   # setting LANGUAGE=CXX in non-GPU builds does not work.
   list(APPEND CORENEURON_CODE_FILES ${CORENEURON_CUDA_FILES})
-  if(CORENRN_ENABLE_OPENMP_OFFLOAD)
+  if(CORENRN_ACCELERATOR_OFFLOAD STREQUAL "OpenMP")
     list(REMOVE_ITEM CORENEURON_CODE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/utils/randoms/nrnran123.cu")
-  else()
+  elseif(CORENRN_ACCELERATOR_OFFLOAD STREQUAL "OpenACC")
     list(REMOVE_ITEM CORENEURON_CODE_FILES
          "${CMAKE_CURRENT_SOURCE_DIR}/utils/randoms/nrnran123.cpp")
+  else()
+    message(
+      FATAL_ERROR
+        "Don't know how to build Random123 compatibility layer for GPU with ${CORENRN_ACCELERATOR_OFFLOAD} offload."
+    )
   endif()
 
   # Eigen-3.5+ provides better GPU support. However, some functions cannot be called directly from

--- a/coreneuron/utils/randoms/nrnran123.cu
+++ b/coreneuron/utils/randoms/nrnran123.cu
@@ -76,23 +76,33 @@ using random123_allocator = coreneuron::unified_allocator<coreneuron::nrnran123_
  * shutdown. If the destructor calls cudaFree and the CUDA runtime has already
  * been shut down then tools like cuda-memcheck reports errors.
  */
+#if defined(CORENEURON_ENABLE_GPU) && defined(CORENEURON_PREFER_OPENMP_OFFLOAD) && defined(_OPENMP)
+nrn_pragma_omp(declare target)
+philox4x32_key_t g_k{};
+nrn_pragma_omp(end declare target)
+#else
 philox4x32_key_t* g_k{};
+#endif
 
 // In a GPU build we need a device-side global pointer to this global state.
 // This is set to the same unified memory address as `g_k` in
 // `setup_global_state()` if the GPU is enabled. It would be cleaner to use
 // __managed__ here, but unfortunately that does not work on machines that do
 // not have a GPU.
-#ifdef __CUDACC__
+#ifdef __CUDA_ARCH__
 CORENRN_DEVICE philox4x32_key_t* g_k_dev;
 #endif
 
 OMP_Mutex g_instance_count_mutex;
+
+nrn_pragma_omp(declare target)
 std::size_t g_instance_count{};
+nrn_pragma_omp(end declare target)
 
 constexpr double SHIFT32 = 1.0 / 4294967297.0; /* 1/(2^32 + 1) */
 
 void setup_global_state() {
+#if !defined(CORENEURON_PREFER_OPENMP_OFFLOAD)
     if (g_k) {
         // Already initialised, nothing to do
         return;
@@ -116,6 +126,7 @@ void setup_global_state() {
         }
     }
 #endif
+#endif
 }
 
 /** @brief Get the Random123 global state from either host or device code.
@@ -126,12 +137,25 @@ CORENRN_HOST_DEVICE philox4x32_key_t& get_global_state() {
     // Called from device code
     ret = g_k_dev;
 #else
+#if defined(CORENEURON_ENABLE_GPU) && defined(CORENEURON_PREFER_OPENMP_OFFLOAD) && defined(_OPENMP)
+    ret = &g_k;
+#else
     // Called from host code
     ret = g_k;
+#endif
 #endif
     assert(ret);
     return *ret;
 }
+
+nrn_pragma_omp(declare target)
+/** @brief Provide a helper function in global namespace that is declared target for OpenMP
+ * offloading to function correctly with NVHPC
+ */
+philox4x32_ctr_t philox4x32_helper(coreneuron::nrnran123_State* s) {
+    return philox4x32(s->c, get_global_state());
+}
+nrn_pragma_omp(end declare target)
 }  // namespace
 
 namespace coreneuron {
@@ -157,7 +181,7 @@ CORENRN_HOST_DEVICE void nrnran123_setseq(nrnran123_State* s, uint32_t seq, char
         s->which_ = which;
     }
     s->c.v[0] = seq;
-    s->r = philox4x32(s->c, get_global_state());
+    s->r = philox4x32_helper(s);
 }
 
 CORENRN_HOST_DEVICE void nrnran123_getids(nrnran123_State* s, uint32_t* id1, uint32_t* id2) {
@@ -181,7 +205,7 @@ CORENRN_HOST_DEVICE uint32_t nrnran123_ipick(nrnran123_State* s) {
     if (which > 3) {
         which = 0;
         s->c.v[0]++;
-        s->r = philox4x32(s->c, get_global_state());
+        s->r = philox4x32_helper(s);
     }
     s->which_ = which;
     return rval;

--- a/coreneuron/utils/randoms/nrnran123.cu
+++ b/coreneuron/utils/randoms/nrnran123.cu
@@ -89,7 +89,7 @@ philox4x32_key_t* g_k{};
 // `setup_global_state()` if the GPU is enabled. It would be cleaner to use
 // __managed__ here, but unfortunately that does not work on machines that do
 // not have a GPU.
-#ifdef __CUDA_ARCH__
+#if defined(__CUDACC__) && !defined(CORENEURON_PREFER_OPENMP_OFFLOAD)
 CORENRN_DEVICE philox4x32_key_t* g_k_dev;
 #endif
 

--- a/coreneuron/utils/randoms/nrnran123.cu
+++ b/coreneuron/utils/randoms/nrnran123.cu
@@ -95,9 +95,7 @@ CORENRN_DEVICE philox4x32_key_t* g_k_dev;
 
 OMP_Mutex g_instance_count_mutex;
 
-nrn_pragma_omp(declare target)
 std::size_t g_instance_count{};
-nrn_pragma_omp(end declare target)
 
 constexpr double SHIFT32 = 1.0 / 4294967297.0; /* 1/(2^32 + 1) */
 
@@ -117,11 +115,13 @@ void setup_global_state() {
         // there is no point initialising the device global to it.
         {
             auto const code = cudaMemcpyToSymbol(g_k_dev, &g_k, sizeof(g_k));
+            static_cast<void>(code);
             assert(code == cudaSuccess);
         }
         // Make sure g_k_dev is updated.
         {
             auto const code = cudaDeviceSynchronize();
+            static_cast<void>(code);
             assert(code == cudaSuccess);
         }
     }
@@ -152,7 +152,7 @@ nrn_pragma_omp(declare target)
 /** @brief Provide a helper function in global namespace that is declared target for OpenMP
  * offloading to function correctly with NVHPC
  */
-philox4x32_ctr_t philox4x32_helper(coreneuron::nrnran123_State* s) {
+CORENRN_HOST_DEVICE philox4x32_ctr_t philox4x32_helper(coreneuron::nrnran123_State* s) {
     return philox4x32(s->c, get_global_state());
 }
 nrn_pragma_omp(end declare target)


### PR DESCRIPTION
**Description**

A clean branch based on the experiments done during GPU hackathon implementing OpenMP offloading for
coreneuron random123, keeping the CUDA/OpenACC versions intact so they can coexist.

- [x] Currently building with extra flags to make sure Random123 doesn't break, should be checked and put into build system
- [x] Check if OpenMP offloading is properly working
- [x] Check if different build variants are functional (that's what the CI is for)
- [x] Profile implementation

Fixes # (issue)

**How to test this?**

```bash
cmake .. -G Ninja -DCORENRN_ENABLE_GPU=ON -DCORENRN_ENABLE_NMODL=ON \
    -DCORENRN_NMODL_FLAGS=""  -DCMAKE_CUDA_COMPILER=nvcc  \
    -DCMAKE_CXX_FLAGS="-DR123_USE_SSE=0" -DCMAKE_CXX_COMPILER=nvc++ \
    -DCORENRN_ENABLE_OPENMP=ON -DCORENRN_ENABLE_OPENMP_OFFLOAD=ON
ninja
ctest -V
```

**Test System**
 - BB5

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=master,
