### PR TITLE
CORENEURON_COMMIT: ${CI_COMMIT_SHA}

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,7 @@ variables:
 spack_setup:
   extends: .spack_setup_ccache
   variables:
+    CORENEURON_COMMIT: ${CI_COMMIT_SHA}
     # Enable fetching GitHub PR descriptions and parsing them to find out what
     # branches to build of other projects.
     PARSE_GITHUB_PR_DESCRIPTIONS: "true"


### PR DESCRIPTION
**Description**
This is a backwards-compatible change that should keep things working smoothly when we merge a planned change to the `gitlab-pipelines` helper. It simply makes it explicit that the commit on which the CoreNEURON pipeline is running is also the commit of CoreNEURON that should be built by Spack. This is already the (implicit) default.

**Use certain branches for the SimulationStack CI**
CI_BRANCHES:NEURON_BRANCH=master,