### PR TITLE
GitHub Actions CI updates

### DIFF
--- a/.github/workflows/clang_cmake_format_check.yaml
+++ b/.github/workflows/clang_cmake_format_check.yaml
@@ -10,10 +10,10 @@ on:
 jobs:
   build:
     name: clang-cmake-format-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
         - name: Fetch repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: Install clang-format 11
           run: |
               sudo apt-get update

--- a/.github/workflows/coreneuron-ci.yml
+++ b/.github/workflows/coreneuron-ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-18.04, macOS-10.15 ]
+        os: [ ubuntu-20.04, macOS-10.15 ]
         config:
           # Defaults: CORENRN_ENABLE_MPI=ON
           - {cmake_option: "-DCORENRN_ENABLE_MPI=ON -DCORENRN_ENABLE_DEBUG_CODE=ON", documentation: ON}
@@ -68,7 +68,7 @@ jobs:
           GCC_VERSION: ${{ matrix.config.gcc_version }}
 
       - name: Set up Python3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
         env:
@@ -92,9 +92,9 @@ jobs:
       - name: Install NMODL dependencies
         if: ${{ matrix.config.use_nmodl == 'ON' ||  matrix.config.use_ispc == 'ON' }}
         run: |
-          python3 -m pip install --upgrade pip jinja2 pyyaml pytest "sympy<1.6";
+          python3 -m pip install --upgrade pip jinja2 pyyaml pytest sympy
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Python3 documentation dependencies
         if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.config.documentation == 'ON' }}
@@ -162,7 +162,7 @@ jobs:
           echo ::set-output name=status::done
           
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        uses: JamesIves/github-pages-deploy-action@v4
         if: steps.documentation.outputs.status == 'done' && github.ref == 'refs/heads/master'
         with:
           branch: gh-pages # The branch the action should deploy to.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,19 +15,21 @@ on:
       - release/**
 
 env:
-  BUILD_TYPE: Release
-  DEFAULT_PY_VERSION: 3.8
+  CMAKE_BUILD_PARALLEL_LEVEL: 3
 
 jobs:
   coverage:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: "Coverage Test"
     steps:
       - name: Install packages
         run: |
-          sudo apt-get install doxygen bison flex libboost-all-dev libopenmpi-dev openmpi-bin python3-dev python3-pip lcov libfl-dev
+          sudo apt-get update
+          sudo apt-get install bison doxygen flex lcov libboost-all-dev \
+            libopenmpi-dev libfl-dev ninja-build openmpi-bin python3-dev \
+            python3-pip
         shell: bash
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Build and Test for Coverage
@@ -36,10 +38,15 @@ jobs:
         working-directory: ${{runner.workspace}}/CoreNeuron
         run:  |
           mkdir build && cd build
-          cmake .. -DCORENRN_ENABLE_MPI=ON -DCORENRN_ENABLE_DEBUG_CODE=ON -DCMAKE_C_FLAGS="-coverage -O0" -DCMAKE_CXX_FLAGS="-coverage -O0";
-          make -j2
+          cmake .. -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_FLAGS="-coverage" \
+            -DCMAKE_CXX_FLAGS="-coverage" \
+            -DCORENRN_ENABLE_MPI=ON \
+            -DCORENRN_ENABLE_DEBUG_CODE=ON
+          cmake --build .
           (cd ..;  lcov --capture  --initial --directory . --no-external --output-file build/coverage-base.info)
-          make test
+          ctest --output-on-failure
           (cd ..; lcov --capture  --directory . --no-external --output-file build/coverage-run.info)
           lcov --add-tracefile coverage-base.info --add-tracefile coverage-run.info --output-file coverage-combined.info
           lcov --remove coverage-combined.info --output-file coverage.info "*/external/*"
@@ -55,4 +62,3 @@ jobs:
           shasum -a 256 -c codecov.SHA256SUM 
           chmod +x codecov 
           ./codecov -f build/coverage.info
-

--- a/.github/workflows/test-as-submodule.yml
+++ b/.github/workflows/test-as-submodule.yml
@@ -63,7 +63,7 @@ jobs:
           echo "Will use neuron branch: $nrn_branch"
           echo ::set-output name=neuron_branch::"${nrn_branch}"
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout NEURON
         with:
           path: nrn


### PR DESCRIPTION
**Description**
Inspired by https://github.com/BlueBrain/nmodl/pull/879 and seeing if this fixes failures this morning.

Prefer Ubuntu 20.04 to 18.04 and bump major versions of some actions.

Drop sympy version constraints for NMODL and use a debug (not release) build for coverage.

**Use certain branches in CI pipelines.**
<!-- You can steer which versions of CoreNEURON dependencies will be used in
     the various CI pipelines (GitLab, test-as-submodule) here. Expressions are
     of the form PROJ_REF=VALUE, where PROJ is the relevant Spack package name,
     transformed to upper case and with hyphens replaced with underscores.
     REF may be BRANCH, COMMIT or TAG, with exceptions:
      - SPACK_COMMIT and SPACK_TAG are invalid (hpc/gitlab-pipelines limitation)
      - NEURON_COMMIT and NEURON_TAG are invalid (test-as-submodule limitation)
     These values for NEURON, nmodl and Spack are the defaults and are given
     for illustrative purposes; they can safely be removed.
-->
CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop
