### PR TITLE
Enable dynamic MPI in github CI when built as neuron submodule

### DIFF
--- a/.github/workflows/test-as-submodule.yml
+++ b/.github/workflows/test-as-submodule.yml
@@ -30,19 +30,6 @@ jobs:
       CMAKE_BUILD_PARALLEL_LEVEL: ${{matrix.cores}}
     steps:
 
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"
-      - name: Dump job context
-        env:
-          JOB_CONTEXT: ${{ toJSON(job) }}
-        run: echo "$JOB_CONTEXT"
-      - name: Dump env context
-        env:
-          ENV_CONTEXT: ${{ toJSON(env) }}
-        run: echo "$ENV_CONTEXT"
-
       - name: Install homebrew packages
         if: startsWith(matrix.os, 'macOS')
         run: |
@@ -63,11 +50,11 @@ jobs:
 
       - name: Set NEURON branch
         id: vars
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
         run: |
-          pr_number=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
-          nrn_branch=`curl -H "Accept: application/vnd.github.v3+json"  \
-                      https://api.github.com/repos/bluebrain/coreneuron/pulls/$pr_number \
-                      | jq -r '.body' | grep "^CI_BRANCHES" \
+          nrn_branch=`echo $GITHUB_CONTEXT  \
+                      | jq -r '.event .pull_request .body' | grep "^CI_BRANCHES" \
                       | awk -v FS="(NEURON_BRANCH=|,)" '{print $2}'`
           if [ -z "$nrn_branch" ]; then
               nrn_branch=master

--- a/.github/workflows/test-as-submodule.yml
+++ b/.github/workflows/test-as-submodule.yml
@@ -90,6 +90,7 @@ jobs:
             -DNRN_ENABLE_CORENEURON=ON \
             -DNRN_ENABLE_INTERVIEWS=OFF \
             -DNRN_ENABLE_RX3D=OFF \
+            -DNRN_ENABLE_MPI_DYNAMIC=ON \
             -DNRN_ENABLE_TESTS=ON
 
       - name: Build NEURON

--- a/.github/workflows/test-as-submodule.yml
+++ b/.github/workflows/test-as-submodule.yml
@@ -55,6 +55,7 @@ jobs:
           #       by the GitLab CI plans.
           path: nrn
           repository: neuronsimulator/nrn
+          ref: pramodk/coreneuron-update
 
       - name: Update CoreNEURON submodule
         run: |

--- a/.github/workflows/test-as-submodule.yml
+++ b/.github/workflows/test-as-submodule.yml
@@ -60,9 +60,11 @@ jobs:
                       https://api.github.com/repos/bluebrain/coreneuron/pulls/$pr_number \
                       | jq -r '.body' | grep "^CI_BRANCHES" \
                       | awk -v FS="(NEURON_BRANCH=|,)" '{print $2}'`
-          if [ ! -z "$nrn_branch" ] then
+          if [ ! -z "$nrn_branch" ]; then
               echo "Changing to neuron branch: $nrn_branch"
+              cd ${GITHUB_WORKSPACE}/nrn
               git checkout $nrn_branch
+              cd -
           fi
 
       - name: Update CoreNEURON submodule

--- a/.github/workflows/test-as-submodule.yml
+++ b/.github/workflows/test-as-submodule.yml
@@ -67,7 +67,7 @@ jobs:
           echo "Using CoreNEURON SHA ${coreneuron_sha}"
           # https://stackoverflow.com/a/33575837
           git update-index --cacheinfo 160000,${coreneuron_sha},external/coreneuron
-          git submodule update --recursive
+          git submodule update --init external/coreneuron
           echo "NEURON status"
           git status
           git log -n 1

--- a/.github/workflows/test-as-submodule.yml
+++ b/.github/workflows/test-as-submodule.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set NEURON branch
         id: vars
         env:
-          GITHUB_PR_BODY: ${{github.event.pull_request.body}}
+          GITHUB_PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           nrn_branch=`echo ${GITHUB_PR_BODY} | grep "^CI_BRANCHES" \
                       | awk -v FS="(NEURON_BRANCH=|,)" '{print $2}'`

--- a/.github/workflows/test-as-submodule.yml
+++ b/.github/workflows/test-as-submodule.yml
@@ -47,25 +47,26 @@ jobs:
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
-        name: Checkout NEURON
-        with:
-          path: nrn
-          repository: neuronsimulator/nrn
-
       - name: Update NEURON branch
+        id: vars
         run: |
           pr_number=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
           nrn_branch=`curl -H "Accept: application/vnd.github.v3+json"  \
                       https://api.github.com/repos/bluebrain/coreneuron/pulls/$pr_number \
                       | jq -r '.body' | grep "^CI_BRANCHES" \
                       | awk -v FS="(NEURON_BRANCH=|,)" '{print $2}'`
-          if [ ! -z "$nrn_branch" ]; then
-              echo "Changing to neuron branch: $nrn_branch"
-              cd ${GITHUB_WORKSPACE}/nrn
-              git checkout $nrn_branch
-              cd -
+          if [ -z "$nrn_branch" ]; then
+              nrn_branch=master
           fi
+          echo "Will use neuron branch: $nrn_branch"
+          echo ::set-output name=neuron_branch::"${nrn_branch}"
+
+      - uses: actions/checkout@v2
+        name: Checkout NEURON
+        with:
+          path: nrn
+          repository: neuronsimulator/nrn
+          ref: ${{ steps.vars.outputs.neuron_branch }}
 
       - name: Update CoreNEURON submodule
         run: |

--- a/.github/workflows/test-as-submodule.yml
+++ b/.github/workflows/test-as-submodule.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           GITHUB_PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          nrn_branch=`echo ${GITHUB_PR_BODY} | grep "^CI_BRANCHES" \
+          nrn_branch=`echo "${GITHUB_PR_BODY}" | grep "^CI_BRANCHES" \
                       | awk -v FS="(NEURON_BRANCH=|,)" '{print $2}'`
           if [ -z "$nrn_branch" ]; then
               nrn_branch=master

--- a/.github/workflows/test-as-submodule.yml
+++ b/.github/workflows/test-as-submodule.yml
@@ -29,6 +29,20 @@ jobs:
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: ${{matrix.cores}}
     steps:
+
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Dump job context
+        env:
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        run: echo "$JOB_CONTEXT"
+      - name: Dump env context
+        env:
+          ENV_CONTEXT: ${{ toJSON(env) }}
+        run: echo "$ENV_CONTEXT"
+
       - name: Install homebrew packages
         if: startsWith(matrix.os, 'macOS')
         run: |
@@ -47,7 +61,7 @@ jobs:
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
 
-      - name: Update NEURON branch
+      - name: Set NEURON branch
         id: vars
         run: |
           pr_number=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')

--- a/.github/workflows/test-as-submodule.yml
+++ b/.github/workflows/test-as-submodule.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install homebrew packages
         if: startsWith(matrix.os, 'macOS')
         run: |
-          brew install bison coreutils flex ninja openmpi jq
+          brew install bison coreutils flex ninja openmpi
           python3 -m pip install --upgrade numpy pytest pytest-cov
           echo /usr/local/opt/flex/bin:/usr/local/opt/bison/bin >> $GITHUB_PATH
           echo "CC=clang" >> $GITHUB_ENV
@@ -44,17 +44,16 @@ jobs:
         run: |
           sudo apt-get install bison cython3 flex libfl-dev libopenmpi-dev \
             ninja-build openmpi-bin python3-dev python3-numpy python3-pytest \
-            python3-pytest-cov jq
+            python3-pytest-cov
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
 
       - name: Set NEURON branch
         id: vars
         env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
+          GITHUB_PR_BODY: ${{github.event.pull_request.body}}
         run: |
-          nrn_branch=`echo $GITHUB_CONTEXT  \
-                      | jq -r '.event .pull_request .body' | grep "^CI_BRANCHES" \
+          nrn_branch=`echo ${GITHUB_PR_BODY} | grep "^CI_BRANCHES" \
                       | awk -v FS="(NEURON_BRANCH=|,)" '{print $2}'`
           if [ -z "$nrn_branch" ]; then
               nrn_branch=master

--- a/.github/workflows/test-as-submodule.yml
+++ b/.github/workflows/test-as-submodule.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install homebrew packages
         if: startsWith(matrix.os, 'macOS')
         run: |
-          brew install bison coreutils flex ninja openmpi
+          brew install bison coreutils flex ninja openmpi jq
           python3 -m pip install --upgrade numpy pytest pytest-cov
           echo /usr/local/opt/flex/bin:/usr/local/opt/bison/bin >> $GITHUB_PATH
           echo "CC=clang" >> $GITHUB_ENV
@@ -43,19 +43,27 @@ jobs:
         run: |
           sudo apt-get install bison cython3 flex libfl-dev libopenmpi-dev \
             ninja-build openmpi-bin python3-dev python3-numpy python3-pytest \
-            python3-pytest-cov
+            python3-pytest-cov jq
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
         name: Checkout NEURON
         with:
-          # TODO: allow configuring a non-default branch of NEURON, ideally
-          #       using the same CI_BRANCHES syntax in a PR body that is used
-          #       by the GitLab CI plans.
           path: nrn
           repository: neuronsimulator/nrn
-          ref: pramodk/coreneuron-update
+
+      - name: Update NEURON branch
+        run: |
+          pr_number=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+          nrn_branch=`curl -H "Accept: application/vnd.github.v3+json"  \
+                      https://api.github.com/repos/bluebrain/coreneuron/pulls/$pr_number \
+                      | jq -r '.body' | grep "^CI_BRANCHES" \
+                      | awk -v FS="(NEURON_BRANCH=|,)" '{print $2}'`
+          if [ ! -z "$nrn_branch" ] then
+              echo "Changing to neuron branch: $nrn_branch"
+              git checkout $nrn_branch
+          fi
 
       - name: Update CoreNEURON submodule
         run: |

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -242,7 +242,10 @@ if(CORENRN_ENABLE_MPI AND CORENRN_ENABLE_MPI_DYNAMIC)
       list(GET NRN_MPI_LIBNAME_LIST ${val} libname)
 
       add_library(core${libname}_lib SHARED ${MPI_LIB_FILES})
-      target_include_directories(core${libname}_lib PUBLIC ${include})
+      target_include_directories(
+        core${libname}_lib
+        PUBLIC ${include}
+        PRIVATE ${CORENEURON_PROJECT_SOURCE_DIR})
 
       # ~~~
       # TODO: somehow mingw requires explicit linking. This needs to be verified


### PR DESCRIPTION
* Add CI for dynamic MPI under NEURON
   - Currently there is no CI that builds neuron+coreneuron with dynamic MPI support
   - This should help to detect errors like below early
       https://dev.azure.com/neuronsimulator/nrn/_build/results?buildId=4649&view=logs
* Add missing include path for dynamic MPI targets
* Cherry-pick improvement from #744 

Fixes # (issue)

Azure CI failure in https://github.com/neuronsimulator/nrn/pull/1580

**How to test this?**

```bash
cmake .. -DCMAKE_INSTALL_PREFIX=`pwd`/install -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF -DPYTHON_EXECUTABLE=`which python3` -DCORENRN_ENABLE_GPU=OFF   -DCORENRN_ENABLE_NMODL=OFF  -DCMAKE_INSTALL_PREFIX=../install -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_TESTS=ON -DNRN_ENABLE_MPI_DYNAMIC=ON
make -j12
```

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=pramodk/coreneuron-update,


### TODO

- [ ] Fix GitHub CI tests due to coreneuron dynamic MPI

Co-authored-by: Olli Lupton <oliver.lupton@epfl.ch>