### PR TITLE
Check variable return by get_target_property before it's usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,23 +473,25 @@ add_subdirectory(coreneuron)
 
 if(CORENRN_ENABLE_GPU)
   get_target_property(CORENRN_LINK_LIBRARIES coreneuron INTERFACE_LINK_LIBRARIES)
-  foreach(LIB ${CORENRN_LINK_LIBRARIES})
-    get_filename_component(dir_path ${LIB} DIRECTORY)
-    if(TARGET ${LIB})
-      # See, for example, caliper where the coreneuron target depends on the caliper target (so we
-      # get LIB=caliper in this loop), but -l and -L are already added manually here:
-      # https://github.com/BlueBrain/CoreNeuron/blob/856cea4aa647c8f2b0d5bda6d0fc32144c5942e3/CMakeLists.txt#L411-L412
-      message(
-        NOTICE
-        "Ignoring dependency '${LIB}' of 'coreneuron' and assuming relevant flags have already been added to CORENEURON_LIB_LINK_FLAGS."
-      )
-    elseif(NOT dir_path)
-      # In case LIB is not a target but is just the name of a library, e.g. "dl"
-      set_property(GLOBAL APPEND_STRING PROPERTY CORENEURON_LIB_LINK_FLAGS " -l${LIB}")
-    else()
-      set_property(GLOBAL APPEND_STRING PROPERTY CORENEURON_LIB_LINK_FLAGS " ${LIB}")
-    endif()
-  endforeach()
+  if(CORENRN_LINK_LIBRARIES)
+    foreach(LIB ${CORENRN_LINK_LIBRARIES})
+      get_filename_component(dir_path ${LIB} DIRECTORY)
+      if(TARGET ${LIB})
+        # See, for example, caliper where the coreneuron target depends on the caliper target (so we
+        # get LIB=caliper in this loop), but -l and -L are already added manually here:
+        # https://github.com/BlueBrain/CoreNeuron/blob/856cea4aa647c8f2b0d5bda6d0fc32144c5942e3/CMakeLists.txt#L411-L412
+        message(
+          NOTICE
+          "Ignoring dependency '${LIB}' of 'coreneuron' and assuming relevant flags have already been added to CORENEURON_LIB_LINK_FLAGS."
+        )
+      elseif(NOT dir_path)
+        # In case LIB is not a target but is just the name of a library, e.g. "dl"
+        set_property(GLOBAL APPEND_STRING PROPERTY CORENEURON_LIB_LINK_FLAGS " -l${LIB}")
+      else()
+        set_property(GLOBAL APPEND_STRING PROPERTY CORENEURON_LIB_LINK_FLAGS " ${LIB}")
+      endif()
+    endforeach()
+  endif()
 endif()
 
 include(MakefileBuildOptions)


### PR DESCRIPTION
**Description**

* CMake's `get_target_property` might return `<VAR>-NOTFOUND` and
  hence it should be checked before it's usage
* As mentioned in neuronsimulator/nrn/issues/1788, it can result
  into error like:
```
    => LINKING executable ./special LDFLAGS are:     -lreadline -lncurses
       /users/bp000174/nrn-install/share/nrn/nrnmain.cpp:
       /usr/bin/ld: cannot find -lCORENRN_LINK_LIBRARIES-NOTFOUND
```


**Test System**

- Piz-Daint

CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop
