### PR TITLE
vector_new1: make return type match NEURON.

### DIFF
--- a/coreneuron/utils/ivocvect.cpp
+++ b/coreneuron/utils/ivocvect.cpp
@@ -23,8 +23,8 @@ double* vector_vec(IvocVect* v) {
 /*
  * Retro-compatibility implementations
  */
-void* vector_new1(int n) {
-    return (void*) (new IvocVect(n));
+IvocVect* vector_new1(int n) {
+    return new IvocVect(n);
 }
 
 nrn_pragma_acc(routine seq)

--- a/coreneuron/utils/ivocvect.hpp
+++ b/coreneuron/utils/ivocvect.hpp
@@ -76,7 +76,7 @@ extern int vector_capacity(IvocVect* v);
 extern double* vector_vec(IvocVect* v);
 
 // retro-compatibility API
-extern void* vector_new1(int n);
+extern IvocVect* vector_new1(int n);
 nrn_pragma_acc(routine seq)
 extern int vector_capacity(void* v);
 nrn_pragma_acc(routine seq)


### PR DESCRIPTION
**Description**
In NEURON the return type is `IvocVect*`:
https://github.com/neuronsimulator/nrn/blob/331e75096ea984d2945ba675b44d969470fbfb1b/src/oc/oc_ansi.h#L191

This helps us to prepare for https://github.com/neuronsimulator/nrn/pull/1597.

**Use certain branches in CI pipelines.**
<!-- You can steer which versions of CoreNEURON dependencies will be used in
     the various CI pipelines (GitLab, test-as-submodule) here. Expressions are
     of the form PROJ_REF=VALUE, where PROJ is the relevant Spack package name,
     transformed to upper case and with hyphens replaced with underscores.
     REF may be BRANCH, COMMIT or TAG, with exceptions:
      - SPACK_COMMIT and SPACK_TAG are invalid (hpc/gitlab-pipelines limitation)
      - NEURON_COMMIT and NEURON_TAG are invalid (test-as-submodule limitation)
     These values for NEURON, nmodl and Spack are the defaults and are given
     for illustrative purposes; they can safely be removed.
-->
CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop