### PR TITLE
Link to libdl.so to avoid linking issues with mpich on centos7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,8 +261,6 @@ find_package(Perl REQUIRED)
 # =============================================================================
 # build mod files for coreneuron
 list(APPEND CORENRN_COMPILE_DEFS CORENEURON_BUILD)
-list(APPEND CORENRN_COMPILE_DEFS CLI11_HAS_FILESYSTEM=0)
-
 set(CMAKE_REQUIRED_QUIET TRUE)
 check_include_files(malloc.h have_malloc_h)
 if(have_malloc_h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,8 @@ find_package(Perl REQUIRED)
 # =============================================================================
 # build mod files for coreneuron
 list(APPEND CORENRN_COMPILE_DEFS CORENEURON_BUILD)
+list(APPEND CORENRN_COMPILE_DEFS CLI11_HAS_FILESYSTEM=0)
+
 set(CMAKE_REQUIRED_QUIET TRUE)
 check_include_files(malloc.h have_malloc_h)
 if(have_malloc_h)

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -184,14 +184,17 @@ if(CORENRN_ENABLE_MPI AND NOT CORENRN_ENABLE_MPI_DYNAMIC)
   target_link_libraries(coreneuron-core PUBLIC ${MPI_CXX_LIBRARIES})
 endif()
 
+# ~~~
+# main coreneuron library needs to be linked to libdl.so
+# only in case of dynamic mpi build. But on old system
+# like centos7, we saw mpich library require explici
+# link to libdl.so. See
+#   https://github.com/neuronsimulator/nrn-build-ci/pull/51
+# ~~~
+target_link_libraries(coreneuron-core PUBLIC ${CMAKE_DL_LIBS})
+
 # this is where we handle dynamic mpi library build
 if(CORENRN_ENABLE_MPI AND CORENRN_ENABLE_MPI_DYNAMIC)
-  # ~~~
-  # main coreneuron library needs to be linked to libdl.so and
-  # and should be aware of shared library suffix on different platforms.
-  # ~~~
-  target_link_libraries(coreneuron-core PUBLIC ${CMAKE_DL_LIBS})
-
   # store mpi library targets that will be built
   list(APPEND corenrn_mpi_targets "")
 


### PR DESCRIPTION
**Description**

Main coreneuron library needs to be linked to libdl.so
only in case of dynamic mpi build. But on an old system
like centos7, we saw mpich library require explicit
ink to libdl.so.

See https://github.com/neuronsimulator/nrn-build-ci/pull/51

**How to test this?**

CI is launched via nrn-build-pipeline: https://github.com/neuronsimulator/nrn-build-ci/pull/51

CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop
