### PR TITLE
Change num_spikes datatype to unsigned long

### DIFF
--- a/coreneuron/io/output_spikes.cpp
+++ b/coreneuron/io/output_spikes.cpp
@@ -218,8 +218,8 @@ static void output_spikes_parallel(const char* outpath, const SpikesInfo& spikes
 
     // each spike record in the file is time + gid (64 chars sufficient)
     const int SPIKE_RECORD_LEN = 64;
-    unsigned long num_spikes = spikevec_gid.size();
-    unsigned long num_bytes = (sizeof(char) * num_spikes * SPIKE_RECORD_LEN);
+    size_t num_spikes = spikevec_gid.size();
+    size_t num_bytes = (sizeof(char) * num_spikes * SPIKE_RECORD_LEN);
     char* spike_data = (char*) malloc(num_bytes);
 
     if (spike_data == nullptr) {
@@ -232,8 +232,8 @@ static void output_spikes_parallel(const char* outpath, const SpikesInfo& spikes
 
     // populate buffer with all spike entries
     char spike_entry[SPIKE_RECORD_LEN];
-    unsigned long spike_data_offset = 0;
-    for (unsigned long i = 0; i < num_spikes; i++) {
+    size_t spike_data_offset = 0;
+    for (size_t i = 0; i < num_spikes; i++) {
         int spike_entry_chars =
             snprintf(spike_entry, 64, "%.8g\t%d\n", spikevec_time[i], spikevec_gid[i]);
         spike_data_offset =
@@ -242,7 +242,7 @@ static void output_spikes_parallel(const char* outpath, const SpikesInfo& spikes
 
     // calculate offset into global file. note that we don't write
     // all num_bytes but only "populated" buffer
-    unsigned long num_chars = strlen(spike_data);
+    size_t num_chars = strlen(spike_data);
 
     nrnmpi_write_file(fname, spike_data, num_chars);
 

--- a/coreneuron/io/output_spikes.cpp
+++ b/coreneuron/io/output_spikes.cpp
@@ -218,8 +218,8 @@ static void output_spikes_parallel(const char* outpath, const SpikesInfo& spikes
 
     // each spike record in the file is time + gid (64 chars sufficient)
     const int SPIKE_RECORD_LEN = 64;
-    unsigned num_spikes = spikevec_gid.size();
-    unsigned num_bytes = (sizeof(char) * num_spikes * SPIKE_RECORD_LEN);
+    unsigned long num_spikes = spikevec_gid.size();
+    unsigned long num_bytes = (sizeof(char) * num_spikes * SPIKE_RECORD_LEN);
     char* spike_data = (char*) malloc(num_bytes);
 
     if (spike_data == nullptr) {
@@ -232,8 +232,8 @@ static void output_spikes_parallel(const char* outpath, const SpikesInfo& spikes
 
     // populate buffer with all spike entries
     char spike_entry[SPIKE_RECORD_LEN];
-    unsigned spike_data_offset = 0;
-    for (unsigned i = 0; i < num_spikes; i++) {
+    unsigned long spike_data_offset = 0;
+    for (unsigned long i = 0; i < num_spikes; i++) {
         int spike_entry_chars =
             snprintf(spike_entry, 64, "%.8g\t%d\n", spikevec_time[i], spikevec_gid[i]);
         spike_data_offset =


### PR DESCRIPTION
**Description**

MMB 70M cell simulation was failing when writing out.dat spikes.
This PR fixes the issue by changing the datatype of the number of spikes and the buffer size to unsigned long.

Jira ticket: https://bbpteam.epfl.ch/project/issues/browse/BBPBGLIB-941
