### PR TITLE
Fix clang warnings.

### DIFF
--- a/coreneuron/io/nrn2core_data_init.cpp
+++ b/coreneuron/io/nrn2core_data_init.cpp
@@ -1,6 +1,6 @@
 /*
 # =============================================================================
-# Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
+# Copyright (c) 2016 - 2022 Blue Brain Project/EPFL
 #
 # See top-level LICENSE file for details.
 # =============================================================================.
@@ -135,16 +135,14 @@ NrnCoreTransferEvents* (*nrn2core_transfer_tqueue_)(int tid);
 static std::unordered_map<int, int> type2movable;
 static void setup_type2semantics() {
     if (type2movable.empty()) {
-        for (auto& mf: corenrn.get_memb_funcs()) {
-            size_t n_memb_func = (int) (corenrn.get_memb_funcs().size());
-            for (int type = 0; type < n_memb_func; ++type) {
-                int* ds = corenrn.get_memb_func((size_t) type).dparam_semantics;
-                if (ds) {
-                    int dparam_size = corenrn.get_prop_dparam_size()[type];
-                    for (int psz = 0; psz < dparam_size; ++psz) {
-                        if (ds[psz] == -4) {  // netsend semantics
-                            type2movable[type] = psz;
-                        }
+        std::size_t const n_memb_func{corenrn.get_memb_funcs().size()};
+        for (std::size_t type = 0; type < n_memb_func; ++type) {
+            int* ds{corenrn.get_memb_func(type).dparam_semantics};
+            if (ds) {
+                int dparam_size = corenrn.get_prop_dparam_size()[type];
+                for (int psz = 0; psz < dparam_size; ++psz) {
+                    if (ds[psz] == -4) {  // netsend semantics
+                        type2movable[type] = psz;
                     }
                 }
             }
@@ -154,9 +152,7 @@ static void setup_type2semantics() {
 
 /** Copy each thread's queue from NEURON **/
 static void nrn2core_tqueue() {
-    if (type2movable.empty()) {
-        setup_type2semantics();  // need type2movable for SelfEvent.
-    }
+    setup_type2semantics();                        // need type2movable for SelfEvent.
     for (int tid = 0; tid < nrn_nthread; ++tid) {  // should be parallel
         NrnCoreTransferEvents* ncte = (*nrn2core_transfer_tqueue_)(tid);
         if (ncte) {
@@ -336,7 +332,6 @@ void watch_activate_clear() {
                 // zero all the WATCH slots.
                 Memb_list* ml = tml->ml;
                 int type = tml->index;
-                int* semantics = corenrn.get_memb_func(type).dparam_semantics;
                 int dparam_size = corenrn.get_prop_dparam_size()[type];
                 // which slots are WATCH
                 int first, last;

--- a/coreneuron/io/nrn_checkpoint.hpp
+++ b/coreneuron/io/nrn_checkpoint.hpp
@@ -1,6 +1,6 @@
 /*
 # =============================================================================
-# Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
+# Copyright (c) 2016 - 2022 Blue Brain Project/EPFL
 #
 # See top-level LICENSE file for details.
 # =============================================================================.
@@ -11,7 +11,7 @@
 #include "coreneuron/io/phase2.hpp"
 
 namespace coreneuron {
-class NrnThread;
+struct NrnThread;
 class FileHandler;
 
 class CheckPoints {

--- a/coreneuron/io/nrn_setup.hpp
+++ b/coreneuron/io/nrn_setup.hpp
@@ -1,6 +1,6 @@
 /*
 # =============================================================================
-# Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
+# Copyright (c) 2016 - 2022 Blue Brain Project/EPFL
 #
 # See top-level LICENSE file for details.
 # =============================================================================.
@@ -21,7 +21,7 @@ void read_phase1(NrnThread& nt, UserParams& userParams);
 void read_phase2(NrnThread& nt, UserParams& userParams);
 void read_phase3(NrnThread& nt, UserParams& userParams);
 void read_phasegap(NrnThread& nt, UserParams& userParams);
-static void setup_ThreadData(NrnThread& nt);
+void setup_ThreadData(NrnThread& nt);
 
 void nrn_setup(const char* filesdat,
                bool is_mapping_needed,

--- a/coreneuron/io/phase2.cpp
+++ b/coreneuron/io/phase2.cpp
@@ -1,6 +1,6 @@
 /*
 # =============================================================================
-# Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
+# Copyright (c) 2016 - 2022 Blue Brain Project/EPFL
 #
 # See top-level LICENSE file for details.
 # =============================================================================
@@ -587,7 +587,6 @@ void Phase2::fill_before_after_lists(NrnThread& nt, const std::vector<Memb_func>
         for (auto tml = nt.tml; tml; tml = tml->next) {
             if (before_after_map[tml->index]) {
                 int mtype = tml->index;
-                Memb_list* ml = tml->ml;
                 for (auto bam = before_after_map[mtype]; bam && bam->type == mtype;
                      bam = bam->next) {
                     auto tbl = (NrnThreadBAList*) emalloc(sizeof(NrnThreadBAList));
@@ -692,7 +691,6 @@ void Phase2::pdata_relocation(const NrnThread& nt, const std::vector<Memb_func>&
                 size_t iptype = 0;
                 for (int iml = 0; iml < cnt; ++iml) {
                     for (int i = 0; i < szdp; ++i) {
-                        int s = semantics[i];
                         if (semantics[i] == -5) {  // POINTER
                             int* pd = pdata + nrn_i_layout(iml, cnt, i, szdp, layout);
                             int ix = *pd;  // relative to elem0

--- a/coreneuron/io/phase2.hpp
+++ b/coreneuron/io/phase2.hpp
@@ -1,6 +1,6 @@
 /*
 # =============================================================================
-# Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
+# Copyright (c) 2016 - 2022 Blue Brain Project/EPFL
 #
 # See top-level LICENSE file for details.
 # =============================================================================
@@ -19,7 +19,7 @@ struct NrnThread;
 struct NrnThreadMembList;
 struct Memb_func;
 struct Memb_list;
-class NrnThreadChkpnt;
+struct NrnThreadChkpnt;
 
 class Phase2 {
   public:

--- a/coreneuron/io/reports/nrnreport.cpp
+++ b/coreneuron/io/reports/nrnreport.cpp
@@ -1,6 +1,6 @@
 /*
 # =============================================================================
-# Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
+# Copyright (c) 2016 - 2022 Blue Brain Project/EPFL
 #
 # See top-level LICENSE file for details.
 # =============================================================================
@@ -52,6 +52,7 @@ void nrn_flush_reports(double t) {
  */
 void setup_report_engine(double dt_report, double mindelay) {
     int min_steps_to_record = static_cast<int>(std::round(mindelay / dt_report));
+    static_cast<void>(min_steps_to_record);
 #ifdef ENABLE_BIN_REPORTS
     records_set_min_steps_to_record(min_steps_to_record);
     records_setup_communicator();

--- a/coreneuron/network/multisend.hpp
+++ b/coreneuron/network/multisend.hpp
@@ -1,6 +1,6 @@
 /*
 # =============================================================================
-# Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
+# Copyright (c) 2016 - 2022 Blue Brain Project/EPFL
 #
 # See top-level LICENSE file for details.
 # =============================================================================
@@ -15,7 +15,7 @@ extern int n_multisend_interval;
 extern bool use_phase2_;
 
 class PreSyn;
-class NrnThread;
+struct NrnThread;
 
 void nrn_multisend_send(PreSyn*, double t, NrnThread*);
 void nrn_multisend_receive(NrnThread*);  // must be thread 0

--- a/coreneuron/network/partrans.cpp
+++ b/coreneuron/network/partrans.cpp
@@ -1,6 +1,6 @@
 /*
 # =============================================================================
-# Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
+# Copyright (c) 2016 - 2022 Blue Brain Project/EPFL
 #
 # See top-level LICENSE file for details.
 # =============================================================================
@@ -82,6 +82,7 @@ void nrnmpi_v_transfer() {
             outsrc_buf_[outsrc_indices[i]] = src_gather[src_gather_indices[i]];
         }
     }
+    static_cast<void>(compute_gpu);
 
     // transfer
     int n_insrc_buf = insrcdspl_[nrnmpi_numprocs];
@@ -133,6 +134,7 @@ void nrn_partrans::copy_gap_indices_to_device() {
     // Ensure index vectors, src_gather, and insrc_buf_ are on the gpu.
     if (insrcdspl_) {
         int n_insrc_buf = insrcdspl_[nrnmpi_numprocs];
+        static_cast<void>(n_insrc_buf);
         nrn_pragma_acc(enter data create(insrc_buf_[:n_insrc_buf]))
         // clang-format off
         nrn_pragma_omp(target enter data map(alloc: insrc_buf_[:n_insrc_buf]))
@@ -151,6 +153,8 @@ void nrn_partrans::copy_gap_indices_to_device() {
 
             size_t n_src_gather = ttd.src_gather.size();
             const double* src_gather = ttd.src_gather.data();
+            static_cast<void>(n_src_gather);
+            static_cast<void>(src_gather);
             nrn_pragma_acc(enter data create(src_gather[:n_src_gather]))
             nrn_pragma_omp(target enter data map(alloc: src_gather[:n_src_gather]))
         }

--- a/coreneuron/permute/cellorder1.cpp
+++ b/coreneuron/permute/cellorder1.cpp
@@ -1,6 +1,6 @@
 /*
 # =============================================================================
-# Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
+# Copyright (c) 2016 - 2022 Blue Brain Project/EPFL
 #
 # See top-level LICENSE file for details.
 # =============================================================================
@@ -100,23 +100,6 @@ using TNI = std::pair<TNode*, int>;
 using HashCnt = std::map<size_t, std::pair<TNode*, int>>;
 using TNIVec = std::vector<TNI>;
 
-static char* stree(TNode* nd) {
-    char s[1000];
-
-    if (nd->treesize > 100) {
-        return strdup("");
-    }
-    s[0] = '(';
-    s[1] = '\0';
-    for (const auto& child: nd->children) {  // need sorted by child hash
-        char* sr = stree(child);
-        strcat(s, sr);
-        free(sr);
-    }
-    strcat(s, ")");
-    return strdup(s);
-}
-
 /*
 assess the quality of the ordering. The measure is the size of a contiguous
 list of nodes whose parents have the same order. How many contiguous lists
@@ -209,6 +192,8 @@ static void quality(VecTNode& nodevec, size_t max = 32) {
             }
         }
     }
+    static_cast<void>(nrace1);
+    static_cast<void>(nrace2);
 #if CORENRN_DEBUG
     printf("nrace = %ld (parent in same group of %ld nodes)\n", nrace1, max);
     printf("nrace = %ld (parent used more than once by same group of %ld nodes)\n", nrace2, max);
@@ -375,6 +360,7 @@ int* node_order(int ncell,
             ntopol += 1;
         }
     }
+    static_cast<void>(ntopol);
 #ifdef DEBUG
     printf("%d distinct tree topologies\n", ntopol);
 #endif

--- a/coreneuron/sim/fadvance_core.cpp
+++ b/coreneuron/sim/fadvance_core.cpp
@@ -1,6 +1,6 @@
 /*
 # =============================================================================
-# Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
+# Copyright (c) 2016 - 2022 Blue Brain Project/EPFL
 #
 # See top-level LICENSE file for details.
 # =============================================================================.
@@ -315,6 +315,7 @@ void nrncore2nrn_send_values(NrnThread* nth) {
             // https://github.com/BlueBrain/CoreNeuron/issues/611
             for (int i = 0; i < tr->n_trajec; ++i) {
                 double* gather_i = tr->gather[i];
+                static_cast<void>(gather_i);
                 nrn_pragma_acc(update self(gather_i [0:1]) if (nth->compute_gpu)
                                    async(nth->stream_id))
                 nrn_pragma_omp(target update from(gather_i [0:1]) if (nth->compute_gpu))

--- a/coreneuron/utils/ivocvect.hpp
+++ b/coreneuron/utils/ivocvect.hpp
@@ -1,6 +1,6 @@
 /*
 # =============================================================================
-# Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
+# Copyright (c) 2016 - 2022 Blue Brain Project/EPFL
 #
 # See top-level LICENSE file for details.
 # =============================================================================.
@@ -31,8 +31,8 @@ class fixed_vector {
     fixed_vector(const fixed_vector& vec) = delete;
     fixed_vector& operator=(const fixed_vector& vec) = delete;
     fixed_vector(fixed_vector&& vec)
-        : data_(nullptr)
-        , n_(vec.n_) {
+        : n_{vec.n_}
+        , data_{nullptr} {
         std::swap(data_, vec.data_);
     }
     fixed_vector& operator=(fixed_vector&& vec) {

--- a/coreneuron/utils/randoms/nrnran123.cu
+++ b/coreneuron/utils/randoms/nrnran123.cu
@@ -201,7 +201,7 @@ CORENRN_HOST_DEVICE void nrnran123_getids3(nrnran123_State* s,
 CORENRN_HOST_DEVICE uint32_t nrnran123_ipick(nrnran123_State* s) {
     uint32_t rval;
     char which = s->which_;
-    rval = s->r.v[which++];
+    rval = s->r.v[int{which++}];
     if (which > 3) {
         which = 0;
         s->c.v[0]++;

--- a/coreneuron/utils/utils.cpp
+++ b/coreneuron/utils/utils.cpp
@@ -1,17 +1,22 @@
+/*
+# =============================================================================
+# Copyright (c) 2021-22 Blue Brain Project/EPFL
+#
+# See top-level LICENSE file for details.
+# =============================================================================.
+*/
 #include <sys/time.h>
 #include "utils.hpp"
 #include "coreneuron/apps/corenrn_parameters.hpp"
 
 namespace coreneuron {
-void nrn_abort(int errcode) {
+[[noreturn]] void nrn_abort(int errcode) {
 #if NRNMPI
     if (corenrn_param.mpi_enable && nrnmpi_initialized()) {
         nrnmpi_abort(errcode);
-    } else
-#endif
-    {
-        abort();
     }
+#endif
+    std::abort();
 }
 
 double nrn_wtime() {

--- a/coreneuron/utils/utils.hpp
+++ b/coreneuron/utils/utils.hpp
@@ -1,6 +1,6 @@
 /*
 # =============================================================================
-# Copyright (c) 2021 Blue Brain Project/EPFL
+# Copyright (c) 2021-22 Blue Brain Project/EPFL
 #
 # See top-level LICENSE file for details.
 # =============================================================================.
@@ -13,7 +13,7 @@
 #include "coreneuron/mpi/core/nrnmpi.hpp"
 
 namespace coreneuron {
-extern void nrn_abort(int errcode);
+[[noreturn]] void nrn_abort(int errcode);
 template <typename... Args>
 void nrn_fatal_error(const char* msg, Args&&... args) {
     if (nrnmpi_myid == 0) {


### PR DESCRIPTION
**Description**
Fix warnings in non-generated code with `-Wall` and AppleClang 13.1.6.

**Use certain branches in CI pipelines.**
<!-- You can steer which versions of CoreNEURON dependencies will be used in
     the various CI pipelines (GitLab, test-as-submodule) here. Expressions are
     of the form PROJ_REF=VALUE, where PROJ is the relevant Spack package name,
     transformed to upper case and with hyphens replaced with underscores.
     REF may be BRANCH, COMMIT or TAG, with exceptions:
      - SPACK_COMMIT and SPACK_TAG are invalid (hpc/gitlab-pipelines limitation)
      - NEURON_COMMIT and NEURON_TAG are invalid (test-as-submodule limitation)
     These values for NEURON, nmodl and Spack are the defaults and are given
     for illustrative purposes; they can safely be removed.
-->
CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop