### PR TITLE
Minimum Boost 1.59

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,7 +22,8 @@ endif()
 set(CMAKE_BUILD_RPATH ${CMAKE_BINARY_DIR}/bin/${CMAKE_HOST_SYSTEM_PROCESSOR})
 
 set(Boost_NO_BOOST_CMAKE TRUE)
-find_package(Boost 1.41.0 QUIET COMPONENTS filesystem system atomic unit_test_framework)
+# Minimum set by needing the multi-argument version of BOOST_AUTO_TEST_CASE.
+find_package(Boost 1.59 QUIET COMPONENTS filesystem system atomic unit_test_framework)
 
 if(Boost_FOUND)
   if(CORENRN_ENABLE_UNIT_TESTS)


### PR DESCRIPTION
**Description**
https://github.com/BlueBrain/CoreNeuron/pull/841 added tests that use a two-parameter form of the `BOOST_AUTO_TEST_CASE` macro, which was added in https://github.com/boostorg/test/commit/24e5ddec4a0100d0f9464b9ecfe3d4a658ee96fe and exists in Boost 1.59+.

This is causing failures on CentOS7 in https://github.com/neuronsimulator/nrn-build-ci/runs/7738697401 after the NEURON submodule of CoreNEURON was updated in https://github.com/neuronsimulator/nrn/pull/1942.

**Use certain branches in CI pipelines.**
<!-- You can steer which versions of CoreNEURON dependencies will be used in
     the various CI pipelines (GitLab, test-as-submodule) here. Expressions are
     of the form PROJ_REF=VALUE, where PROJ is the relevant Spack package name,
     transformed to upper case and with hyphens replaced with underscores.
     REF may be BRANCH, COMMIT or TAG, with exceptions:
      - SPACK_COMMIT and SPACK_TAG are invalid (hpc/gitlab-pipelines limitation)
      - NEURON_COMMIT and NEURON_TAG are invalid (test-as-submodule limitation)
     These values for NEURON, nmodl and Spack are the defaults and are given
     for illustrative purposes; they can safely be removed.
-->
CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop
