### PR TITLE
Replace posix_memalign with std::aligned_alloc

### DIFF
--- a/coreneuron/utils/memory.h
+++ b/coreneuron/utils/memory.h
@@ -176,7 +176,7 @@ class MemoryManaged {
 #include <cstdlib>
 
 inline void alloc_memory(void*& pointer, size_t num_bytes, size_t alignment) {
-    size_t fill;
+    size_t fill = 0;
     if (num_bytes % alignment != 0) {
         size_t multiple = num_bytes / alignment;
         fill = alignment * (multiple + 1) - num_bytes;

--- a/coreneuron/utils/memory.h
+++ b/coreneuron/utils/memory.h
@@ -173,14 +173,15 @@ class MemoryManaged {
     // does nothing by default
 };
 
-#include <stdlib.h>
+#include <cstdlib>
 
 inline void alloc_memory(void*& pointer, size_t num_bytes, size_t alignment) {
-#if defined(MINGW)
-    nrn_assert((pointer = _aligned_malloc(num_bytes, alignment)) != nullptr);
-#else
-    nrn_assert(posix_memalign(&pointer, alignment, num_bytes) == 0);
-#endif
+    size_t fill;
+    if (num_bytes % alignment != 0) {
+        size_t multiple = num_bytes / alignment;
+        fill = alignment * (multiple + 1) - num_bytes;
+    }
+    nrn_assert((pointer = std::aligned_alloc(alignment, num_bytes + fill)) != nullptr);
 }
 
 inline void calloc_memory(void*& pointer, size_t num_bytes, size_t alignment) {

--- a/coreneuron/utils/nrnoc_aux.cpp
+++ b/coreneuron/utils/nrnoc_aux.cpp
@@ -101,14 +101,7 @@ void* erealloc(void* ptr, size_t size) {
 }
 
 void* nrn_cacheline_alloc(void** memptr, size_t size) {
-#if HAVE_MEMALIGN
-    if (posix_memalign(memptr, 64, size) != 0) {
-        fprintf(stderr, "posix_memalign not working\n");
-        assert(0);
-    }
-#else
-    *memptr = emalloc(size);
-#endif
+    alloc_memory(*memptr, size, 64);
     return *memptr;
 }
 


### PR DESCRIPTION
Unfortunately aligned_alloc does not allow aligning buffers that are not a multiple of the alignment. To help with this we allocate slightly larger buffers where necessary.

**Description**

Updates `alloc_memory` and `nrn_cacheline_alloc` to use `std::aligned_alloc` instead the POSIX memalign.

Fixes (partially) #836



**Use certain branches in CI pipelines.**
<!-- You can steer which versions of CoreNEURON dependencies will be used in
     the various CI pipelines (GitLab, test-as-submodule) here. Expressions are
     of the form PROJ_REF=VALUE, where PROJ is the relevant Spack package name,
     transformed to upper case and with hyphens replaced with underscores.
     REF may be BRANCH, COMMIT or TAG, with exceptions:
      - SPACK_COMMIT and SPACK_TAG are invalid (hpc/gitlab-pipelines limitation)
      - NEURON_COMMIT and NEURON_TAG are invalid (test-as-submodule limitation)
     These values for NEURON, nmodl and Spack are the defaults and are given
     for illustrative purposes; they can safely be removed.
-->
CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop
