### PR TITLE
Use matched allocation/deallocation routines.

### DIFF
--- a/coreneuron/permute/cellorder.hpp
+++ b/coreneuron/permute/cellorder.hpp
@@ -116,7 +116,7 @@ void copy_array(T*& dest, T* src, size_t n) {
 // copy src array to dest with NRN_SOA_BYTE_ALIGN ecalloc_align allocation
 template <typename T>
 void copy_align_array(T*& dest, T* src, size_t n) {
-    dest = (T*) ecalloc_align(n, sizeof(T));
+    dest = static_cast<T*>(ecalloc_align(n, sizeof(T)));
     std::copy(src, src + n, dest);
 }
 

--- a/coreneuron/permute/cellorder1.cpp
+++ b/coreneuron/permute/cellorder1.cpp
@@ -532,10 +532,7 @@ static void admin1(int ncell,
 
     // this vector is used to move from one compartment to the other (per cell)
     // its length is equal to the cell with the highest number of compartments
-    stride = (int*) ecalloc_align(nstride + 1, sizeof(int));
-    for (int i = 0; i <= nstride; ++i) {
-        stride[i] = 0;
-    }
+    stride = static_cast<int*>(ecalloc_align(nstride + 1, sizeof(int)));
     for (size_t i = ncell; i < nodevec.size(); ++i) {
         TNode& nd = *nodevec[i];
         // compute how many compartments with the same order

--- a/coreneuron/utils/memory.h
+++ b/coreneuron/utils/memory.h
@@ -213,11 +213,13 @@ inline int soa_padded_size(int cnt, int layout) {
 
 /** Check for the pointer alignment.
  */
-inline bool is_aligned(void* pointer, size_t alignment) {
-    return (((uintptr_t)(const void*) (pointer)) % (alignment) == 0);
+inline bool is_aligned(void* pointer, std::size_t alignment) {
+    return (reinterpret_cast<std::uintptr_t>(pointer) % alignment) == 0;
 }
 
-/** Allocate the aligned memory.
+/**
+ * Allocate aligned memory. This will be unified memory if the corresponding
+ * CMake option is set. This must be freed with the free_memory method.
  */
 inline void* emalloc_align(size_t size, size_t alignment = NRN_SOA_BYTE_ALIGN) {
     void* memptr;
@@ -226,7 +228,10 @@ inline void* emalloc_align(size_t size, size_t alignment = NRN_SOA_BYTE_ALIGN) {
     return memptr;
 }
 
-/** Allocate the aligned memory and set it to 0.
+/**
+ * Allocate the aligned memory and set it to 0. This will be unified memory if
+ * the corresponding CMake option is set. This must be freed with the
+ * free_memory method.
  */
 inline void* ecalloc_align(size_t n, size_t size, size_t alignment = NRN_SOA_BYTE_ALIGN) {
     void* p;

--- a/tests/unit/interleave_info/check_constructors.cpp
+++ b/tests/unit/interleave_info/check_constructors.cpp
@@ -25,10 +25,10 @@ BOOST_AUTO_TEST_CASE(interleave_info_test) {
     info1.nstride = nstride;
 
     // to avoid same values, different sub-array is used to initialize different members
-    copy_array(info1.stridedispl, data1, nwarp + 1);
-    copy_array(info1.stride, data1 + 1, nstride);
-    copy_array(info1.firstnode, data1 + 1, nwarp + 1);
-    copy_array(info1.lastnode, data1 + 1, nwarp + 1);
+    copy_align_array(info1.stridedispl, data1, nwarp + 1);
+    copy_align_array(info1.stride, data1 + 1, nstride);
+    copy_align_array(info1.firstnode, data1 + 1, nwarp + 1);
+    copy_align_array(info1.lastnode, data1 + 1, nwarp + 1);
 
     // check if copy_array works
     BOOST_CHECK_NE(info1.firstnode, info1.lastnode);
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(interleave_info_test) {
                                   info1.lastnode,
                                   info1.lastnode + nwarp + 1);
 
-    copy_array(info1.cellsize, data1 + 4, nwarp);
+    copy_align_array(info1.cellsize, data1 + 4, nwarp);
     copy_array(info1.nnode, data2, nwarp);
     copy_array(info1.ncycle, data2 + 1, nwarp);
     copy_array(info1.idle, data2 + 2, nwarp);


### PR DESCRIPTION
Fixes an AddressSanitizer error in the test.