### PR TITLE
Avoid perl path from build machine appearing in wheel / binary distributions

### DIFF
--- a/extra/nrnivmodl-core.in
+++ b/extra/nrnivmodl-core.in
@@ -19,7 +19,15 @@ APP_NAME=$(basename $0)
 
 # directory and parent directory of this script
 PARENT_DIR="$(dirname $BASH_SOURCE)/.."
-ROOT_DIR=$(@PERL_EXECUTABLE@ -e "use Cwd 'abs_path'; print abs_path('$PARENT_DIR')")
+
+# prefer perl exe set by neuron wrappers in case of wheel
+PERL_EXE=${CORENRN_PERLEXE:-@PERL_EXECUTABLE@}
+# in case of mac installer, wrapper is not used and hence
+# check if binary exist. otherwise, just rely on perl being
+# in default $PATH
+if [ ! -f "${PERL_EXE}" ]; then PERL_EXE=$(which perl); fi
+
+ROOT_DIR=$(${PERL_EXE} -e "use Cwd 'abs_path'; print abs_path('$PARENT_DIR')")
 
 # default arguments : number of parallel builds and default mod file path
 PARALLEL_BUILDS=4


### PR DESCRIPTION
In case of wheel, neuron wrapper scripts will set `CORENRN_PERLEXE` variable pointing to perl binary
   to use. Prefer that over `PERL_EXECUTABLE` found by CMake

Fixes #799

- [x] Check wheel build by upstream neuron PR https://github.com/neuronsimulator/nrn/pull/1779

CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop
