### PR TITLE
Fix out-of-range error from ASan

### DIFF
--- a/coreneuron/network/multisend_setup.cpp
+++ b/coreneuron/network/multisend_setup.cpp
@@ -421,7 +421,7 @@ static void fill_multisend_lists(bool use_phase2,
         PreSyn* ps = g.second;
         if (ps->output_index_ >= 0) {  // only ones that generate spikes
             int i = ps->multisend_index_;
-            if (i >= 0) {
+            if (i >= 0) {  // only if the gid has targets on other ranks.
                 max_ntarget_host = std::max(targets_phase1[i], max_ntarget_host);
                 max_multisend_targets = std::max(targets_phase1[i + 1], max_multisend_targets);
             }

--- a/coreneuron/network/multisend_setup.cpp
+++ b/coreneuron/network/multisend_setup.cpp
@@ -421,8 +421,10 @@ static void fill_multisend_lists(bool use_phase2,
         PreSyn* ps = g.second;
         if (ps->output_index_ >= 0) {  // only ones that generate spikes
             int i = ps->multisend_index_;
-            max_ntarget_host = std::max(targets_phase1[i], max_ntarget_host);
-            max_multisend_targets = std::max(targets_phase1[i + 1], max_multisend_targets);
+            if (i >= 0) {
+                max_ntarget_host = std::max(targets_phase1[i], max_ntarget_host);
+                max_multisend_targets = std::max(targets_phase1[i + 1], max_multisend_targets);
+            }
         }
     }
     if (use_phase2) {


### PR DESCRIPTION
**Description**
It seems that `i` is sometimes negative. In a debug build on macOS with AppleClang and AddressSanitizer this triggered an error in the `ring_gap_multisend_TEST` test. With this change the tests passed locally.

https://github.com/neuronsimulator/nrn/actions/runs/3054217216/jobs/4925838144#step:14:3620

**Use certain branches in CI pipelines.**
<!-- You can steer which versions of CoreNEURON dependencies will be used in
     the various CI pipelines (GitLab, test-as-submodule) here. Expressions are
     of the form PROJ_REF=VALUE, where PROJ is the relevant Spack package name,
     transformed to upper case and with hyphens replaced with underscores.
     REF may be BRANCH, COMMIT or TAG, with exceptions:
      - SPACK_COMMIT and SPACK_TAG are invalid (hpc/gitlab-pipelines limitation)
      - NEURON_COMMIT and NEURON_TAG are invalid (test-as-submodule limitation)
     These values for NEURON, nmodl and Spack are the defaults and are given
     for illustrative purposes; they can safely be removed.
-->
CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop
