### PR TITLE
Allow multiple BEFORE/AFTER blocks of same type in a mod file.

### DIFF
--- a/coreneuron/io/phase2.cpp
+++ b/coreneuron/io/phase2.cpp
@@ -575,8 +575,8 @@ void Phase2::fill_before_after_lists(NrnThread& nt, const std::vector<Memb_func>
         for (size_t ii = 0; ii < memb_func.size(); ++ii) {
             before_after_map[ii] = nullptr;
         }
-        // First only. In case multiple bam with same mech type.
-        // Will get others, if any, below with bam->next, etc.
+        // Save first before-after block only. In case of multiple before-after blocks with the
+        // same mech type, we will get subsequent ones using linked list below.
         for (auto bam = corenrn.get_bamech()[i]; bam; bam = bam->next) {
             if (!before_after_map[bam->type]) {
                 before_after_map[bam->type] = bam;

--- a/coreneuron/io/phase2.cpp
+++ b/coreneuron/io/phase2.cpp
@@ -582,8 +582,7 @@ void Phase2::fill_before_after_lists(NrnThread& nt, const std::vector<Memb_func>
                 before_after_map[bam->type] = bam;
             }
         }
-        /* Unnecessary, but keep in order wrt tml */
-        // But necessary to keep in order wrt multiple BAMech with same mech type
+        // necessary to keep in order wrt multiple BAMech with same mech type
         NrnThreadBAList** ptbl = nt.tbl + i;
         for (auto tml = nt.tml; tml; tml = tml->next) {
             if (before_after_map[tml->index]) {

--- a/coreneuron/io/phase2.cpp
+++ b/coreneuron/io/phase2.cpp
@@ -575,19 +575,29 @@ void Phase2::fill_before_after_lists(NrnThread& nt, const std::vector<Memb_func>
         for (size_t ii = 0; ii < memb_func.size(); ++ii) {
             before_after_map[ii] = nullptr;
         }
+        // First only. In case multiple bam with same mech type.
+        // Will get others, if any, below with bam->next, etc.
         for (auto bam = corenrn.get_bamech()[i]; bam; bam = bam->next) {
-            before_after_map[bam->type] = bam;
+            if (!before_after_map[bam->type]) {
+                before_after_map[bam->type] = bam;
+            }
         }
-        /* unnecessary but keep in order anyway */
+        /* Unnecessary, but keep in order wrt tml */
+        // But necessary to keep in order wrt multiple BAMech with same mech type
         NrnThreadBAList** ptbl = nt.tbl + i;
         for (auto tml = nt.tml; tml; tml = tml->next) {
             if (before_after_map[tml->index]) {
-                auto tbl = (NrnThreadBAList*) emalloc(sizeof(NrnThreadBAList));
-                tbl->next = nullptr;
-                tbl->bam = before_after_map[tml->index];
-                tbl->ml = tml->ml;
-                *ptbl = tbl;
-                ptbl = &(tbl->next);
+                int mtype = tml->index;
+                Memb_list* ml = tml->ml;
+                for (auto bam = before_after_map[mtype]; bam && bam->type == mtype;
+                     bam = bam->next) {
+                    auto tbl = (NrnThreadBAList*) emalloc(sizeof(NrnThreadBAList));
+                    *ptbl = tbl;
+                    tbl->next = nullptr;
+                    tbl->bam = bam;
+                    tbl->ml = tml->ml;
+                    ptbl = &(tbl->next);
+                }
             }
         }
     }

--- a/coreneuron/mechanism/register_mech.cpp
+++ b/coreneuron/mechanism/register_mech.cpp
@@ -391,8 +391,16 @@ void hoc_reg_ba(int mt, mod_f_t f, int type) {
     auto bam = (BAMech*) emalloc(sizeof(BAMech));
     bam->f = f;
     bam->type = mt;
-    bam->next = corenrn.get_bamech()[type];
-    corenrn.get_bamech()[type] = bam;
+    bam->next = nullptr;
+    // keep in call order
+    if (!corenrn.get_bamech()[type]) {
+        corenrn.get_bamech()[type] = bam;
+    } else {
+        BAMech* last;
+        for (last = corenrn.get_bamech()[type]; last->next; last = last->next) {
+        }
+        last->next = bam;
+    }
 }
 
 void _nrn_thread_reg0(int i, void (*f)(ThreadDatum*)) {


### PR DESCRIPTION
**Description**

Same extension as neuronsimulator/nrn#1722

**How to test this?**

Tested on NEURON side with

```bash
cmake ... -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_TESTS=ON
make
ctest -R coreneuron_modtests::test_pointer_py_cpu
```

**Use certain branches in CI pipelines.**

CI_BRANCHES:NEURON_BRANCH=hines/bamult,
