### PR TITLE
Bump semantic version to 9.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 # standalone.
 project(
   coreneuron
-  VERSION 8.2.0
+  VERSION 9.0.0
   LANGUAGES CXX)
 
 # ~~~


### PR DESCRIPTION
**Description**
Update the semantic version to match https://github.com/neuronsimulator/nrn/pull/1597, which will be merged imminently.

With https://github.com/neuronsimulator/nrn/pull/1762 and https://github.com/BlueBrain/CoreNeuron/pull/796 CoreNEURON is versioned according to the NEURON scheme. This PR updates CoreNEURON to 9.0.0 so the CoreNEURON submodule commit can be updated in https://github.com/neuronsimulator/nrn/pull/1597.

The CI is running against the branches of https://github.com/neuronsimulator/nrn/pull/1597 and https://github.com/BlueBrain/spack/pull/1624.

**Use certain branches in CI pipelines.**
<!-- You can steer which versions of CoreNEURON dependencies will be used in
     the various CI pipelines (GitLab, test-as-submodule) here. Expressions are
     of the form PROJ_REF=VALUE, where PROJ is the relevant Spack package name,
     transformed to upper case and with hyphens replaced with underscores.
     REF may be BRANCH, COMMIT or TAG, with exceptions:
      - SPACK_COMMIT and SPACK_TAG are invalid (hpc/gitlab-pipelines limitation)
      - NEURON_COMMIT and NEURON_TAG are invalid (test-as-submodule limitation)
     These values for NEURON, nmodl and Spack are the defaults and are given
     for illustrative purposes; they can safely be removed.
-->
CI_BRANCHES:NEURON_BRANCH=olupton/more-c++,NMODL_BRANCH=master,SPACK_BRANCH=olupton/neurodamus
