### PR TITLE
Improve memory usage in report initialization

### DIFF
--- a/coreneuron/apps/main1.cpp
+++ b/coreneuron/apps/main1.cpp
@@ -422,13 +422,13 @@ static void trajectory_return() {
     }
 }
 
-std::unique_ptr<ReportHandler> create_report_handler(ReportConfiguration& config,
+std::unique_ptr<ReportHandler> create_report_handler(const ReportConfiguration& config,
                                                      const SpikesInfo& spikes_info) {
     std::unique_ptr<ReportHandler> report_handler;
     if (config.format == "Bin") {
-        report_handler = std::make_unique<BinaryReportHandler>(config);
+        report_handler = std::make_unique<BinaryReportHandler>();
     } else if (config.format == "SONATA") {
-        report_handler = std::make_unique<SonataReportHandler>(config, spikes_info);
+        report_handler = std::make_unique<SonataReportHandler>(spikes_info);
     } else {
         if (nrnmpi_myid == 0) {
             printf(" WARNING : Report name '%s' has unknown format: '%s'.\n",
@@ -593,7 +593,7 @@ extern "C" int run_solve_core(int argc, char** argv) {
             std::unique_ptr<ReportHandler> report_handler = create_report_handler(configs[i],
                                                                                   spikes_info);
             if (report_handler) {
-                report_handler->create_report(dt, tstop, delay);
+                report_handler->create_report(configs[i], dt, tstop, delay);
                 report_handlers.push_back(std::move(report_handler));
             }
             if (configs[i].report_dt < min_report_dt) {

--- a/coreneuron/io/reports/binary_report_handler.cpp
+++ b/coreneuron/io/reports/binary_report_handler.cpp
@@ -13,7 +13,10 @@
 
 namespace coreneuron {
 
-void BinaryReportHandler::create_report(ReportConfiguration& config, double dt, double tstop, double delay) {
+void BinaryReportHandler::create_report(ReportConfiguration& config,
+                                        double dt,
+                                        double tstop,
+                                        double delay) {
 #ifdef ENABLE_BIN_REPORTS
     records_set_atomic_step(dt);
 #endif  // ENABLE_BIN_REPORTS

--- a/coreneuron/io/reports/binary_report_handler.cpp
+++ b/coreneuron/io/reports/binary_report_handler.cpp
@@ -13,11 +13,11 @@
 
 namespace coreneuron {
 
-void BinaryReportHandler::create_report(double dt, double tstop, double delay) {
+void BinaryReportHandler::create_report(ReportConfiguration& config, double dt, double tstop, double delay) {
 #ifdef ENABLE_BIN_REPORTS
     records_set_atomic_step(dt);
 #endif  // ENABLE_BIN_REPORTS
-    ReportHandler::create_report(dt, tstop, delay);
+    ReportHandler::create_report(config, dt, tstop, delay);
 }
 
 #ifdef ENABLE_BIN_REPORTS
@@ -44,7 +44,7 @@ static void create_custom_extra(const CellMapping& mapping, std::array<int, 5>& 
 }
 
 void BinaryReportHandler::register_section_report(const NrnThread& nt,
-                                                  ReportConfiguration& config,
+                                                  const ReportConfiguration& config,
                                                   const VarsToReport& vars_to_report,
                                                   bool is_soma_target) {
     create_extra_func create_extra = is_soma_target ? create_soma_extra : create_compartment_extra;
@@ -52,14 +52,14 @@ void BinaryReportHandler::register_section_report(const NrnThread& nt,
 }
 
 void BinaryReportHandler::register_custom_report(const NrnThread& nt,
-                                                 ReportConfiguration& config,
+                                                 const ReportConfiguration& config,
                                                  const VarsToReport& vars_to_report) {
     create_extra_func create_extra = create_custom_extra;
     register_report(nt, config, vars_to_report, create_extra);
 }
 
 void BinaryReportHandler::register_report(const NrnThread& nt,
-                                          ReportConfiguration& config,
+                                          const ReportConfiguration& config,
                                           const VarsToReport& vars_to_report,
                                           create_extra_func& create_extra) {
     int sizemapping = 1;

--- a/coreneuron/io/reports/binary_report_handler.hpp
+++ b/coreneuron/io/reports/binary_report_handler.hpp
@@ -20,23 +20,20 @@ namespace coreneuron {
 
 class BinaryReportHandler: public ReportHandler {
   public:
-    BinaryReportHandler(ReportConfiguration& config)
-        : ReportHandler(config) {}
-
-    void create_report(double dt, double tstop, double delay) override;
+    void create_report(ReportConfiguration& config, double dt, double tstop, double delay) override;
 #ifdef ENABLE_BIN_REPORTS
     void register_section_report(const NrnThread& nt,
-                                 ReportConfiguration& config,
+                                 const ReportConfiguration& config,
                                  const VarsToReport& vars_to_report,
                                  bool is_soma_target) override;
     void register_custom_report(const NrnThread& nt,
-                                ReportConfiguration& config,
+                                const ReportConfiguration& config,
                                 const VarsToReport& vars_to_report) override;
 
   private:
     using create_extra_func = std::function<void(const CellMapping&, std::array<int, 5>&)>;
     void register_report(const NrnThread& nt,
-                         ReportConfiguration& config,
+                         const ReportConfiguration& config,
                          const VarsToReport& vars_to_report,
                          create_extra_func& create_extra);
 #endif  // ENABLE_BIN_REPORTS

--- a/coreneuron/io/reports/nrnreport.hpp
+++ b/coreneuron/io/reports/nrnreport.hpp
@@ -19,6 +19,7 @@
 #include <set>
 #include <unordered_map>
 #include <cstdint>
+#include <malloc.h>
 
 #define REPORT_MAX_NAME_LEN     256
 #define REPORT_MAX_FILEPATH_LEN 4096
@@ -102,6 +103,12 @@ struct ReportConfiguration {
     int num_gids;                         // total number of gids
     int buffer_size;                      // hint on buffer size used for this report
     std::vector<int> target;              // list of gids for this report
+
+    ~ReportConfiguration() {
+        // Force cleanup of the std::vector and release the memory
+        std::vector<int>().swap(target);
+        malloc_trim(0);
+    }
 };
 
 void setup_report_engine(double dt_report, double mindelay);

--- a/coreneuron/io/reports/nrnreport.hpp
+++ b/coreneuron/io/reports/nrnreport.hpp
@@ -19,7 +19,6 @@
 #include <set>
 #include <unordered_map>
 #include <cstdint>
-#include <malloc.h>
 
 #define REPORT_MAX_NAME_LEN     256
 #define REPORT_MAX_FILEPATH_LEN 4096
@@ -103,12 +102,6 @@ struct ReportConfiguration {
     int num_gids;                         // total number of gids
     int buffer_size;                      // hint on buffer size used for this report
     std::vector<int> target;              // list of gids for this report
-
-    ~ReportConfiguration() {
-        // Force cleanup of the std::vector and release the memory
-        std::vector<int>().swap(target);
-        malloc_trim(0);
-    }
 };
 
 void setup_report_engine(double dt_report, double mindelay);

--- a/coreneuron/io/reports/nrnreport.hpp
+++ b/coreneuron/io/reports/nrnreport.hpp
@@ -101,7 +101,7 @@ struct ReportConfiguration {
     double stop;                          // stop time of report
     int num_gids;                         // total number of gids
     int buffer_size;                      // hint on buffer size used for this report
-    std::set<int> target;                 // list of gids for this report
+    std::vector<int> target;              // list of gids for this report
 };
 
 void setup_report_engine(double dt_report, double mindelay);

--- a/coreneuron/io/reports/report_configuration_parser.cpp
+++ b/coreneuron/io/reports/report_configuration_parser.cpp
@@ -150,8 +150,6 @@ std::vector<ReportConfiguration> create_report_configurations(const std::string&
             report_conf.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
             report_conf.read(reinterpret_cast<char*>(report.target.data()),
                              report.num_gids * sizeof(int));
-            // Sort the bector to use binary search after
-            std::sort(report.target.begin(), report.target.end());
             // extra new line: skip
             report_conf.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         }

--- a/coreneuron/io/reports/report_configuration_parser.cpp
+++ b/coreneuron/io/reports/report_configuration_parser.cpp
@@ -106,15 +106,14 @@ void register_target_type(ReportConfiguration& report, ReportType report_type) {
 std::vector<ReportConfiguration> create_report_configurations(const std::string& conf_file,
                                                               const std::string& output_dir,
                                                               SpikesInfo& spikes_info) {
-    std::vector<ReportConfiguration> reports;
     std::string report_on;
     int target;
     std::ifstream report_conf(conf_file);
 
     int num_reports = 0;
     report_conf >> num_reports;
-    for (int i = 0; i < num_reports; i++) {
-        ReportConfiguration report;
+    std::vector<ReportConfiguration> reports(num_reports);
+    for (auto& report: reports) {
         report.buffer_size = 4;  // default size to 4 Mb
 
         report_conf >> report.name >> report.target_name >> report.type_str >> report_on >>
@@ -147,15 +146,15 @@ std::vector<ReportConfiguration> create_report_configurations(const std::string&
             parse_filter_string(report_on, report);
         }
         if (report.num_gids) {
-            std::vector<int> new_gids(report.num_gids);
+            report.target.resize(report.num_gids);
             report_conf.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-            report_conf.read(reinterpret_cast<char*>(new_gids.data()),
+            report_conf.read(reinterpret_cast<char*>(report.target.data()),
                              report.num_gids * sizeof(int));
-            report.target = std::set<int>(new_gids.begin(), new_gids.end());
+            // Sort the bector to use binary search after
+            std::sort(report.target.begin(), report.target.end());
             // extra new line: skip
             report_conf.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         }
-        reports.push_back(report);
     }
     // read population information for spike report
     int num_populations;

--- a/coreneuron/io/reports/report_event.hpp
+++ b/coreneuron/io/reports/report_event.hpp
@@ -20,7 +20,7 @@ namespace coreneuron {
 
 #if defined(ENABLE_BIN_REPORTS) || defined(ENABLE_SONATA_REPORTS)
 struct VarWithMapping {
-    int id;
+    uint32_t id;
     double* var_value;
     VarWithMapping(int id_, double* v_)
         : id(id_)
@@ -28,7 +28,7 @@ struct VarWithMapping {
 };
 
 // mapping the set of variables pointers to report to its gid
-using VarsToReport = std::unordered_map<int, std::vector<VarWithMapping>>;
+using VarsToReport = std::unordered_map<uint64_t, std::vector<VarWithMapping>>;
 
 class ReportEvent: public DiscreteEvent {
   public:

--- a/coreneuron/io/reports/report_handler.cpp
+++ b/coreneuron/io/reports/report_handler.cpp
@@ -13,35 +13,35 @@
 
 namespace coreneuron {
 
-std::vector<int> intersection(const NrnThread& nt, std::vector<int>& target_gids) {
-    std::unordered_set<int> thread_gids;
+std::vector<int> intersection_gids(const NrnThread& nt, std::vector<int>& target_gids) {
+    std::vector<int> thread_gids;
     for (int i = 0; i < nt.ncell; i++) {
-        thread_gids.insert(nt.presyns[i].gid_);
+        thread_gids.push_back(nt.presyns[i].gid_);
     }
-    std::vector<int> intersection_gids;
-    for (const auto& gid : target_gids) {
-        if (thread_gids.count(gid)) {
-            intersection_gids.push_back(gid);
-            thread_gids.erase(gid);
-        }
-    }
-    /*target_gids.clear();
-    target_gids.shrink_to_fit();*/
-    return intersection_gids;
+    std::vector<int> intersection;
+
+    std::sort(thread_gids.begin(), thread_gids.end());
+    std::sort(target_gids.begin(), target_gids.end());
+
+    std::set_intersection(thread_gids.begin(),thread_gids.end(),
+                          target_gids.begin(),target_gids.end(),
+                          back_inserter(intersection));
+
+    return intersection;
 }
 
-void ReportHandler::create_report(double dt, double tstop, double delay) {
+void ReportHandler::create_report(ReportConfiguration& report_config, double dt, double tstop, double delay) {
 #if defined(ENABLE_BIN_REPORTS) || defined(ENABLE_SONATA_REPORTS)
-    if (m_report_config.start < t) {
-        m_report_config.start = t;
+    if (report_config.start < t) {
+        report_config.start = t;
     }
-    m_report_config.stop = std::min(m_report_config.stop, tstop);
+    report_config.stop = std::min(report_config.stop, tstop);
 
-    for (const auto& mech: m_report_config.mech_names) {
-        m_report_config.mech_ids.emplace_back(nrn_get_mechtype(mech.data()));
+    for (const auto& mech: report_config.mech_names) {
+        report_config.mech_ids.emplace_back(nrn_get_mechtype(mech.data()));
     }
-    if (m_report_config.type == SynapseReport && m_report_config.mech_ids.empty()) {
-        std::cerr << "[ERROR] mechanism to report: " << m_report_config.mech_names[0]
+    if (report_config.type == SynapseReport && report_config.mech_ids.empty()) {
+        std::cerr << "[ERROR] mechanism to report: " << report_config.mech_names[0]
                   << " is not mapped in this simulation, cannot report on it \n";
         nrn_abort(1);
     }
@@ -52,40 +52,40 @@ void ReportHandler::create_report(double dt, double tstop, double delay) {
             continue;
         }
         const std::vector<int>& nodes_to_gid = map_gids(nt);
-        const std::vector<int> gids_to_report = intersection(nt, m_report_config.target);
+        const std::vector<int> gids_to_report = intersection_gids(nt, report_config.target);
         VarsToReport vars_to_report;
         bool is_soma_target;
-        switch (m_report_config.type) {
+        switch (report_config.type) {
             case IMembraneReport:
                 report_variable = nt.nrn_fast_imem->nrn_sav_rhs;
             case SectionReport:
                 vars_to_report =
                     get_section_vars_to_report(nt,
-                                               m_report_config.target,
+                                               gids_to_report,
                                                report_variable,
-                                               m_report_config.section_type,
-                                               m_report_config.section_all_compartments);
-                is_soma_target = m_report_config.section_type == SectionType::Soma ||
-                                 m_report_config.section_type == SectionType::Cell;
-                register_section_report(nt, m_report_config, vars_to_report, is_soma_target);
+                                               report_config.section_type,
+                                               report_config.section_all_compartments);
+                is_soma_target = report_config.section_type == SectionType::Soma ||
+                                 report_config.section_type == SectionType::Cell;
+                register_section_report(nt, report_config, vars_to_report, is_soma_target);
                 break;
             case SummationReport:
                 vars_to_report = get_summation_vars_to_report(nt,
-                                                              m_report_config.target,
-                                                              m_report_config,
+                                                              gids_to_report,
+                                                              report_config,
                                                               nodes_to_gid);
-                register_custom_report(nt, m_report_config, vars_to_report);
+                register_custom_report(nt, report_config, vars_to_report);
                 break;
             default:
-                vars_to_report = get_synapse_vars_to_report(nt, m_report_config, nodes_to_gid);
-                register_custom_report(nt, m_report_config, vars_to_report);
+                vars_to_report = get_synapse_vars_to_report(nt, gids_to_report, report_config, nodes_to_gid);
+                register_custom_report(nt, report_config, vars_to_report);
         }
         if (!vars_to_report.empty()) {
             auto report_event = std::make_unique<ReportEvent>(dt,
                                                               t,
                                                               vars_to_report,
-                                                              m_report_config.output_path.data(),
-                                                              m_report_config.report_dt);
+                                                              report_config.output_path.data(),
+                                                              report_config.report_dt);
             report_event->send(t, net_cvode_instance, &nt);
             m_report_events.push_back(std::move(report_event));
         }
@@ -100,7 +100,7 @@ void ReportHandler::create_report(double dt, double tstop, double delay) {
 
 #if defined(ENABLE_BIN_REPORTS) || defined(ENABLE_SONATA_REPORTS)
 void ReportHandler::register_section_report(const NrnThread& nt,
-                                            ReportConfiguration& config,
+                                            const ReportConfiguration& config,
                                             const VarsToReport& vars_to_report,
                                             bool is_soma_target) {
     if (nrnmpi_myid == 0) {
@@ -109,7 +109,7 @@ void ReportHandler::register_section_report(const NrnThread& nt,
     }
 }
 void ReportHandler::register_custom_report(const NrnThread& nt,
-                                           ReportConfiguration& config,
+                                           const ReportConfiguration& config,
                                            const VarsToReport& vars_to_report) {
     if (nrnmpi_myid == 0) {
         std::cerr << "[WARNING] : Format '" << config.format << "' in report '"
@@ -163,7 +163,7 @@ void register_sections_to_report(const SecMapping* sections,
 }
 
 VarsToReport ReportHandler::get_section_vars_to_report(const NrnThread& nt,
-                                                       const std::vector<int>& target,
+                                                       const std::vector<int>& gids_to_report,
                                                        double* report_variable,
                                                        SectionType section_type,
                                                        bool all_compartments) const {
@@ -176,47 +176,44 @@ VarsToReport ReportHandler::get_section_vars_to_report(const NrnThread& nt,
         nrn_abort(1);
     }
 
-    for (int i = 0; i < nt.ncell; i++) {
-        int gid = nt.presyns[i].gid_;
-        if (std::binary_search(target.begin(), target.end(), gid)) {
-            const auto& cell_mapping = mapinfo->get_cell_mapping(gid);
-            if (cell_mapping == nullptr) {
-                std::cerr
-                    << "[COMPARTMENTS] Error : Compartment mapping information is missing for gid "
-                    << gid << '\n';
-                nrn_abort(1);
-            }
-            std::vector<VarWithMapping> to_report;
-            to_report.reserve(cell_mapping->size());
-
-            if (section_type_str == "All") {
-                const auto& section_mapping = cell_mapping->secmapvec;
-                for (const auto& sections: section_mapping) {
-                    register_sections_to_report(sections,
-                                                to_report,
-                                                report_variable,
-                                                all_compartments);
-                }
-            } else {
-                /** get section list mapping for the type, if available */
-                if (cell_mapping->get_seclist_section_count(section_type_str) > 0) {
-                    const auto& sections = cell_mapping->get_seclist_mapping(section_type_str);
-                    register_sections_to_report(sections,
-                                                to_report,
-                                                report_variable,
-                                                all_compartments);
-                }
-            }
-            vars_to_report[gid] = to_report;
+    for (const auto& gid: gids_to_report) {
+        const auto& cell_mapping = mapinfo->get_cell_mapping(gid);
+        if (cell_mapping == nullptr) {
+            std::cerr
+                << "[COMPARTMENTS] Error : Compartment mapping information is missing for gid "
+                << gid << '\n';
+            nrn_abort(1);
         }
+        std::vector<VarWithMapping> to_report;
+        to_report.reserve(cell_mapping->size());
+
+        if (section_type_str == "All") {
+            const auto& section_mapping = cell_mapping->secmapvec;
+            for (const auto& sections: section_mapping) {
+                register_sections_to_report(sections,
+                                            to_report,
+                                            report_variable,
+                                            all_compartments);
+            }
+        } else {
+            /** get section list mapping for the type, if available */
+            if (cell_mapping->get_seclist_section_count(section_type_str) > 0) {
+                const auto& sections = cell_mapping->get_seclist_mapping(section_type_str);
+                register_sections_to_report(sections,
+                                            to_report,
+                                            report_variable,
+                                            all_compartments);
+            }
+        }
+        vars_to_report[gid] = to_report;
     }
     return vars_to_report;
 }
 
 VarsToReport ReportHandler::get_summation_vars_to_report(
     const NrnThread& nt,
-    const std::vector<int>& target,
-    ReportConfiguration& report,
+    const std::vector<int>& gids_to_report,
+    const ReportConfiguration& report,
     const std::vector<int>& nodes_to_gids) const {
     VarsToReport vars_to_report;
     const auto* mapinfo = static_cast<NrnThreadMappingInfo*>(nt.mapping);
@@ -227,11 +224,7 @@ VarsToReport ReportHandler::get_summation_vars_to_report(
         nrn_abort(1);
     }
 
-    for (int i = 0; i < nt.ncell; i++) {
-        int gid = nt.presyns[i].gid_;
-        if (!std::binary_search(report.target.begin(), report.target.end(), gid)) {
-            continue;
-        }
+    for (const auto& gid: gids_to_report) {
         bool has_imembrane = false;
         // In case we need convertion of units
         int scale = 1;
@@ -262,65 +255,60 @@ VarsToReport ReportHandler::get_summation_vars_to_report(
                 has_imembrane = true;
             }
         }
-        if (std::binary_search(target.begin(), target.end(), gid)) {
-            const auto& cell_mapping = mapinfo->get_cell_mapping(gid);
-            if (cell_mapping == nullptr) {
-                std::cerr
-                    << "[SUMMATION] Error : Compartment mapping information is missing for gid "
-                    << gid << '\n';
-                nrn_abort(1);
+        const auto& cell_mapping = mapinfo->get_cell_mapping(gid);
+        if (cell_mapping == nullptr) {
+            std::cerr
+                << "[SUMMATION] Error : Compartment mapping information is missing for gid "
+                << gid << '\n';
+            nrn_abort(1);
+        }
+        std::vector<VarWithMapping> to_report;
+        to_report.reserve(cell_mapping->size());
+        summation_report.summation_.resize(nt.end);
+        double* report_variable = summation_report.summation_.data();
+        const auto& section_type_str = getSectionTypeStr(report.section_type);
+        if (report.section_type != SectionType::All) {
+            if (cell_mapping->get_seclist_section_count(section_type_str) > 0) {
+                const auto& sections = cell_mapping->get_seclist_mapping(section_type_str);
+                register_sections_to_report(sections,
+                                            to_report,
+                                            report_variable,
+                                            report.section_all_compartments);
             }
-            std::vector<VarWithMapping> to_report;
-            to_report.reserve(cell_mapping->size());
-            summation_report.summation_.resize(nt.end);
-            double* report_variable = summation_report.summation_.data();
-            const auto& section_type_str = getSectionTypeStr(report.section_type);
-            if (report.section_type != SectionType::All) {
-                if (cell_mapping->get_seclist_section_count(section_type_str) > 0) {
-                    const auto& sections = cell_mapping->get_seclist_mapping(section_type_str);
-                    register_sections_to_report(sections,
-                                                to_report,
-                                                report_variable,
-                                                report.section_all_compartments);
-                }
-            }
-            const auto& section_mapping = cell_mapping->secmapvec;
-            for (const auto& sections: section_mapping) {
-                for (auto& section: sections->secmap) {
-                    // compartment_id
-                    int section_id = section.first;
-                    auto& segment_ids = section.second;
-                    for (const auto& segment_id: segment_ids) {
-                        // corresponding voltage in coreneuron voltage array
-                        if (has_imembrane) {
-                            summation_report.currents_[segment_id].push_back(
-                                std::make_pair(nt.nrn_fast_imem->nrn_sav_rhs + segment_id, 1));
-                        }
-                        if (report.section_type == SectionType::All) {
-                            double* variable = report_variable + segment_id;
-                            to_report.emplace_back(VarWithMapping(section_id, variable));
-                        } else if (report.section_type == SectionType::Cell) {
-                            summation_report.gid_segments_[gid].push_back(segment_id);
-                        }
+        }
+        const auto& section_mapping = cell_mapping->secmapvec;
+        for (const auto& sections: section_mapping) {
+            for (auto& section: sections->secmap) {
+                // compartment_id
+                int section_id = section.first;
+                auto& segment_ids = section.second;
+                for (const auto& segment_id: segment_ids) {
+                    // corresponding voltage in coreneuron voltage array
+                    if (has_imembrane) {
+                        summation_report.currents_[segment_id].push_back(
+                            std::make_pair(nt.nrn_fast_imem->nrn_sav_rhs + segment_id, 1));
+                    }
+                    if (report.section_type == SectionType::All) {
+                        double* variable = report_variable + segment_id;
+                        to_report.emplace_back(VarWithMapping(section_id, variable));
+                    } else if (report.section_type == SectionType::Cell) {
+                        summation_report.gid_segments_[gid].push_back(segment_id);
                     }
                 }
             }
-            vars_to_report[gid] = to_report;
         }
+        vars_to_report[gid] = to_report;
     }
     return vars_to_report;
 }
 
 VarsToReport ReportHandler::get_synapse_vars_to_report(
     const NrnThread& nt,
-    ReportConfiguration& report,
+    const std::vector<int>& gids_to_report,
+    const ReportConfiguration& report,
     const std::vector<int>& nodes_to_gids) const {
     VarsToReport vars_to_report;
-    for (int i = 0; i < nt.ncell; i++) {
-        int gid = nt.presyns[i].gid_;
-        if (!std::binary_search(report.target.begin(), report.target.end(), gid)) {
-            continue;
-        }
+    for (const auto& gid: gids_to_report) {
         // There can only be 1 mechanism
         nrn_assert(report.mech_ids.size() == 1);
         auto mech_id = report.mech_ids[0];

--- a/coreneuron/io/reports/report_handler.cpp
+++ b/coreneuron/io/reports/report_handler.cpp
@@ -13,6 +13,23 @@
 
 namespace coreneuron {
 
+std::vector<int> intersection(const NrnThread& nt, std::vector<int>& target_gids) {
+    std::unordered_set<int> thread_gids;
+    for (int i = 0; i < nt.ncell; i++) {
+        thread_gids.insert(nt.presyns[i].gid_);
+    }
+    std::vector<int> intersection_gids;
+    for (const auto& gid : target_gids) {
+        if (thread_gids.count(gid)) {
+            intersection_gids.push_back(gid);
+            thread_gids.erase(gid);
+        }
+    }
+    /*target_gids.clear();
+    target_gids.shrink_to_fit();*/
+    return intersection_gids;
+}
+
 void ReportHandler::create_report(double dt, double tstop, double delay) {
 #if defined(ENABLE_BIN_REPORTS) || defined(ENABLE_SONATA_REPORTS)
     if (m_report_config.start < t) {
@@ -35,6 +52,7 @@ void ReportHandler::create_report(double dt, double tstop, double delay) {
             continue;
         }
         const std::vector<int>& nodes_to_gid = map_gids(nt);
+        const std::vector<int> gids_to_report = intersection(nt, m_report_config.target);
         VarsToReport vars_to_report;
         bool is_soma_target;
         switch (m_report_config.type) {

--- a/coreneuron/io/reports/report_handler.cpp
+++ b/coreneuron/io/reports/report_handler.cpp
@@ -13,12 +13,13 @@
 
 namespace coreneuron {
 
-std::vector<uint64_t> intersection_gids(const NrnThread& nt, std::vector<int>& target_gids) {
+template <typename T>
+std::vector<T> intersection_gids(const NrnThread& nt, std::vector<T>& target_gids) {
     std::vector<int> thread_gids;
     for (int i = 0; i < nt.ncell; i++) {
         thread_gids.push_back(nt.presyns[i].gid_);
     }
-    std::vector<uint64_t> intersection;
+    std::vector<T> intersection;
 
     std::sort(thread_gids.begin(), thread_gids.end());
     std::sort(target_gids.begin(), target_gids.end());
@@ -57,7 +58,7 @@ void ReportHandler::create_report(ReportConfiguration& report_config,
             continue;
         }
         const std::vector<int>& nodes_to_gid = map_gids(nt);
-        const std::vector<uint64_t> gids_to_report = intersection_gids(nt, report_config.target);
+        const std::vector<int> gids_to_report = intersection_gids(nt, report_config.target);
         VarsToReport vars_to_report;
         bool is_soma_target;
         switch (report_config.type) {
@@ -163,7 +164,7 @@ void register_sections_to_report(const SecMapping* sections,
 }
 
 VarsToReport ReportHandler::get_section_vars_to_report(const NrnThread& nt,
-                                                       const std::vector<uint64_t>& gids_to_report,
+                                                       const std::vector<int>& gids_to_report,
                                                        double* report_variable,
                                                        SectionType section_type,
                                                        bool all_compartments) const {
@@ -206,7 +207,7 @@ VarsToReport ReportHandler::get_section_vars_to_report(const NrnThread& nt,
 
 VarsToReport ReportHandler::get_summation_vars_to_report(
     const NrnThread& nt,
-    const std::vector<uint64_t>& gids_to_report,
+    const std::vector<int>& gids_to_report,
     const ReportConfiguration& report,
     const std::vector<int>& nodes_to_gids) const {
     VarsToReport vars_to_report;
@@ -297,7 +298,7 @@ VarsToReport ReportHandler::get_summation_vars_to_report(
 
 VarsToReport ReportHandler::get_synapse_vars_to_report(
     const NrnThread& nt,
-    const std::vector<uint64_t>& gids_to_report,
+    const std::vector<int>& gids_to_report,
     const ReportConfiguration& report,
     const std::vector<int>& nodes_to_gids) const {
     VarsToReport vars_to_report;

--- a/coreneuron/io/reports/report_handler.cpp
+++ b/coreneuron/io/reports/report_handler.cpp
@@ -13,12 +13,12 @@
 
 namespace coreneuron {
 
-std::vector<int> intersection_gids(const NrnThread& nt, std::vector<int>& target_gids) {
+std::vector<uint64_t> intersection_gids(const NrnThread& nt, std::vector<int>& target_gids) {
     std::vector<int> thread_gids;
     for (int i = 0; i < nt.ncell; i++) {
         thread_gids.push_back(nt.presyns[i].gid_);
     }
-    std::vector<int> intersection;
+    std::vector<uint64_t> intersection;
 
     std::sort(thread_gids.begin(), thread_gids.end());
     std::sort(target_gids.begin(), target_gids.end());
@@ -57,7 +57,7 @@ void ReportHandler::create_report(ReportConfiguration& report_config,
             continue;
         }
         const std::vector<int>& nodes_to_gid = map_gids(nt);
-        const std::vector<int> gids_to_report = intersection_gids(nt, report_config.target);
+        const std::vector<uint64_t> gids_to_report = intersection_gids(nt, report_config.target);
         VarsToReport vars_to_report;
         bool is_soma_target;
         switch (report_config.type) {
@@ -163,7 +163,7 @@ void register_sections_to_report(const SecMapping* sections,
 }
 
 VarsToReport ReportHandler::get_section_vars_to_report(const NrnThread& nt,
-                                                       const std::vector<int>& gids_to_report,
+                                                       const std::vector<uint64_t>& gids_to_report,
                                                        double* report_variable,
                                                        SectionType section_type,
                                                        bool all_compartments) const {
@@ -206,7 +206,7 @@ VarsToReport ReportHandler::get_section_vars_to_report(const NrnThread& nt,
 
 VarsToReport ReportHandler::get_summation_vars_to_report(
     const NrnThread& nt,
-    const std::vector<int>& gids_to_report,
+    const std::vector<uint64_t>& gids_to_report,
     const ReportConfiguration& report,
     const std::vector<int>& nodes_to_gids) const {
     VarsToReport vars_to_report;
@@ -297,7 +297,7 @@ VarsToReport ReportHandler::get_summation_vars_to_report(
 
 VarsToReport ReportHandler::get_synapse_vars_to_report(
     const NrnThread& nt,
-    const std::vector<int>& gids_to_report,
+    const std::vector<uint64_t>& gids_to_report,
     const ReportConfiguration& report,
     const std::vector<int>& nodes_to_gids) const {
     VarsToReport vars_to_report;

--- a/coreneuron/io/reports/report_handler.cpp
+++ b/coreneuron/io/reports/report_handler.cpp
@@ -145,7 +145,7 @@ void register_sections_to_report(const SecMapping* sections,
 }
 
 VarsToReport ReportHandler::get_section_vars_to_report(const NrnThread& nt,
-                                                       const std::set<int>& target,
+                                                       const std::vector<int>& target,
                                                        double* report_variable,
                                                        SectionType section_type,
                                                        bool all_compartments) const {
@@ -160,7 +160,7 @@ VarsToReport ReportHandler::get_section_vars_to_report(const NrnThread& nt,
 
     for (int i = 0; i < nt.ncell; i++) {
         int gid = nt.presyns[i].gid_;
-        if (target.find(gid) != target.end()) {
+        if (std::binary_search(target.begin(), target.end(), gid)) {
             const auto& cell_mapping = mapinfo->get_cell_mapping(gid);
             if (cell_mapping == nullptr) {
                 std::cerr
@@ -197,7 +197,7 @@ VarsToReport ReportHandler::get_section_vars_to_report(const NrnThread& nt,
 
 VarsToReport ReportHandler::get_summation_vars_to_report(
     const NrnThread& nt,
-    const std::set<int>& target,
+    const std::vector<int>& target,
     ReportConfiguration& report,
     const std::vector<int>& nodes_to_gids) const {
     VarsToReport vars_to_report;
@@ -211,7 +211,7 @@ VarsToReport ReportHandler::get_summation_vars_to_report(
 
     for (int i = 0; i < nt.ncell; i++) {
         int gid = nt.presyns[i].gid_;
-        if (report.target.find(gid) == report.target.end()) {
+        if (!std::binary_search(report.target.begin(), report.target.end(), gid)) {
             continue;
         }
         bool has_imembrane = false;
@@ -244,7 +244,7 @@ VarsToReport ReportHandler::get_summation_vars_to_report(
                 has_imembrane = true;
             }
         }
-        if (target.find(gid) != target.end()) {
+        if (std::binary_search(target.begin(), target.end(), gid)) {
             const auto& cell_mapping = mapinfo->get_cell_mapping(gid);
             if (cell_mapping == nullptr) {
                 std::cerr
@@ -300,7 +300,7 @@ VarsToReport ReportHandler::get_synapse_vars_to_report(
     VarsToReport vars_to_report;
     for (int i = 0; i < nt.ncell; i++) {
         int gid = nt.presyns[i].gid_;
-        if (report.target.find(gid) == report.target.end()) {
+        if (!std::binary_search(report.target.begin(), report.target.end(), gid)) {
             continue;
         }
         // There can only be 1 mechanism

--- a/coreneuron/io/reports/report_handler.hpp
+++ b/coreneuron/io/reports/report_handler.hpp
@@ -10,6 +10,7 @@
 
 #include <memory>
 #include <vector>
+#include <unordered_set>
 
 #include "nrnreport.hpp"
 #include "coreneuron/io/reports/report_event.hpp"

--- a/coreneuron/io/reports/report_handler.hpp
+++ b/coreneuron/io/reports/report_handler.hpp
@@ -33,12 +33,12 @@ class ReportHandler {
                                         ReportConfiguration& config,
                                         const VarsToReport& vars_to_report);
     VarsToReport get_section_vars_to_report(const NrnThread& nt,
-                                            const std::set<int>& target,
+                                            const std::vector<int>& target,
                                             double* report_variable,
                                             SectionType section_type,
                                             bool all_compartments) const;
     VarsToReport get_summation_vars_to_report(const NrnThread& nt,
-                                              const std::set<int>& target,
+                                              const std::vector<int>& target,
                                               ReportConfiguration& report,
                                               const std::vector<int>& nodes_to_gids) const;
     VarsToReport get_synapse_vars_to_report(const NrnThread& nt,

--- a/coreneuron/io/reports/report_handler.hpp
+++ b/coreneuron/io/reports/report_handler.hpp
@@ -10,7 +10,6 @@
 
 #include <memory>
 #include <vector>
-#include <unordered_set>
 
 #include "nrnreport.hpp"
 #include "coreneuron/io/reports/report_event.hpp"
@@ -32,16 +31,16 @@ class ReportHandler {
                                         const ReportConfiguration& config,
                                         const VarsToReport& vars_to_report);
     VarsToReport get_section_vars_to_report(const NrnThread& nt,
-                                            const std::vector<int>& gids_to_report,
+                                            const std::vector<uint64_t>& gids_to_report,
                                             double* report_variable,
                                             SectionType section_type,
                                             bool all_compartments) const;
     VarsToReport get_summation_vars_to_report(const NrnThread& nt,
-                                              const std::vector<int>& gids_to_report,
+                                              const std::vector<uint64_t>& gids_to_report,
                                               const ReportConfiguration& report,
                                               const std::vector<int>& nodes_to_gids) const;
     VarsToReport get_synapse_vars_to_report(const NrnThread& nt,
-                                            const std::vector<int>& gids_to_report,
+                                            const std::vector<uint64_t>& gids_to_report,
                                             const ReportConfiguration& report,
                                             const std::vector<int>& nodes_to_gids) const;
     std::vector<int> map_gids(const NrnThread& nt) const;

--- a/coreneuron/io/reports/report_handler.hpp
+++ b/coreneuron/io/reports/report_handler.hpp
@@ -31,16 +31,16 @@ class ReportHandler {
                                         const ReportConfiguration& config,
                                         const VarsToReport& vars_to_report);
     VarsToReport get_section_vars_to_report(const NrnThread& nt,
-                                            const std::vector<uint64_t>& gids_to_report,
+                                            const std::vector<int>& gids_to_report,
                                             double* report_variable,
                                             SectionType section_type,
                                             bool all_compartments) const;
     VarsToReport get_summation_vars_to_report(const NrnThread& nt,
-                                              const std::vector<uint64_t>& gids_to_report,
+                                              const std::vector<int>& gids_to_report,
                                               const ReportConfiguration& report,
                                               const std::vector<int>& nodes_to_gids) const;
     VarsToReport get_synapse_vars_to_report(const NrnThread& nt,
-                                            const std::vector<uint64_t>& gids_to_report,
+                                            const std::vector<int>& gids_to_report,
                                             const ReportConfiguration& report,
                                             const std::vector<int>& nodes_to_gids) const;
     std::vector<int> map_gids(const NrnThread& nt) const;

--- a/coreneuron/io/reports/report_handler.hpp
+++ b/coreneuron/io/reports/report_handler.hpp
@@ -20,35 +20,33 @@ namespace coreneuron {
 
 class ReportHandler {
   public:
-    ReportHandler(ReportConfiguration& config)
-        : m_report_config(config){};
     virtual ~ReportHandler() = default;
 
-    virtual void create_report(double dt, double tstop, double delay);
+    virtual void create_report(ReportConfiguration& config, double dt, double tstop, double delay);
 #if defined(ENABLE_BIN_REPORTS) || defined(ENABLE_SONATA_REPORTS)
     virtual void register_section_report(const NrnThread& nt,
-                                         ReportConfiguration& config,
+                                         const ReportConfiguration& config,
                                          const VarsToReport& vars_to_report,
                                          bool is_soma_target);
     virtual void register_custom_report(const NrnThread& nt,
-                                        ReportConfiguration& config,
+                                        const ReportConfiguration& config,
                                         const VarsToReport& vars_to_report);
     VarsToReport get_section_vars_to_report(const NrnThread& nt,
-                                            const std::vector<int>& target,
+                                            const std::vector<int>& gids_to_report,
                                             double* report_variable,
                                             SectionType section_type,
                                             bool all_compartments) const;
     VarsToReport get_summation_vars_to_report(const NrnThread& nt,
-                                              const std::vector<int>& target,
-                                              ReportConfiguration& report,
+                                              const std::vector<int>& gids_to_report,
+                                              const ReportConfiguration& report,
                                               const std::vector<int>& nodes_to_gids) const;
     VarsToReport get_synapse_vars_to_report(const NrnThread& nt,
-                                            ReportConfiguration& report,
+                                            const std::vector<int>& gids_to_report,
+                                            const ReportConfiguration& report,
                                             const std::vector<int>& nodes_to_gids) const;
     std::vector<int> map_gids(const NrnThread& nt) const;
 #endif  // defined(ENABLE_BIN_REPORTS) || defined(ENABLE_SONATA_REPORTS)
   protected:
-    ReportConfiguration m_report_config;
 #if defined(ENABLE_BIN_REPORTS) || defined(ENABLE_SONATA_REPORTS)
     std::vector<std::unique_ptr<ReportEvent>> m_report_events;
 #endif  // defined(ENABLE_BIN_REPORTS) || defined(ENABLE_SONATA_REPORTS)

--- a/coreneuron/io/reports/sonata_report_handler.cpp
+++ b/coreneuron/io/reports/sonata_report_handler.cpp
@@ -17,7 +17,10 @@
 
 namespace coreneuron {
 
-void SonataReportHandler::create_report(ReportConfiguration& config, double dt, double tstop, double delay) {
+void SonataReportHandler::create_report(ReportConfiguration& config,
+                                        double dt,
+                                        double tstop,
+                                        double delay) {
 #ifdef ENABLE_SONATA_REPORTS
     sonata_set_atomic_step(dt);
 #endif  // ENABLE_SONATA_REPORTS

--- a/coreneuron/io/reports/sonata_report_handler.cpp
+++ b/coreneuron/io/reports/sonata_report_handler.cpp
@@ -17,23 +17,23 @@
 
 namespace coreneuron {
 
-void SonataReportHandler::create_report(double dt, double tstop, double delay) {
+void SonataReportHandler::create_report(ReportConfiguration& config, double dt, double tstop, double delay) {
 #ifdef ENABLE_SONATA_REPORTS
     sonata_set_atomic_step(dt);
 #endif  // ENABLE_SONATA_REPORTS
-    ReportHandler::create_report(dt, tstop, delay);
+    ReportHandler::create_report(config, dt, tstop, delay);
 }
 
 #ifdef ENABLE_SONATA_REPORTS
 void SonataReportHandler::register_section_report(const NrnThread& nt,
-                                                  ReportConfiguration& config,
+                                                  const ReportConfiguration& config,
                                                   const VarsToReport& vars_to_report,
                                                   bool is_soma_target) {
     register_report(nt, config, vars_to_report);
 }
 
 void SonataReportHandler::register_custom_report(const NrnThread& nt,
-                                                 ReportConfiguration& config,
+                                                 const ReportConfiguration& config,
                                                  const VarsToReport& vars_to_report) {
     register_report(nt, config, vars_to_report);
 }
@@ -55,7 +55,7 @@ std::pair<std::string, int> SonataReportHandler::get_population_info(int gid) {
 }
 
 void SonataReportHandler::register_report(const NrnThread& nt,
-                                          ReportConfiguration& config,
+                                          const ReportConfiguration& config,
                                           const VarsToReport& vars_to_report) {
     sonata_create_report(config.output_path.data(),
                          config.start,

--- a/coreneuron/io/reports/sonata_report_handler.cpp
+++ b/coreneuron/io/reports/sonata_report_handler.cpp
@@ -69,7 +69,7 @@ void SonataReportHandler::register_report(const NrnThread& nt,
     sonata_set_report_max_buffer_size_hint(config.output_path.data(), config.buffer_size);
 
     for (const auto& kv: vars_to_report) {
-        int gid = kv.first;
+        uint64_t gid = kv.first;
         const std::vector<VarWithMapping>& vars = kv.second;
         if (!vars.size())
             continue;

--- a/coreneuron/io/reports/sonata_report_handler.hpp
+++ b/coreneuron/io/reports/sonata_report_handler.hpp
@@ -17,23 +17,22 @@ namespace coreneuron {
 
 class SonataReportHandler: public ReportHandler {
   public:
-    SonataReportHandler(ReportConfiguration& config, const SpikesInfo& spikes_info)
-        : ReportHandler(config)
-        , m_spikes_info(spikes_info) {}
+    SonataReportHandler(const SpikesInfo& spikes_info)
+        : m_spikes_info(spikes_info) {}
 
-    void create_report(double dt, double tstop, double delay) override;
+    void create_report(ReportConfiguration& config, double dt, double tstop, double delay) override;
 #ifdef ENABLE_SONATA_REPORTS
     void register_section_report(const NrnThread& nt,
-                                 ReportConfiguration& config,
+                                 const ReportConfiguration& config,
                                  const VarsToReport& vars_to_report,
                                  bool is_soma_target) override;
     void register_custom_report(const NrnThread& nt,
-                                ReportConfiguration& config,
+                                const ReportConfiguration& config,
                                 const VarsToReport& vars_to_report) override;
 
   private:
     void register_report(const NrnThread& nt,
-                         ReportConfiguration& config,
+                         const ReportConfiguration& config,
                          const VarsToReport& vars_to_report);
     std::pair<std::string, int> get_population_info(int gid);
 #endif  // ENABLE_SONATA_REPORTS


### PR DESCRIPTION
**Description**

A high memory usage was taking place in the report initialization when reporting big targets.

**Solution**

Use a std::vector instead of a std::set to store the target gids and do the intersection between the target and the NrnThread gids to loop through them instead of searching in the full target.

CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop
