### PR TITLE
Try to declare dependencies on libcorenrnmech.so properly

### DIFF
--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -311,6 +311,12 @@ add_custom_command(
   COMMENT "Running nrnivmodl-core with halfgap.mod")
 add_custom_target(nrniv-core ALL DEPENDS ${output_binaries})
 
+# Build a target representing the libcorenrnmech.so that is produced under bin/x86_64, which
+# executables such as the unit tests must link against
+add_library(builtin-libcorenrnmech SHARED IMPORTED)
+add_dependencies(builtin-libcorenrnmech nrniv-core)
+set_target_properties(builtin-libcorenrnmech PROPERTIES IMPORTED_LOCATION "${corenrn_mech_library}")
+
 if(CORENRN_ENABLE_GPU)
   separate_arguments(CORENRN_ACC_FLAGS UNIX_COMMAND "${NVHPC_ACC_COMP_FLAGS}")
   target_compile_options(coreneuron-core PRIVATE ${CORENRN_ACC_FLAGS})
@@ -325,7 +331,7 @@ add_dependencies(coreneuron-for-tests coreneuron-core ${NMODL_TARGET_TO_DEPEND})
 # ${corenrn_mech_library} is libcorenrnmech.{a,so}, which contains both the compiled default
 # mechanisms and the content of libcoreneuron-core.a.
 add_library(coreneuron-all INTERFACE)
-target_link_libraries(coreneuron-all INTERFACE "${corenrn_mech_library}")
+target_link_libraries(coreneuron-all INTERFACE builtin-libcorenrnmech)
 # Also copy the dependencies of libcoreneuron-core as interface dependencies of this new target
 # (example: ${corenrn_mech_library} will probably depend on MPI, so when the unit tests link against
 # ${corenrn_mech_library} they need to know to link against MPI too).

--- a/extra/nrnivmodl_core_makefile.in
+++ b/extra/nrnivmodl_core_makefile.in
@@ -16,7 +16,7 @@ DESTDIR =
 TARGET_LIB_TYPE = $(BUILD_TYPE)
 
 # required for OSX to execute nrnivmodl-core
-ifneq ($(SDKROOT),)
+ifeq ($(origin SDKROOT), undefined)
   export SDKROOT := $(shell xcrun --sdk macosx --show-sdk-path)
 endif
 


### PR DESCRIPTION
**Description**
In the CI for neuronsimulator/nrn#1929 we started seeing errors like (https://github.com/neuronsimulator/nrn/runs/8186384877?check_suite_focus=true#step:8:939):
```
gmake[2]: *** No rule to make target 'bin/x86_64/libcorenrnmech.so', needed by 'bin/cmd_interface_test_bin'.  Stop.
```
which do not seem(?) to affect the builds using Ninja.

https://cmake.org/cmake/help/latest/command/add_custom_command.html mentions some restrictions on depending on the outputs of a custom command from other directories. These tweaks seem to avoid the issue.

Also, fix the `nrnivmodl-core` logic for when the `SDKROOT` environment variable is **not** set.

**Use certain branches in CI pipelines.**
<!-- You can steer which versions of CoreNEURON dependencies will be used in
     the various CI pipelines (GitLab, test-as-submodule) here. Expressions are
     of the form PROJ_REF=VALUE, where PROJ is the relevant Spack package name,
     transformed to upper case and with hyphens replaced with underscores.
     REF may be BRANCH, COMMIT or TAG, with exceptions:
      - SPACK_COMMIT and SPACK_TAG are invalid (hpc/gitlab-pipelines limitation)
      - NEURON_COMMIT and NEURON_TAG are invalid (test-as-submodule limitation)
     These values for NEURON, nmodl and Spack are the defaults and are given
     for illustrative purposes; they can safely be removed.
-->
CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop
