### PR TITLE
Print mechanism count and memory size only if count is >0

### DIFF
--- a/coreneuron/io/mech_report.cpp
+++ b/coreneuron/io/mech_report.cpp
@@ -56,14 +56,16 @@ void write_mech_report() {
 
     /// print global stats to stdout
     if (nrnmpi_myid == 0) {
-        printf("\n================= MECHANISMS COUNT BY TYPE ===================\n");
+        printf("\n============== MECHANISMS COUNT AND SIZE BY TYPE =============\n");
         printf("%4s %20s %10s %25s\n", "Id", "Name", "Count", "Total memory size (KiB)");
         for (size_t i = 0; i < total_mech_count.size(); i++) {
-            printf("%4lu %20s %10ld %25.2lf\n",
-                   i,
-                   nrn_get_mechname(i),
-                   total_mech_count[i],
-                   static_cast<double>(total_mech_size[i]) / 1024);
+            if (total_mech_count[i] > 0) {
+                printf("%4lu %20s %10ld %25.2lf\n",
+                    i,
+                    nrn_get_mechname(i),
+                    total_mech_count[i],
+                    static_cast<double>(total_mech_size[i]) / 1024);
+            }
         }
         printf("==============================================================\n");
     }

--- a/coreneuron/io/mech_report.cpp
+++ b/coreneuron/io/mech_report.cpp
@@ -61,10 +61,10 @@ void write_mech_report() {
         for (size_t i = 0; i < total_mech_count.size(); i++) {
             if (total_mech_count[i] > 0) {
                 printf("%4lu %20s %10ld %25.2lf\n",
-                    i,
-                    nrn_get_mechname(i),
-                    total_mech_count[i],
-                    static_cast<double>(total_mech_size[i]) / 1024);
+                       i,
+                       nrn_get_mechname(i),
+                       total_mech_count[i],
+                       static_cast<double>(total_mech_size[i]) / 1024);
             }
         }
         printf("==============================================================\n");


### PR DESCRIPTION
**Description**

Print mechanism count and memory size only if count is >0. This helps reduce the verbosity of the output when `--model-stats` is enabled.

Example output from the following test is:

```
============== MECHANISMS COUNT AND SIZE BY TYPE =============
  Id                 Name      Count   Total memory size (KiB)
   3          capacitance        392                      7.91
   4                  pas        372                     16.23
   9               ExpSyn         40                      4.60
  15               na_ion         20                      1.19
  16                k_ion         20                      1.19
  17                   hh         20                      4.70
  18              NetStim          1                      0.21
==============================================================
Memory size information for all NrnThreads per rank
------------------------------------------------------------------
                 field          min          max          avg
                n_cell           10           10           10.00
         n_compartment          396          408          402.00
           n_mechanism            6            7            6.50
                _ndata         4472         4632         4552.00
               _nidata            0            0            0.00
               _nvdata           20           23           21.50
              n_presyn           10           11           10.50
      n_presyn (bytes)          640          704          672.00
        n_input_presyn           10           10           10.00
n_input_presyn (bytes)          240          240          240.00
             n_pntproc           20           21           20.50
     n_pntproc (bytes)          160          168          164.00
              n_netcon           10           11           10.50
      n_netcon (bytes)          400          440          420.00
              n_weight           10           11           10.50
     NrnThread (bytes)        43644        45312        44478.00
    model size (bytes)        44060        45736        44898.00
 Setup Done   : 0.00 seconds 
 Model size   : 87.69 kB
 ```

**How to test this?**

Run any model with CoreNEURON and `--model-stats` enabled.

```bash
cmake ..
cmake --build . --parallel 8
bash tests/integration/ring/integration_test.sh  # This script has already --model-stats enabled
```

**Test System**
 - OS: Ubuntu 22.04
 - Compiler: GCC 11.2.0
 - Version: Current branch
 - Backend: CPU
