### PR TITLE
Extend CMake/CUDAHOSTCXX/... workaround.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,10 +141,10 @@ if(CORENRN_ENABLE_GPU)
     message(STATUS "Setting default CUDA architectures to ${CMAKE_CUDA_ARCHITECTURES}")
   endif()
 
-  if(${CMAKE_VERSION} VERSION_LESS 3.16)
-    if(DEFINED CMAKE_CUDA_HOST_COMPILER)
-      unset(ENV{CUDAHOSTCXX})
-    endif()
+  # See https://gitlab.kitware.com/cmake/cmake/-/issues/23081, this should not be needed according
+  # to the CMake documentation, but it is not clear that any version behaves as documented.
+  if(DEFINED CMAKE_CUDA_HOST_COMPILER)
+    unset(ENV{CUDAHOSTCXX})
   endif()
 
   # Enable CUDA language support.


### PR DESCRIPTION
**Description**
Remove a CMake version check as it appears that 3.21 and 3.22 do not behave as documented.

This fixes Spack GPU builds with more modern CMake versions. Spack sets `CUDAHOSTCXX` to point to the C++ compiler (`nvc++` in GPU builds) and, despite the documentation, this is not overridden by `CMAKE_CUDA_HOST_COMPILER` being set to point to `g++`. The version of `nvc++` in the new deployment (21.11 using GCC 11.2 headers) is not supported as a host compiler for `nvcc` in CUDA (11.5.1) -- [link](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements).

**How to test this?**
```bash
spack install coreneuron%nvhpc+gpu
```
with a CMake version such as 3.21 will return an error like
```
Compiling the CUDA compiler identification source file "CMakeCUDACompilerId.cu" failed.
```
where the build log shows `-ccbin path/to/nvc++`. 

**Use certain branches for the SimulationStack CI**
CI_BRANCHES:NEURON_BRANCH=master,
