### PR TITLE
Add Unified Memory build in Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,7 +149,7 @@ test:coreneuron:mod2c:nvhpc:acc:
 
 test:coreneuron:mod2c:nvhpc:acc:unified:
   extends: [.ctest, .gpu_node]
-  needs: ["build:coreneuron:mod2c:nvhpc:acc:unified:"]
+  needs: ["build:coreneuron:mod2c:nvhpc:acc:unified"]
 
 test:coreneuron:nmodl:nvhpc:omp:
   extends: [.ctest, .gpu_node]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,6 +80,15 @@ build:coreneuron:mod2c:nvhpc:acc:
     # See https://github.com/BlueBrain/CoreNeuron/issues/518 re: build_type
     SPACK_PACKAGE_SPEC: +gpu+openmp+tests~legacy-unit~report build_type=RelWithDebInfo
 
+# Build CoreNEURON with Unified Memory on GPU
+build:coreneuron:mod2c:nvhpc:acc:unified:
+  extends: [.build, .spack_nvhpc]
+  variables:
+    SPACK_PACKAGE: coreneuron
+    # +report pulls in a lot of dependencies and the tests fail.
+    # See https://github.com/BlueBrain/CoreNeuron/issues/518 re: build_type
+    SPACK_PACKAGE_SPEC: +gpu+unified+openmp+tests~legacy-unit~report build_type=RelWithDebInfo
+
 build:coreneuron:nmodl:nvhpc:omp:
   extends: [.build, .spack_nvhpc]
   variables:
@@ -137,6 +146,10 @@ build:neuron:nmodl:intel:
 test:coreneuron:mod2c:nvhpc:acc:
   extends: [.ctest, .gpu_node]
   needs: ["build:coreneuron:mod2c:nvhpc:acc"]
+
+test:coreneuron:mod2c:nvhpc:acc:unified:
+  extends: [.ctest, .gpu_node]
+  needs: ["build:coreneuron:mod2c:nvhpc:acc:unified:"]
 
 test:coreneuron:nmodl:nvhpc:omp:
   extends: [.ctest, .gpu_node]


### PR DESCRIPTION
**Description**

Added `Unified Memory` build with `mod2c` in Gitlab CI similar to the old Jenkins pipeline

Partly tackles #732 

**Use certain branches for the CI**

CI_BRANCHES:NEURON_BRANCH=master,
