### PR TITLE
Fix test-as-submodule CI.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,15 @@ nrnivmodl mod
  - Version: [e.g. master branch]
  - Backend: [e.g. CPU]
 
-**Use certain branches for the SimulationStack CI**
-
-CI_BRANCHES:NEURON_BRANCH=master,
+**Use certain branches in CI pipelines.**
+<!-- You can steer which versions of CoreNEURON dependencies will be used in
+     the various CI pipelines (GitLab, test-as-submodule) here. Expressions are
+     of the form PROJ_REF=VALUE, where PROJ is the relevant Spack package name,
+     transformed to upper case and with hyphens replaced with underscores.
+     REF may be BRANCH, COMMIT or TAG, with exceptions:
+      - SPACK_COMMIT and SPACK_TAG are invalid (hpc/gitlab-pipelines limitation)
+      - NEURON_COMMIT and NEURON_TAG are invalid (test-as-submodule limitation)
+     These values for NEURON, nmodl and Spack are the defaults and are given
+     for illustrative purposes; they can safely be removed.
+-->
+CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop

--- a/.github/workflows/test-as-submodule.yml
+++ b/.github/workflows/test-as-submodule.yml
@@ -55,8 +55,8 @@ jobs:
           GITHUB_PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           nrn_branch=$(echo "${GITHUB_PR_BODY}" | grep "^CI_BRANCHES" \
-                      | awk -v FS="NEURON_BRANCH=" '{print $2}' \
-                      | awk -v FS="," '{print $1}')
+                      | awk -F '[:,]{1}NEURON_BRANCH=' '{print $2}' \
+                      | awk -F ',' '{print $1}')
           if [ -z "$nrn_branch" ]; then
               nrn_branch=master
           fi

--- a/.github/workflows/test-as-submodule.yml
+++ b/.github/workflows/test-as-submodule.yml
@@ -54,9 +54,9 @@ jobs:
         env:
           GITHUB_PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          nrn_branch=`echo "${GITHUB_PR_BODY}" | grep "^CI_BRANCHES" \
-                      | awk -v FS="NEURON_BRANCH=" '{print $2}'` \
-                      | awk -v FS="," '{print $1}'
+          nrn_branch=$(echo "${GITHUB_PR_BODY}" | grep "^CI_BRANCHES" \
+                      | awk -v FS="NEURON_BRANCH=" '{print $2}' \
+                      | awk -v FS="," '{print $1}')
           if [ -z "$nrn_branch" ]; then
               nrn_branch=master
           fi


### PR DESCRIPTION
**Description**
Previously the closing ``` ` ``` was in the wrong place, meaning that `nrn_branch` was not set correctly and CoreNEURON PRs were always tested against `master` of NEURON.

Note that in bash:
```console
$ foo=bar | echo hello
hello
$ echo $foo

$
```

Also tweak the first `awk` command so that it would not match `CI_BRANCHES:FOONEURON_BRANCH=bar`.

This should fix a failure in https://github.com/BlueBrain/CoreNeuron/pull/772.

Also update the GitHub PR template to include a comment describing usage of the `CI_BRANCHES` keyword.

**Use certain branches for the SimulationStack CI**
CI_BRANCHES:NEURON_BRANCH=master