### PR TITLE
CoreNEURON 1.0.1 Release

### DIFF
--- a/.github/workflows/coreneuron-ci.yml
+++ b/.github/workflows/coreneuron-ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-16.04, macOS-10.15 ]
+        os: [ ubuntu-18.04, macOS-10.15 ]
         config:
           - {cmake_option: "-DCORENRN_ENABLE_MPI=ON", documentation: ON }
           - {cmake_option: "-DCORENRN_ENABLE_MPI=OFF"}
@@ -51,7 +51,7 @@ jobs:
       - name: Install apt packages
         if: startsWith(matrix.os, 'ubuntu')
         run: |
-          sudo apt-get install doxygen bison flex libboost-all-dev libopenmpi-dev openmpi-bin python3-dev python3-pip
+          sudo apt-get install doxygen bison flex libfl-dev libboost-all-dev libopenmpi-dev openmpi-bin python3-dev python3-pip
         shell: bash
 
       - name: Install specific apt packages

--- a/CMake/OpenAccHelper.cmake
+++ b/CMake/OpenAccHelper.cmake
@@ -23,7 +23,7 @@ if(CORENRN_ENABLE_GPU)
   endif()
 
   # various flags for PGI compiler with GPU build
-  if(${CMAKE_C_COMPILER_ID} STREQUAL "PGI")
+  if(${CMAKE_C_COMPILER_ID} STREQUAL "PGI" OR ${CMAKE_C_COMPILER_ID} STREQUAL "NVHPC")
 
     # workaround for old PGI version
     set(PGI_ACC_FLAGS "-acc")


### PR DESCRIPTION
**Description**

Fore CoreNEURON release 1.0.1. Goes with https://github.com/neuronsimulator/nrn/pull/1603

**Use certain branches for the SimulationStack CI**

CI_BRANCHES:NEURON_BRANCH=8.0.1-cherries,
