### PR TITLE
Print memory footprint of each mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,4 +395,4 @@ You can see current [contributors here](https://github.com/BlueBrain/CoreNeuron/
 
 CoreNEURON is developed in a joint collaboration between the Blue Brain Project and Yale University. This work is supported by funding to the Blue Brain Project, a research center of the École polytechnique fédérale de Lausanne (EPFL), from the Swiss government’s ETH Board of the Swiss Federal Institutes of Technology, NIH grant number R01NS11613 (Yale University), the European Union Seventh Framework Program (FP7/20072013) under grant agreement n◦ 604102 (HBP) and the European Union’s Horizon 2020 Framework Programme for Research and Innovation under Specific Grant Agreement n◦ 720270 (Human Brain Project SGA1), n◦ 785907 (Human Brain Project SGA2) and n◦ 945539 (Human Brain Project SGA3).
 
-Copyright (c) 2016 - 2021 Blue Brain Project/EPFL
+Copyright (c) 2016 - 2022 Blue Brain Project/EPFL

--- a/coreneuron/apps/corenrn_parameters.cpp
+++ b/coreneuron/apps/corenrn_parameters.cpp
@@ -40,7 +40,7 @@ corenrn_parameters::corenrn_parameters() {
     app.add_set(
         "--verbose",
         this->verbose,
-        {verbose_level::NONE, verbose_level::ERROR, verbose_level::INFO, verbose_level::DEBUG},
+        {verbose_level::NONE, verbose_level::ERROR, verbose_level::INFO, verbose_level::DEBUG_INFO},
         "Verbose level: 0 = NONE, 1 = ERROR, 2 = INFO, 3 = DEBUG. Default is INFO");
     app.add_flag("--model-stats",
                  this->model_stats,

--- a/coreneuron/apps/corenrn_parameters.hpp
+++ b/coreneuron/apps/corenrn_parameters.hpp
@@ -35,7 +35,13 @@
 namespace coreneuron {
 
 struct corenrn_parameters_data {
-    enum verbose_level : std::uint32_t { NONE = 0, ERROR = 1, INFO = 2, DEBUG_INFO = 3, DEFAULT = INFO };
+    enum verbose_level : std::uint32_t {
+        NONE = 0,
+        ERROR = 1,
+        INFO = 2,
+        DEBUG_INFO = 3,
+        DEFAULT = INFO
+    };
 
     static constexpr int report_buff_size_default = 4;
 

--- a/coreneuron/apps/corenrn_parameters.hpp
+++ b/coreneuron/apps/corenrn_parameters.hpp
@@ -35,7 +35,7 @@
 namespace coreneuron {
 
 struct corenrn_parameters_data {
-    enum verbose_level : std::uint32_t { NONE = 0, ERROR = 1, INFO = 2, DEBUG = 3, DEFAULT = INFO };
+    enum verbose_level : std::uint32_t { NONE = 0, ERROR = 1, INFO = 2, DEBUG_INFO = 3, DEFAULT = INFO };
 
     static constexpr int report_buff_size_default = 4;
 

--- a/coreneuron/io/mech_report.cpp
+++ b/coreneuron/io/mech_report.cpp
@@ -28,7 +28,8 @@ void write_mech_report() {
             const int type = tml->index;
             const auto& ml = tml->ml;
             local_mech_count[type] += ml->nodecount;
-            mech_size[type] = corenrn.get_prop_param_size()[type] * sizeof(double) + corenrn.get_prop_dparam_size()[type] * sizeof(Datum);
+            mech_size[type] = corenrn.get_prop_param_size()[type] * sizeof(double) +
+                              corenrn.get_prop_dparam_size()[type] * sizeof(Datum);
         }
     }
 
@@ -51,9 +52,19 @@ void write_mech_report() {
     /// print global stats to stdout
     if (nrnmpi_myid == 0) {
         printf("\n================ MECHANISMS COUNT BY TYPE ==================\n");
-        printf("%4s %20s %10s %25s %25s\n", "Id", "Name", "Count", "Size per mechanism (Bytes)", "Total memory size (KBs)");
+        printf("%4s %20s %10s %25s %25s\n",
+               "Id",
+               "Name",
+               "Count",
+               "Size per mechanism (Bytes)",
+               "Total memory size (KBs)");
         for (size_t i = 0; i < total_mech_count.size(); i++) {
-            printf("%4lu %20s %10ld %25zu %25.2lf\n", i, nrn_get_mechname(i), total_mech_count[i], mech_size[i], static_cast<double>(total_mech_count[i]*mech_size[i])/1024);
+            printf("%4lu %20s %10ld %25zu %25.2lf\n",
+                   i,
+                   nrn_get_mechname(i),
+                   total_mech_count[i],
+                   mech_size[i],
+                   static_cast<double>(total_mech_count[i] * mech_size[i]) / 1024);
         }
         printf("=============================================================\n");
     }

--- a/coreneuron/io/mech_report.cpp
+++ b/coreneuron/io/mech_report.cpp
@@ -57,7 +57,7 @@ void write_mech_report() {
     /// print global stats to stdout
     if (nrnmpi_myid == 0) {
         printf("\n================= MECHANISMS COUNT BY TYPE ===================\n");
-        printf("%4s %20s %10s %25s\n", "Id", "Name", "Count", "Total memory size (KBs)");
+        printf("%4s %20s %10s %25s\n", "Id", "Name", "Count", "Total memory size (kBs)");
         for (size_t i = 0; i < total_mech_count.size(); i++) {
             printf("%4lu %20s %10ld %25.2lf\n",
                    i,

--- a/coreneuron/io/mech_report.cpp
+++ b/coreneuron/io/mech_report.cpp
@@ -19,6 +19,7 @@ void write_mech_report() {
     /// mechanim count across all gids, local to rank
     const auto n_memb_func = corenrn.get_memb_funcs().size();
     std::vector<long> local_mech_count(n_memb_func, 0);
+    std::vector<size_t> mech_size(n_memb_func, 0);
 
     /// each gid record goes on separate row, only check non-empty threads
     for (int i = 0; i < nrn_nthread; i++) {
@@ -27,6 +28,7 @@ void write_mech_report() {
             const int type = tml->index;
             const auto& ml = tml->ml;
             local_mech_count[type] += ml->nodecount;
+            mech_size[type] = corenrn.get_prop_param_size()[type] * sizeof(double) + corenrn.get_prop_dparam_size()[type] * sizeof(Datum);
         }
     }
 
@@ -49,9 +51,9 @@ void write_mech_report() {
     /// print global stats to stdout
     if (nrnmpi_myid == 0) {
         printf("\n================ MECHANISMS COUNT BY TYPE ==================\n");
-        printf("%4s %20s %10s\n", "Id", "Name", "Count");
+        printf("%4s %20s %10s %25s %25s\n", "Id", "Name", "Count", "Size per mechanism (Bytes)", "Total memory size (KBs)");
         for (size_t i = 0; i < total_mech_count.size(); i++) {
-            printf("%4lu %20s %10ld\n", i, nrn_get_mechname(i), total_mech_count[i]);
+            printf("%4lu %20s %10ld %25zu %25.2lf\n", i, nrn_get_mechname(i), total_mech_count[i], mech_size[i], static_cast<double>(total_mech_count[i]*mech_size[i])/1024);
         }
         printf("=============================================================\n");
     }

--- a/coreneuron/io/mech_report.cpp
+++ b/coreneuron/io/mech_report.cpp
@@ -29,7 +29,7 @@ void write_mech_report() {
             const int type = tml->index;
             const auto& ml = tml->ml;
             local_mech_count[type] += ml->nodecount;
-            local_mech_size[type] = memb_list_size(tml);
+            local_mech_size[type] = memb_list_size(tml, true);
         }
     }
 

--- a/coreneuron/io/mech_report.cpp
+++ b/coreneuron/io/mech_report.cpp
@@ -56,7 +56,7 @@ void write_mech_report() {
 
     /// print global stats to stdout
     if (nrnmpi_myid == 0) {
-        printf("\n================ MECHANISMS COUNT BY TYPE ==================\n");
+        printf("\n================= MECHANISMS COUNT BY TYPE ===================\n");
         printf("%4s %20s %10s %25s\n", "Id", "Name", "Count", "Total memory size (KBs)");
         for (size_t i = 0; i < total_mech_count.size(); i++) {
             printf("%4lu %20s %10ld %25.2lf\n",
@@ -65,7 +65,7 @@ void write_mech_report() {
                    total_mech_count[i],
                    static_cast<double>(total_mech_size[i]) / 1024);
         }
-        printf("=============================================================\n");
+        printf("===============================================================\n");
     }
 }
 

--- a/coreneuron/io/mech_report.cpp
+++ b/coreneuron/io/mech_report.cpp
@@ -57,7 +57,7 @@ void write_mech_report() {
     /// print global stats to stdout
     if (nrnmpi_myid == 0) {
         printf("\n================= MECHANISMS COUNT BY TYPE ===================\n");
-        printf("%4s %20s %10s %25s\n", "Id", "Name", "Count", "Total memory size (kB)");
+        printf("%4s %20s %10s %25s\n", "Id", "Name", "Count", "Total memory size (KiB)");
         for (size_t i = 0; i < total_mech_count.size(); i++) {
             printf("%4lu %20s %10ld %25.2lf\n",
                    i,

--- a/coreneuron/io/mech_report.cpp
+++ b/coreneuron/io/mech_report.cpp
@@ -57,7 +57,7 @@ void write_mech_report() {
     /// print global stats to stdout
     if (nrnmpi_myid == 0) {
         printf("\n================= MECHANISMS COUNT BY TYPE ===================\n");
-        printf("%4s %20s %10s %25s\n", "Id", "Name", "Count", "Total memory size (kBs)");
+        printf("%4s %20s %10s %25s\n", "Id", "Name", "Count", "Total memory size (kB)");
         for (size_t i = 0; i < total_mech_count.size(); i++) {
             printf("%4lu %20s %10ld %25.2lf\n",
                    i,
@@ -65,7 +65,7 @@ void write_mech_report() {
                    total_mech_count[i],
                    static_cast<double>(total_mech_size[i]) / 1024);
         }
-        printf("===============================================================\n");
+        printf("==============================================================\n");
     }
 }
 

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -966,9 +966,11 @@ void read_phase3(NrnThread& nt, UserParams& userParams) {
     nt.summation_report_handler_ = std::make_unique<SummationReportMapping>();
 }
 
-static size_t memb_list_size(NrnThreadMembList* tml) {
+// Returns the size of the dynamically allocated memory for NrnThreadMembList
+size_t memb_list_size(NrnThreadMembList* tml) {
     size_t nbyte = sizeof(NrnThreadMembList) + sizeof(Memb_list);
     nbyte += tml->ml->nodecount * sizeof(int);
+    nbyte += corenrn.get_prop_param_size()[tml->index] * tml->ml->nodecount * sizeof(double);
     nbyte += corenrn.get_prop_dparam_size()[tml->index] * tml->ml->nodecount * sizeof(Datum);
 #ifdef DEBUG
     int i = tml->index;

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -966,11 +966,37 @@ void read_phase3(NrnThread& nt, UserParams& userParams) {
     nt.summation_report_handler_ = std::make_unique<SummationReportMapping>();
 }
 
-// Returns the size of the dynamically allocated memory for NrnThreadMembList
-size_t memb_list_size(NrnThreadMembList* tml) {
+/* Returns the size of the dynamically allocated memory for NrnThreadMembList
+ * Includes:
+ *  - Size of NrnThreadMembList
+ *  - Size of Memb_list
+ *  - Size of nodeindices
+ *  - Size of _permute
+ *  - Size of _thread
+ *  - Size of NetReceive and NetSend Buffers
+ *  - Size of int variables
+ *  - Size of double variables (If include_data is enabled. Those variables are already counted
+ * since they point to nt->_data.)
+ */
+size_t memb_list_size(NrnThreadMembList* tml, bool include_data) {
     size_t nbyte = sizeof(NrnThreadMembList) + sizeof(Memb_list);
     nbyte += tml->ml->nodecount * sizeof(int);
-    nbyte += corenrn.get_prop_param_size()[tml->index] * tml->ml->nodecount * sizeof(double);
+    if (tml->ml->_permute) {
+        nbyte += tml->ml->nodecount * sizeof(int);
+    }
+    if (tml->ml->_thread) {
+        Memb_func& mf = corenrn.get_memb_func(tml->index);
+        nbyte += mf.thread_size_ * sizeof(ThreadDatum);
+    }
+    if (tml->ml->_net_receive_buffer) {
+        nbyte += sizeof(NetReceiveBuffer_t) + tml->ml->_net_receive_buffer->size_of_object();
+    }
+    if (tml->ml->_net_send_buffer) {
+        nbyte += sizeof(NetSendBuffer_t) + tml->ml->_net_send_buffer->size_of_object();
+    }
+    if (include_data) {
+        nbyte += corenrn.get_prop_param_size()[tml->index] * tml->ml->nodecount * sizeof(double);
+    }
     nbyte += corenrn.get_prop_dparam_size()[tml->index] * tml->ml->nodecount * sizeof(Datum);
 #ifdef DEBUG
     int i = tml->index;
@@ -1033,7 +1059,7 @@ size_t model_size(bool detailed_report) {
         // Memb_list size
         int nmech = 0;
         for (auto tml = nt.tml; tml; tml = tml->next) {
-            nb_nt += memb_list_size(tml);
+            nb_nt += memb_list_size(tml, false);
             ++nmech;
         }
 

--- a/coreneuron/io/nrn_setup.cpp
+++ b/coreneuron/io/nrn_setup.cpp
@@ -991,7 +991,7 @@ size_t output_presyn_size(void) {
     size_t nbyte = sizeof(gid2out) + sizeof(int) * gid2out.size() +
                    sizeof(PreSyn*) * gid2out.size();
 #ifdef DEBUG
-    printf(" gid2out table bytes=~%ld size=%d\n", nbyte, gid2out.size());
+    printf(" gid2out table bytes=~%ld size=%ld\n", nbyte, gid2out.size());
 #endif
     return nbyte;
 }
@@ -1003,7 +1003,7 @@ size_t input_presyn_size(void) {
     size_t nbyte = sizeof(gid2in) + sizeof(int) * gid2in.size() +
                    sizeof(InputPreSyn*) * gid2in.size();
 #ifdef DEBUG
-    printf(" gid2in table bytes=~%ld size=%d\n", nbyte, gid2in.size());
+    printf(" gid2in table bytes=~%ld size=%ld\n", nbyte, gid2in.size());
 #endif
     return nbyte;
 }

--- a/coreneuron/io/nrn_setup.hpp
+++ b/coreneuron/io/nrn_setup.hpp
@@ -42,7 +42,7 @@ extern void nrn_setup_cleanup();
 
 extern int nrn_i_layout(int i, int cnt, int j, int size, int layout);
 
-size_t memb_list_size(NrnThreadMembList* tml);
+size_t memb_list_size(NrnThreadMembList* tml, bool include_data);
 
 size_t model_size(bool detailed_report);
 

--- a/coreneuron/io/nrn_setup.hpp
+++ b/coreneuron/io/nrn_setup.hpp
@@ -42,6 +42,8 @@ extern void nrn_setup_cleanup();
 
 extern int nrn_i_layout(int i, int cnt, int j, int size, int layout);
 
+size_t memb_list_size(NrnThreadMembList* tml);
+
 size_t model_size(bool detailed_report);
 
 namespace coreneuron {

--- a/coreneuron/mechanism/mechanism.hpp
+++ b/coreneuron/mechanism/mechanism.hpp
@@ -50,6 +50,13 @@ struct NetReceiveBuffer_t {
     int _displ_cnt; /* number of unique _pnt_index */
     int _size;      /* capacity */
     int _pnt_offset;
+    size_t size_of_object() {
+        size_t nbytes = 0;
+        nbytes += _size * sizeof(int) * 3;
+        nbytes += (_size + 1) * sizeof(int);
+        nbytes += _size * sizeof(double) * 2;
+        return nbytes;
+    }
 };
 
 struct NetSendBuffer_t: MemoryManaged {
@@ -76,6 +83,13 @@ struct NetSendBuffer_t: MemoryManaged {
         reallocated = 1;
         _nsb_t = (double*) ecalloc_align(_size, sizeof(double));
         _nsb_flag = (double*) ecalloc_align(_size, sizeof(double));
+    }
+
+    size_t size_of_object() {
+        size_t nbytes = 0;
+        nbytes += _size * sizeof(int) * 4;
+        nbytes += _size * sizeof(double) * 2;
+        return nbytes;
     }
 
     ~NetSendBuffer_t() {


### PR DESCRIPTION
**Description**

Report the size of the dynamically allocated memory for each mechanism based on the `ml->data` and `ml->pdata` structures.

**How to test this?**

Building CoreNEURON and running the following test:

```bash
mkdir build && cd build
cmake .. -DCMAKE_INSTALL_PREFIX=./install -DNRN_ENABLE_CORENEURON=ON -DCORENRN_ENABLE_NMODL=OFF -DCORENRN_ENABLE_GPU=OFF -G Ninja
cmake --build . --parallel 8 --target install
bash tests/integration/ring/integration_test.sh
```
Has the following output:

```
================= MECHANISMS COUNT BY TYPE ===================
  Id                 Name      Count   Total memory size (KiB)
   0               (null)          0                      0.00
   1               (null)          0                      0.00
   2           morphology          0                      0.00
   3          capacitance        392                      7.88
   4                  pas        372                     16.20
   5        extracellular          0                      0.00
   6              fastpas          0                      0.00
   7               IClamp          0                      0.00
   8         AlphaSynapse          0                      0.00
   9               ExpSyn         40                      4.57
  10              Exp2Syn          0                      0.00
  11              SEClamp          0                      0.00
  12               VClamp          0                      0.00
  13               OClamp          0                      0.00
  14              APCount          0                      0.00
  15               na_ion         20                      1.16
  16                k_ion         20                      1.16
  17                   hh         20                      4.67
  18              NetStim          1                      0.20
  19             IntFire1          0                      0.00
  20             IntFire2          0                      0.00
  21             IntFire4          0                      0.00
  22     PointProcessMark          0                      0.00
  23          PatternStim          0                      0.00
  24              HalfGap          0                      0.00
==============================================================
Memory size information for all NrnThreads per rank
------------------------------------------------------------------
                 field          min          max          avg
                n_cell           10           10           10.00
         n_compartment          396          408          402.00
           n_mechanism            6            7            6.50
                _ndata         4472         4632         4552.00
               _nidata            0            0            0.00
               _nvdata           20           23           21.50
              n_presyn           10           11           10.50
      n_presyn (bytes)          640          704          672.00
        n_input_presyn           10           10           10.00
n_input_presyn (bytes)          240          240          240.00
             n_pntproc           20           21           20.50
     n_pntproc (bytes)          160          168          164.00
              n_netcon           10           11           10.50
      n_netcon (bytes)          400          440          420.00
              n_weight           10           11           10.50
     NrnThread (bytes)        43532        45184        44358.00
    model size (bytes)        43948        45608        44778.00
 Setup Done   : 0.00 seconds 
 Model size   : 87.46 kB
 ```

Only issue is that with `NMODL` the `NetStim` size of `net_send` is `128` instaed of `0`.

**Test System**
 - OS: Ubuntu 20.04
 - Compiler: GCC 9.4.0
 - Version:master
 - Backend: CPU
