### PR TITLE
Fix pdata calculation

### DIFF
--- a/coreneuron/mechanism/eion.cpp
+++ b/coreneuron/mechanism/eion.cpp
@@ -233,7 +233,7 @@ ion_style("name_ion", [c_style, e_style, einit, eadvance, cinit])
  and models.
 */
 
-#define iontype ppd[0] /* how _AMBIGUOUS is to be handled */
+#define iontype ppd[_iml] /* how _AMBIGUOUS is to be handled */
 /*the bitmap is
 03	concentration unused, nrnocCONST, DEP, STATE
 04	initialize concentrations

--- a/coreneuron/mechanism/eion.cpp
+++ b/coreneuron/mechanism/eion.cpp
@@ -265,6 +265,7 @@ void nrn_cur_ion(NrnThread* nt, Memb_list* ml, int type) {
     ppd = ml->pdata;
     // clang-format off
     nrn_pragma_acc(parallel loop present(pd[0:_cntml_padded * 5],
+                                         ppd[0:_cntml_actual],
                                          nrn_ion_global_map[0:nrn_ion_global_map_size]
                                                            [0:ion_global_map_member_size])
                                  if (nt->compute_gpu)
@@ -304,7 +305,7 @@ void nrn_init_ion(NrnThread* nt, Memb_list* ml, int type) {
     // needs to be like this.
     // clang-format off
     nrn_pragma_acc(parallel loop present(pd[0:_cntml_padded * 5],
-                                         ppd[0:1],
+                                         ppd[0:_cntml_actual],
                                          nrn_ion_global_map[0:nrn_ion_global_map_size]
                                                            [0:ion_global_map_member_size])
                                  if (nt->compute_gpu))


### PR DESCRIPTION
**Description**

Different sections might have different `iontype`s as for example in the M1 NetPyNE simulation. Instead of reading only the `iontype` of the first section of each mechanism, calculate each one based on its `iontype`.

**How to test this?**

I was able to reproduce this issue only with the M1 simulation and when setting `cfg.singleCellPops = 1`.
This option `Creates pops with 1 single cell (to debug)` according to the documentation.
Using this branch I managed to get the same spikes between CoreNEURON and NEURON on CPU with `debug` builds enabled and using direct mode.

With this PR M1 and S1 simulations (reduced versions with `cfg.singleCellPops = 1`) generate the same spikes in CPU with debug and release builds on offline and online CoreNEURON execution.

Related neuron part https://github.com/neuronsimulator/nrn/blob/9624c96e17b6b676245582f66f83c64f11876368/src/nrnoc/eion.cpp#L356

M1 and S1 results validation from the large sims with the full circuit are WIP.