### PR TITLE
Default/Minimal coreneuron should be always available in NEURON (cpu)

### DIFF
--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -326,13 +326,25 @@ set_target_properties(
 # =============================================================================
 set(modfile_directory "${CORENEURON_PROJECT_SOURCE_DIR}/tests/integration/ring_gap/mod")
 file(GLOB modfiles "${modfile_directory}/*.mod")
+
+if(CORENRN_ENABLE_SHARED)
+  set(corenrn_mech_library
+      "${CMAKE_BINARY_DIR}/bin/${CMAKE_SYSTEM_PROCESSOR}/libcorenrnmech${CMAKE_SHARED_LIBRARY_SUFFIX}"
+      CACHE INTERNAL "coreneuron mechanism library")
+else()
+  set(corenrn_mech_library
+      "${CMAKE_BINARY_DIR}/bin/${CMAKE_SYSTEM_PROCESSOR}/libcorenrnmech${CMAKE_STATIC_LIBRARY_SUFFIX}"
+      CACHE INTERNAL "coreneuron mechanism library")
+endif()
+
 set(output_binaries "${CMAKE_BINARY_DIR}/bin/${CMAKE_SYSTEM_PROCESSOR}/special-core"
-                    "${CMAKE_BINARY_DIR}/bin/${CMAKE_SYSTEM_PROCESSOR}/libcorenrnmech.a")
+                    "${corenrn_mech_library}")
+
 add_custom_command(
   OUTPUT ${output_binaries}
   DEPENDS scopmath coreneuron ${NMODL_TARGET_TO_DEPEND} ${modfiles} ${CORENEURON_BUILTIN_MODFILES}
-  COMMAND ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core -b STATIC -m ${CORENRN_MOD2CPP_BINARY} -p 1
-          "${modfile_directory}"
+  COMMAND ${CMAKE_BINARY_DIR}/bin/nrnivmodl-core -b ${COMPILE_LIBRARY_TYPE} -m
+          ${CORENRN_MOD2CPP_BINARY} -p 1 "${modfile_directory}"
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   COMMENT "Running nrnivmodl-core with halfgap.mod")
 add_custom_target(nrniv-core ALL DEPENDS ${output_binaries})
@@ -415,6 +427,9 @@ install(
   DESTINATION bin
   RENAME nrniv-core)
 install(FILES apps/coreneuron.cpp DESTINATION share/coreneuron)
+
+# install mechanism library
+install(FILES ${corenrn_mech_library} DESTINATION lib)
 
 # install random123 and nmodl headers
 install(DIRECTORY ${CMAKE_BINARY_DIR}/include/ DESTINATION include)

--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -182,6 +182,11 @@ ORIGIN_RPATH := $(if $(filter Darwin,$(OS_NAME)),@loader_path,$$ORIGIN)
 SONAME_OPTION := -Wl,$(if $(filter Darwin,$(OS_NAME)),-install_name${COMMA_OP}@rpath/,-soname${COMMA_OP})$(notdir ${COREMECH_LIB_PATH})
 LIB_RPATH = $(if $(DESTDIR),$(DESTDIR)/lib,$(ORIGIN_RPATH))
 
+# When special-core is installed, it needs to find library in the
+# lib folder of install prefix. We use relative path in order it
+# to be portable when files are moved (e.g. python wheel)
+INSTALL_LIB_RPATH = $(ORIGIN_RPATH)/../lib
+
 # All objects used during build
 ALL_OBJS = $(MOD_FUNC_OBJ) $(DIMPLIC_OBJ) $(mod_cpp_objs) $(mod_ispc_objs)
 
@@ -214,7 +219,7 @@ $(SPECIAL_EXE): coremech_lib_target
 	$(CXX_LINK_EXE_CMD) -o $(SPECIAL_EXE) $(CORENRN_SHARE_CORENRN_DIR)/coreneuron.cpp \
 	  -I$(CORENRN_INC_DIR) $(INCFLAGS) \
 	  -L$(OUTPUT_DIR) -l$(COREMECH_LIB_NAME) $(CORENRNLIB_FLAGS) $(LDFLAGS) \
-	  -Wl,-rpath,'$(LIB_RPATH)' -Wl,-rpath,$(CORENRN_LIB_DIR)
+	  -Wl,-rpath,'$(LIB_RPATH)' -Wl,-rpath,$(CORENRN_LIB_DIR) -Wl,-rpath,'$(INSTALL_LIB_RPATH)'
 
 coremech_lib_target: $(corenrnmech_lib_target)
 	rm -rf $(OUTPUT_DIR)/.libs/lib$(COREMECH_LIB_NAME)$(LIB_SUFFIX); \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,11 +14,6 @@ endif()
 
 set(CMAKE_BUILD_RPATH ${CMAKE_BINARY_DIR}/bin/${CMAKE_HOST_SYSTEM_PROCESSOR})
 
-# mechanism library path
-set(corenrn_mech_lib
-    "${CMAKE_BINARY_DIR}/bin/${CMAKE_HOST_SYSTEM_PROCESSOR}/libcorenrnmech${CMAKE_STATIC_LIBRARY_SUFFIX}"
-)
-
 set(Boost_NO_BOOST_CMAKE TRUE)
 find_package(Boost 1.41.0 QUIET COMPONENTS filesystem system atomic unit_test_framework)
 

--- a/tests/unit/cmdline_interface/CMakeLists.txt
+++ b/tests/unit/cmdline_interface/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(
   ${MPI_CXX_LIBRARIES}
   ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
   coreneuron
-  ${corenrn_mech_lib}
+  ${corenrn_mech_library}
   ${reportinglib_LIBRARY}
   ${sonatareport_LIBRARY})
 target_include_directories(cmd_interface_test_bin SYSTEM

--- a/tests/unit/interleave_info/CMakeLists.txt
+++ b/tests/unit/interleave_info/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(
   ${MPI_CXX_LIBRARIES}
   ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
   coreneuron
-  ${corenrn_mech_lib}
+  ${corenrn_mech_library}
   ${reportinglib_LIBRARY}
   ${sonatareport_LIBRARY})
 add_dependencies(interleave_info_bin nrniv-core)

--- a/tests/unit/lfp/CMakeLists.txt
+++ b/tests/unit/lfp/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(
   ${MPI_CXX_LIBRARIES}
   ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
   coreneuron
-  ${corenrn_mech_lib}
+  ${corenrn_mech_library}
   ${reportinglib_LIBRARY}
   ${sonatareport_LIBRARY})
 # Tell CMake *not* to run an explicit device code linker step (which will produce errors); let the

--- a/tests/unit/queueing/CMakeLists.txt
+++ b/tests/unit/queueing/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(
   ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   coreneuron
-  ${corenrn_mech_lib}
+  ${corenrn_mech_library}
   ${reportinglib_LIBRARY}
   ${sonatareport_LIBRARY})
 add_dependencies(queuing_test_bin nrniv-core)


### PR DESCRIPTION
**Description**

* Before this PR, user always had to do `nrnivmodl -coreneuron .``
  to have coreneuron with default mechanisms.
* This was because we were not installing default mechanism library
  libcorenrnmech.so into install dir. Note that this was done in order
  to force user to re-build optimised library from vendor compiler
  like Intel.
* But, for basic demonstration and testing, I think it's always
  helpful to ship default mechanism library as a fallback. The
  library <arch>/libcorenrnmech.so built by user will be preferred anyway.
* Update nmodl to latest master


**How to test this?**


If you install neuron+coreneuron as:

```console
cmake .. -DCMAKE_INSTALL_PREFIX=`pwd`/install -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF  -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_TESTS=ON -DNRN_CMAKE_FORMAT=ON
make -j
make install
```

Now we can run basic coreneuron test without `nrnivmodl -coreneuron .`:

```console
export PYTHONPATH=~/some-dir/install/lib/python:$PYTHONPATH
export PATH=~/some-dir/install/bin:$PATH
python3 ../test/coreneuron/test_psolve.py
```

**Test System**
 - OS: MacOS
 - Compiler: Clang

Hope this works elsewhere!

**Use certain branches in CI pipelines.**
<!-- You can steer which versions of CoreNEURON dependencies will be used in
     the various CI pipelines (GitLab, test-as-submodule) here. Expressions are
     of the form PROJ_REF=VALUE, where PROJ is the relevant Spack package name,
     transformed to upper case and with hyphens replaced with underscores.
     REF may be BRANCH, COMMIT or TAG, with exceptions:
      - SPACK_COMMIT and SPACK_TAG are invalid (hpc/gitlab-pipelines limitation)
      - NEURON_COMMIT and NEURON_TAG are invalid (test-as-submodule limitation)
     These values for NEURON, nmodl and Spack are the defaults and are given
     for illustrative purposes; they can safely be removed.
-->
CI_BRANCHES:NEURON_BRANCH=pramodk/corenrn-mechlib-install,