### PR TITLE
nrnivmodl_core_makefile: fix SDKROOT

### DIFF
--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -16,9 +16,8 @@ DESTDIR =
 TARGET_LIB_TYPE = $(BUILD_TYPE)
 
 # required for OSX to execute nrnivmodl-core
-OSX_SYSROOT=@CMAKE_OSX_SYSROOT@
-ifneq ($(OSX_SYSROOT),)
-  export SDKROOT := $(OSX_SYSROOT)
+ifneq ($(SDKROOT),)
+  export SDKROOT := $(shell xcrun --sdk macosx --show-sdk-path)
 endif
 
 # CoreNEURON installation directories


### PR DESCRIPTION
**Description**

Needed for neuronsimulator/nrn#1939

CI_BRANCHES:NEURON_BRANCH=fixmf
