### PR TITLE
Undo std::aligned_alloc introduction

### DIFF
--- a/coreneuron/utils/memory.h
+++ b/coreneuron/utils/memory.h
@@ -176,12 +176,11 @@ class MemoryManaged {
 #include <cstdlib>
 
 inline void alloc_memory(void*& pointer, size_t num_bytes, size_t alignment) {
-    size_t fill = 0;
-    if (num_bytes % alignment != 0) {
-        size_t multiple = num_bytes / alignment;
-        fill = alignment * (multiple + 1) - num_bytes;
-    }
-    nrn_assert((pointer = std::aligned_alloc(alignment, num_bytes + fill)) != nullptr);
+#if defined(MINGW)
+    nrn_assert((pointer = _aligned_malloc(num_bytes, alignment)) != nullptr);
+#else
+    nrn_assert(posix_memalign(&pointer, alignment, num_bytes) == 0);
+#endif
 }
 
 inline void calloc_memory(void*& pointer, size_t num_bytes, size_t alignment) {


### PR DESCRIPTION
turns out it's slower than posix_memalign

Just to be sure I'm running the benchmark [CI](https://bbpgitlab.epfl.ch/hpc/cellular/coreneuron-perf-tests/-/pipelines/75916).


CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop
