### PR TITLE
Assertions should not have side effects

### DIFF
--- a/coreneuron/io/core2nrn_data_return.cpp
+++ b/coreneuron/io/core2nrn_data_return.cpp
@@ -546,7 +546,8 @@ void core2nrn_tqueue(NrnThread& nt) {
     }
     // TQitems from binq_
     for (q = tqe->binq_->first(); q; q = tqe->binq_->next(q)) {
-        assert(core2nrn_tqueue_item(q, sewm, nt) == false);
+        bool const result = core2nrn_tqueue_item(q, sewm, nt);
+        assert(result == false);
     }
 
     // For self events with weight, find the NetCon index and send that

--- a/coreneuron/io/phase2.cpp
+++ b/coreneuron/io/phase2.cpp
@@ -246,10 +246,10 @@ void Phase2::read_file(FileHandler& F, const NrnThread& nt) {
         preSynConditionEventFlags.push_back(F.read_int());
     }
 
-    assert(F.read_int() == -1);
+    nrn_assert(F.read_int() == -1);
     restore_events(F);
 
-    assert(F.read_int() == -1);
+    nrn_assert(F.read_int() == -1);
     restore_events(F);
 }
 


### PR DESCRIPTION
**Description**
Some things I came across when debugging failures with `-DNDEBUG`.

**Use certain branches in CI pipelines.**
<!-- You can steer which versions of CoreNEURON dependencies will be used in
     the various CI pipelines (GitLab, test-as-submodule) here. Expressions are
     of the form PROJ_REF=VALUE, where PROJ is the relevant Spack package name,
     transformed to upper case and with hyphens replaced with underscores.
     REF may be BRANCH, COMMIT or TAG, with exceptions:
      - SPACK_COMMIT and SPACK_TAG are invalid (hpc/gitlab-pipelines limitation)
      - NEURON_COMMIT and NEURON_TAG are invalid (test-as-submodule limitation)
     These values for NEURON, nmodl and Spack are the defaults and are given
     for illustrative purposes; they can safely be removed.
-->
CI_BRANCHES:NEURON_BRANCH=master,NMODL_BRANCH=master,SPACK_BRANCH=develop
