### PR TITLE
GitLab CI improvements (also testing NEURON C++)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,6 +60,7 @@ simulation_stack:
     SYNAPSETOOL_BRANCH: "${SYNAPSETOOL_BRANCH}"
   trigger:
     project: hpc/sim/blueconfigs
+    branch: olupton/clean-env
     # CoreNEURON CI status depends on the BlueConfigs CI status.
     strategy: depend
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,6 +51,7 @@ simulation_stack:
   variables:
     CORENEURON_BRANCH: "${CI_COMMIT_BRANCH}"
     MODELS_COMMON_BRANCH: "${MODELS_COMMON_BRANCH}"
+    # TODO: for consistency this should default to master if no CI_BRANCHES setting was used.
     NEURON_BRANCH: "${NEURON_BRANCH}"
     PYNEURODAMUS_BRANCH: "${PYNEURODAMUS_BRANCH}"
     REPORTINGLIB_BRANCH: "${REPORTINGLIB_BRANCH}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,10 +9,10 @@ include:
 
 variables:
   NEURON_BRANCH:
-    description: Branch of NEURON to build against CoreNEURON.
+    description: Branch of NEURON to build against CoreNEURON (NEURON_COMMIT and NEURON_TAG also possible)
     value: master
   NMODL_BRANCH:
-    description: Branch of NMODL to build CoreNEURON against.
+    description: Branch of NMODL to build CoreNEURON against (NMODL_COMMIT and NMODL_TAG also possible)
     value: master
 
 # Set up Spack
@@ -50,7 +50,6 @@ simulation_stack:
     SYNAPSETOOL_BRANCH: $SYNAPSETOOL_BRANCH
   trigger:
     project: hpc/sim/blueconfigs
-    branch: olupton/clean-env
     # CoreNEURON CI status depends on the BlueConfigs CI status.
     strategy: depend
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,14 @@ include:
   - project: hpc/gitlab-upload-logs
     file: enable-upload.yml
 
+variables:
+  NEURON_BRANCH:
+    description: Branch of NEURON to build against CoreNEURON.
+    value: master
+  NMODL_BRANCH:
+    description: Branch of NMODL to build CoreNEURON against.
+    value: master
+
 # Set up Spack
 spack_setup:
   extends: .spack_setup_ccache
@@ -27,37 +35,19 @@ spack_setup:
     - sed -i -e 's#\(git\s*=\s\)"https://github.com/BlueBrain/CoreNeuron"#\1"git@bbpgitlab.epfl.ch:hpc/coreneuron.git"#' package.py
     - git diff
     - fi
-    # Translate the GitHub PR specifications, which are things like
-    #   SPACK_PACKAGE_REF_neuron=branch="master"
-    # into the form that the SimulationStack CI understands, which are plain
-    # ${foo}_BRANCH variables that only accept branch names. Current names are
-    # CORENEURON,MODELS_COMMON,NEURON,PYNEURODAMUS,REPORTINGLIB,SPACK,SYNAPSETOOL
-    # where CORENEURON_BRANCH is just ${CI_COMMIT_BRANCH}, but the others might
-    # be set in the GitHub PR description. Save the values of things like
-    # NEURON_BRANCH to spack_clone_variables.env, which is already defined by
-    # the gitlab-pipelines helper and can just be appended to.
-    # TODO: consider allowing these to be overriden when launching the
-    # CoreNEURON pipeline
-    - echo "SPACK_BRANCH=${SPACK_BRANCH}" >> spack_clone_variables.env
-    - for package in MODELS_COMMON NEURON PYNEURODAMUS REPORTINGLIB SYNAPSETOOL; do
-    - PACKAGE_BRANCH=$(sed -n -e "s/^SPACK_PACKAGE_REF_${package,,}=branch=\(['\"]\)\([^\1]\+\)\1/\2/p" spack_clone_variables.env)
-    - echo "${package}_BRANCH=${PACKAGE_BRANCH}" >> spack_clone_variables.env
-    - done
-    - cat spack_clone_variables.env
 
 simulation_stack:
   stage: .pre
   # Take advantage of GitHub PR description parsing in the spack_setup job.
   needs: [spack_setup]
   variables:
-    CORENEURON_BRANCH: "${CI_COMMIT_BRANCH}"
-    MODELS_COMMON_BRANCH: "${MODELS_COMMON_BRANCH}"
-    # TODO: for consistency this should default to master if no CI_BRANCHES setting was used.
-    NEURON_BRANCH: "${NEURON_BRANCH}"
-    PYNEURODAMUS_BRANCH: "${PYNEURODAMUS_BRANCH}"
-    REPORTINGLIB_BRANCH: "${REPORTINGLIB_BRANCH}"
-    SPACK_BRANCH: "${SPACK_BRANCH}"
-    SYNAPSETOOL_BRANCH: "${SYNAPSETOOL_BRANCH}"
+    CORENEURON_BRANCH: $CI_COMMIT_BRANCH
+    MODELS_COMMON_BRANCH: $MODELS_COMMON_BRANCH
+    NEURON_BRANCH: $NEURON_BRANCH
+    PYNEURODAMUS_BRANCH: $PYNEURODAMUS_BRANCH
+    REPORTINGLIB_BRANCH: $REPORTINGLIB_BRANCH
+    SPACK_BRANCH: $SPACK_BRANCH
+    SYNAPSETOOL_BRANCH: $SYNAPSETOOL_BRANCH
   trigger:
     project: hpc/sim/blueconfigs
     branch: olupton/clean-env
@@ -84,7 +74,6 @@ simulation_stack:
   variables:
     bb5_duration: "2:00:00"
     SPACK_PACKAGE: neuron
-    SPACK_PACKAGE_REF: ''
     SPACK_PACKAGE_SPEC: +coreneuron+debug+tests~legacy-unit~rx3d model_tests=channel-benchmark,olfactory,tqperf-heavy
 .gpu_node:
   variables:
@@ -100,7 +89,6 @@ build:nmodl:
   extends: [.build]
   variables:
     SPACK_PACKAGE: nmodl
-    SPACK_PACKAGE_REF: ''
     SPACK_PACKAGE_SPEC: ~legacy-unit
     SPACK_PACKAGE_COMPILER: gcc
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,6 @@ spack_setup:
 
 simulation_stack:
   stage: .pre
-  interruptible: true
   # Take advantage of GitHub PR description parsing in the spack_setup job.
   needs: [spack_setup]
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,5 @@
 include:
   - project: hpc/gitlab-pipelines
-    ref: olupton/a-big-plus
     file:
       - spack-build-components.gitlab-ci.yml
       - github-project-pipelines.gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 include:
   - project: hpc/gitlab-pipelines
+    ref: olupton/a-big-plus
     file:
       - spack-build-components.gitlab-ci.yml
       - github-project-pipelines.gitlab-ci.yml
@@ -46,6 +47,7 @@ spack_setup:
 
 simulation_stack:
   stage: .pre
+  interruptible: true
   # Take advantage of GitHub PR description parsing in the spack_setup job.
   needs: [spack_setup]
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,19 +22,6 @@ spack_setup:
     # Enable fetching GitHub PR descriptions and parsing them to find out what
     # branches to build of other projects.
     PARSE_GITHUB_PR_DESCRIPTIONS: "true"
-  script:
-    - !reference [.spack_setup_ccache, script]
-    # This allows us to use the CoreNEURON repository in regression tests of
-    # the gitlab-pipelines repositories. The regression test pipeline triggers
-    # *this* pipeline as a child, having pushed a modified branch to the GitLab
-    # mirror of the CoreNEURON repository. We have to update the Spack recipe
-    # to point at the GitLab mirror so the relevant commit (on the modified
-    # branch) can be found.
-    - if [[ "${CI_PIPELINE_SOURCE}" == "pipeline" ]]; then
-    - cd $(spack location -p coreneuron)
-    - sed -i -e 's#\(git\s*=\s\)"https://github.com/BlueBrain/CoreNeuron"#\1"git@bbpgitlab.epfl.ch:hpc/coreneuron.git"#' package.py
-    - git diff
-    - fi
 
 simulation_stack:
   stage: .pre


### PR DESCRIPTION
**Description**
Simplify GitLab CI configuration following upstream changes to `hpc/gitlab-helpers` and https://github.com/BlueBrain/spack/pull/1468.
- it is now more convenient to trigger CoreNEURON's pipeline manually, with `NEURON_BRANCH` and `NMODL_BRANCH` optionally set
- we no longer rely on (the default) `CI_BRANCHES:NEURON_BRANCH=master` to make the SimulationStack child pipeline build `neuron@develop` instead of `neuron`

This PR is also serving as a way of testing the NEURON C++ changes in https://github.com/neuronsimulator/nrn/pull/1597 in the CoreNEURON CI, but that is not relevant to the actual changeset in CoreNEURON.

**Use certain branches for the SimulationStack CI**
CI_BRANCHES:NEURON_BRANCH=olupton/more-c++,SPACK_BRANCH=olupton/test-neuron-c++