### PR TITLE
Cherry-pick for 8.2.1: Link to libdl.so to avoid linking issues with mpich on centos7 (#856)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,4 +39,4 @@ nrnivmodl mod
      These values for NEURON, nmodl and Spack are the defaults and are given
      for illustrative purposes; they can safely be removed.
 -->
-CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop
+CI_BRANCHES:NEURON_BRANCH=release/8.2,NMODL_TAG=0.4,SPACK_BRANCH=develop

--- a/coreneuron/CMakeLists.txt
+++ b/coreneuron/CMakeLists.txt
@@ -169,13 +169,15 @@ if(CORENRN_ENABLE_MPI AND NOT CORENRN_ENABLE_MPI_DYNAMIC)
   target_link_libraries(coreneuron ${MPI_CXX_LIBRARIES})
 endif()
 
+# ~~~
+# main coreneuron library needs to be linked to libdl.so only in case of dynamic mpi build. But on
+# old system like centos7, we saw mpich library require explici link to libdl.so. See
+# https://github.com/neuronsimulator/nrn-build-ci/pull/51
+# ~~~
+target_link_libraries(coreneuron ${CMAKE_DL_LIBS})
+
 # this is where we handle dynamic mpi library build
 if(CORENRN_ENABLE_MPI AND CORENRN_ENABLE_MPI_DYNAMIC)
-  # ~~~
-  # main coreneuron library needs to be linked to libdl.so and
-  # and should be aware of shared library suffix on different platforms.
-  # ~~~
-  target_link_libraries(coreneuron ${CMAKE_DL_LIBS})
 
   # store mpi library targets that will be built
   list(APPEND corenrn_mpi_targets "")


### PR DESCRIPTION
* Cherry-pick #856 for future release 8.2.2
* To avoid CI errors like: https://github.com/neuronsimulator/nrn-build-ci/actions/runs/3125043801/jobs/5069877217#step:7:983


CI_BRANCHES:NEURON_BRANCH=release/8.2,NMODL_TAG=0.4,SPACK_BRANCH=develop
